### PR TITLE
[fix] Disable Vite CSS code splitting temporarily

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -214,6 +214,9 @@ export default defineConfig({
     optimizeDeps: {
       exclude: ["@rollup/browser"],
     },
+    build: {
+      cssCodeSplit: false,
+    },
     resolve: {
       alias: {
         "~/images": fileURLToPath(new URL("./src/assets/images", import.meta.url)),


### PR DESCRIPTION
FIxes layout issues by temporarily disabling [Vite's CSS code splitting](https://vite.dev/config/build-options#build-csscodesplit) temporarily to fix issues with css chunking via `vite.cssScopeTo` introduced in [Astro 5.7.14](https://github.com/withastro/astro/blob/main/packages/astro/CHANGELOG.md#5714)

https://github.com/withastro/astro/pull/13668