### PR TITLE
[fix] exclude @scalar/openapi-parser from Vite dependency optimization

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -213,7 +213,7 @@ export default defineConfig({
   vite: {
     plugins: [tailwindcss()],
     optimizeDeps: {
-      exclude: ["@rollup/browser"],
+      exclude: ["@rollup/browser", "@scalar/openapi-parser"],
     },
     resolve: {
       alias: {


### PR DESCRIPTION
- Add @scalar/openapi-parser to optimizeDeps.exclude array
- Resolves build error: "Top-level await is not available in the configured target environment"