### PR TITLE
Fix excessive config revalidation

### DIFF
--- a/src/lib/ci.mjs
+++ b/src/lib/ci.mjs
@@ -1,0 +1,1 @@
+export const IS_GITHUB_CI = !!process.env.GITHUB_ACTIONS;

--- a/src/lib/og-image/schema.mjs
+++ b/src/lib/og-image/schema.mjs
@@ -1,14 +1,14 @@
 // @ts-check
 import { envField } from "astro/config";
-import { generateSecret } from "../secrets";
+import { IS_GITHUB_CI } from "../ci.mjs";
 import { ENV_NAME } from "./constants.mjs";
 
-export function getEnvsSchema(withFallback = true) {
+export function getEnvsSchema() {
   return {
     [ENV_NAME]: envField.string({
       context: "server",
       access: "secret",
-      default: withFallback ? generateSecret(20) : undefined,
+      optional: IS_GITHUB_CI,
     }),
   };
 }

--- a/src/loaders/moveReference/index.ts
+++ b/src/loaders/moveReference/index.ts
@@ -6,6 +6,7 @@ import type { GitHubConfig, ProcessingStats } from "./types";
 import { GitHubFetcher } from "./services/github-fetcher";
 import { MarkdownProcessor } from "./services/markdown-processor";
 import { getPluginHash } from "./utils/plugin-hash.js";
+import { IS_GITHUB_CI } from "~/lib/ci.mjs";
 
 export function moveReferenceLoader(config: GitHubConfig): Loader {
   async function loadContent(context: LoaderContext): Promise<void> {
@@ -161,7 +162,7 @@ export function moveReferenceLoader(config: GitHubConfig): Loader {
     name: "move-reference",
     load: async (context) => {
       // Don't load Move Reference content in GITHUB CI
-      if (process.env.GITHUB_ACTIONS) {
+      if (IS_GITHUB_CI) {
         context.logger.warn(`${context.collection} loader is disabled in GITHUB CI`);
         return;
       }


### PR DESCRIPTION
Don't generate default secret for `OG_IMAGES_SECRET` env variable, because it invalidates config digest every time.
From now, developers have to specify it in their `.env` manually.