### PR TITLE
[redirects] Setup edge middleware redirect for /en to /

### DIFF
--- a/src/middlewares/en-redirect.ts
+++ b/src/middlewares/en-redirect.ts
@@ -1,0 +1,29 @@
+/**
+ * Middleware to redirect /en/* routes to /* routes
+ * For example:
+ * - /en/sample-page -> /sample-page
+ * - /en -> /
+ */
+
+// eslint-disable-next-line @typescript-eslint/no-invalid-void-type
+export default function middleware(request: Request): Response | void {
+  const url = new URL(request.url);
+  const pathname = url.pathname;
+
+  // Check if the path starts with /en
+  const enPathMatch = /^\/en(\/.*|$)/.exec(pathname);
+
+  if (enPathMatch) {
+    // Get the rest of the path (or / if it's just /en)
+    const restOfPath = enPathMatch[1] ?? "/";
+
+    // Update the pathname
+    url.pathname = restOfPath;
+
+    // Return a redirect response
+    return Response.redirect(url);
+  }
+
+  // If not an /en path, continue to the next middleware
+  return undefined;
+}

--- a/src/middlewares/matcher-routes-manual.js
+++ b/src/middlewares/matcher-routes-manual.js
@@ -6,4 +6,8 @@ export const routes = [
   // '/custom-page/:path*',
   // '/api/:path*',
   // Add your custom routes below
+
+  // Routes for /en/* redirects
+  "/en",
+  "/en/:path*",
 ];

--- a/src/vercel-middleware.ts
+++ b/src/vercel-middleware.ts
@@ -3,6 +3,7 @@ import { next } from "@vercel/edge";
 /* eslint-disable @typescript-eslint/no-invalid-void-type */
 // Edge-compatible middleware that implements a middleware chain pattern
 import i18nRedirect from "./middlewares/i18n-redirect";
+import enRedirect from "./middlewares/en-redirect";
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore - auto-generated import
 import { matcher } from "./middlewares/matcher-routes-dynamic";
@@ -31,6 +32,7 @@ async function applyMiddleware(
 // The main middleware function
 export default async function middleware(req: Request) {
   return await applyMiddleware(req, [
+    enRedirect,
     i18nRedirect,
     // Add more middleware functions here as needed
     next,


### PR DESCRIPTION
Aptos Docs is reverting to `/` for english locale (dropping `/en` prefix to urls). 

This sets up our edge middleware generation to handle this redirect.