### PR TITLE
fix loop type description

### DIFF
--- a/src/content/docs/build/smart-contracts/book/loops.mdx
+++ b/src/content/docs/build/smart-contracts/book/loops.mdx
@@ -250,7 +250,7 @@ script {
 }
 ```
 
-If `loop` does not have a `break`, `loop` can have any type much like `return`, `abort`, `break`, and `continue`.
+If `loop` does not have a `break` or a `continue`, `loop` can have any type much like `return`, `abort`, `break`, and `continue`.
 
 ```move
 script {


### PR DESCRIPTION
This PR fixes an incorrect description about the type of `loop` in Move code.