### PR TITLE
[lint] fix `equal_operands_in_bin_op` title indentation

### DIFF
--- a/src/content/docs/build/smart-contracts/linter.mdx
+++ b/src/content/docs/build/smart-contracts/linter.mdx
@@ -61,7 +61,7 @@ It is a common Move pattern to provide inline specifications in conditions, espe
 
 Note that an `assert!` is translated to a conditional abort, so blocks in `assert!` condition also are reported by this lint.
 
-# `equal_operands_in_bin_op`
+### `equal_operands_in_bin_op`
 
 Checks for binary operations where both operands are the same, which is likely a mistake. For example `x % x`, `x ^ x`,  `x > x`, `x >= x`, `x == x`, `x | x`, `x & x`, `x / x`, and `x != x` are all caught by this lint. The lint suggests replacing these with a more appropriate value or expression, such as `0`, `true`, or `false`.
 


### PR DESCRIPTION
Fix title indentation to match the other ones.