### PR TITLE
[sidebar] Add docs for Sign in with Aptos and js-pro to sidebar

### DIFF
--- a/astro.sidebar.ts
+++ b/astro.sidebar.ts
@@ -132,6 +132,10 @@ export const sidebar = [
           "build/sdks/ts-sdk/ts-examples",
           "build/sdks/ts-sdk/type-safe-contract",
           {
+            label: "React Hooks",
+            link: "https://js-pro.aptos.dev",
+          },
+          {
             label: "Account",
             collapsed: true,
             items: [
@@ -431,6 +435,10 @@ export const sidebar = [
         items: ["build/create-aptos-dapp", "build/create-aptos-dapp/faq"],
       },
       "network/faucet",
+      {
+        label: "Sign in with Aptos",
+        link: "https://siwa.aptos.dev",
+      },
     ],
   }),
 


### PR DESCRIPTION
### Description
Add external links to the documentation for Sign in with Aptos (SIWA) and Aptos JS-Pro for React hooks

### Testing

<img width="280" height="680" alt="image" src="https://github.com/user-attachments/assets/5faa31cb-70c8-4b51-aebe-67237f8b906d" />
