### PR TITLE
[config] Update site url for preview

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -38,7 +38,7 @@ const enableApiReference = ENABLE_API_REFERENCE === "true";
 export default defineConfig({
   site:
     ENV.VERCEL_ENV === "production"
-      ? "https://aptos-docs-astro.vercel.app"
+      ? "https://preview.aptos.dev"
       : ENV.VERCEL_URL
         ? `https://${ENV.VERCEL_URL}`
         : "http://localhost:4321",


### PR DESCRIPTION
Updates site url within config to `preview.aptos.dev` (various uses such as canonical urls, etc). 