### PR TITLE
[lint] Added `empty_range` docs

### DIFF
--- a/src/content/docs/build/smart-contracts/linter.mdx
+++ b/src/content/docs/build/smart-contracts/linter.mdx
@@ -61,6 +61,10 @@ It is a common Move pattern to provide inline specifications in conditions, espe
 
 Note that an `assert!` is translated to a conditional abort, so blocks in `assert!` condition also are reported by this lint.
 
+### `empty_range`
+
+Checks for empty ranges in `for` loops, such as `for i in 0..0 { ... }`, which do not execute the loop body. This can happen when the start of the range is greater than or equal to the end of the range, resulting in an empty iteration.
+
 # `equal_operands_in_bin_op`
 
 Checks for binary operations where both operands are the same, which is likely a mistake. For example `x % x`, `x ^ x`,  `x > x`, `x >= x`, `x == x`, `x | x`, `x & x`, `x / x`, and `x != x` are all caught by this lint. The lint suggests replacing these with a more appropriate value or expression, such as `0`, `true`, or `false`.


### PR DESCRIPTION
Added docs for new lint added in [this PR](https://github.com/aptos-labs/aptos-core/pull/17052).

