### PR TITLE
Replace Aptos Build references with Geomi and update URLs

### DIFF
--- a/src/content/docs/build/ai/aptos-mcp.mdx
+++ b/src/content/docs/build/ai/aptos-mcp.mdx
@@ -19,9 +19,9 @@ and others that support the Model Context Protocol.
 
 ### Generate a Build Bot Api Key
 
-To be able to make Aptos Build actions like managing API keys, etc., follow these instructions to generate a new Bot API Key to use with the MCP.
+To be able to make Geomi actions like managing API keys, etc., follow these instructions to generate a new Bot API Key to use with the MCP.
 
-- Go to https://build.aptoslabs.com/
+- Go to https://geomi.dev/
 - Click on your name in the bottom left corner
 - Click on "Bot Keys"
 - Click on the "Create Bot Key" button

--- a/src/content/docs/build/apis.mdx
+++ b/src/content/docs/build/apis.mdx
@@ -58,4 +58,4 @@ such anyone can operate these APIs and many independent operators and builders w
 [Aptos Labs](https://aptoslabs.com) operates a deployment of these APIs on behalf of [Aptos Foundation](https://aptosfoundation.org/)
 for each [Aptos Network](/network/nodes/networks) and makes them available for public consumption.
 
-These APIs allow for limited access on a per-IP basis without an API key (anonymous access). To get much higher rate limits you can sign up for an [Aptos Build](https://build.aptoslabs.com/) account.
+These APIs allow for limited access on a per-IP basis without an API key (anonymous access). To get much higher rate limits you can sign up for an [Geomi](https://geomi.dev/) account.

--- a/src/content/docs/build/apis/aptos-labs-developer-portal.mdx
+++ b/src/content/docs/build/apis/aptos-labs-developer-portal.mdx
@@ -1,7 +1,7 @@
 ---
-title: "Aptos Labs Aptos Build"
+title: "Aptos Labs Geomi"
 ---
 
-[Aptos Build](https://build.aptoslabs.com) is your gateway to access Aptos Labs provided APIs in a quick and easy fashion to power your dapp. Beyond API access it offers gas station and no code indexing services.
+[Geomi](https://geomi.dev) is your gateway to access Aptos Labs provided APIs in a quick and easy fashion to power your dapp. Beyond API access it offers gas station and no code indexing services.
 
-Learn more about Aptos Build at the dedicated [Aptos Build docs site](https://build.aptoslabs.com/docs).
+Learn more about Geomi at the dedicated [Geomi docs site](https://geomi.dev/docs).

--- a/src/content/docs/build/apis/fullnode-rest-api.mdx
+++ b/src/content/docs/build/apis/fullnode-rest-api.mdx
@@ -19,7 +19,7 @@ For more advanced queries, we recommend using the [Indexer GraphQL API](/build/i
 
 ## Understanding rate limits
 
-As with the [Aptos Indexer](/build/indexer/indexer-api), the Aptos REST API has rate limits based on compute units. You can learn more about how the ratelimiting works by reading the [Aptos Build docs](https://build.aptoslabs.com/docs/start/billing).
+As with the [Aptos Indexer](/build/indexer/indexer-api), the Aptos REST API has rate limits based on compute units. You can learn more about how the ratelimiting works by reading the [Geomi docs](https://geomi.dev/docs/admin/billing).
 
 ## Viewing current and historical state
 

--- a/src/content/docs/build/get-started/developer-setup.mdx
+++ b/src/content/docs/build/get-started/developer-setup.mdx
@@ -68,8 +68,8 @@ Here is an easy way to setup your environment depending on the type of developme
            />
 
            <LinkCard
-             href="https://build.aptoslabs.com/"
-             title="Aptos Build"
+             href="https://geomi.dev/"
+title="Geomi"
              description="Hitting rate limits for Fullnode API / Indexers? Get
          an API Key here"
              target="_blank"

--- a/src/content/docs/build/indexer/indexer-api.mdx
+++ b/src/content/docs/build/indexer/indexer-api.mdx
@@ -44,9 +44,9 @@ If you need to directly make GraphQL queries to the Aptos-Labs hosted Indexer AP
 
 ### Rate limits
 
-Learn more about the rate limits that apply to the Aptos Labs hosted indexer API by reading the [Aptos Build docs](https://build.aptoslabs.com/docs/start/billing).
+Learn more about the rate limits that apply to the Aptos Labs hosted indexer API by reading the [Geomi docs](https://geomi.dev/docs/admin/billing).
 
 If you need a higher rate limit, consider the following solutions:
 
-1. Get an API Key from [Aptos Build](https://build.aptoslabs.com/). Learn more about API keys at the [Aptos Build docs site](https://build.aptoslabs.com/docs/start/api-keys).
+1. Get an API Key from [Geomi](https://geomi.dev/). Learn more about API keys at the [Geomi docs site](https://geomi.dev/docs/api-keys).
 2. Run the Aptos Indexer API yourself. See the guide to self-hosting [here](/build/indexer/txn-stream/self-hosted).

--- a/src/content/docs/build/indexer/indexer-api/indexer-reference.mdx
+++ b/src/content/docs/build/indexer/indexer-api/indexer-reference.mdx
@@ -565,8 +565,8 @@ The following tables are planned for deprecation, or are already deprecated. See
 | Table                               | Notes                                                                                                                                                           |
 | ----------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | address\_version\_from\_move\_resources | Replace with account\_transactions                                                                                                                               |
-| address\_events\_summary              | To query custom events, you should create a [No-Code Indexer](https://build.aptoslabs.com/docs/no-code-indexing)                                                |
-| address\_version\_from\_events         | To query custom events, you should create a [No-Code Indexer](https://build.aptoslabs.com/docs/no-code-indexing)                                                |
+| address\_events\_summary              | To query custom events, you should create a [No-Code Indexer](https://geomi.dev/docs/no-code-indexing)                                                |
+| address\_version\_from\_events         | To query custom events, you should create a [No-Code Indexer](https://geomi.dev/docs/no-code-indexing)                                                |
 | coin\_activities                     | Replace with fungible\_asset\_activities                                                                                                                          |
 | coin\_balances                       | Replace with current\_fungible\_asset\_balances                                                                                                                    |
 | coin\_infos                          | Replace with fungible\_asset\_metadata                                                                                                                            |
@@ -577,7 +577,7 @@ The following tables are planned for deprecation, or are already deprecated. See
 | current\_collection\_datas            | Replace with current\_collections\_v2                                                                                                                             |
 | current\_token\_datas                 | Replace with current\_token\_datas\_v2                                                                                                                             |
 | current\_token\_ownerships            | Replace with current\_token\_ownerships\_v2                                                                                                                        |
-| events\_view                         | To query custom events, you should create a [No-Code Indexer](https://build.aptoslabs.com/docs/no-code-indexing)                                                |
+| events\_view                         | To query custom events, you should create a [No-Code Indexer](https://geomi.dev/docs/no-code-indexing)                                                |
 | move\_resources                      | Replace with account\_transactions                                                                                                                               |
 | move\_resources\_view                 | Replace with account\_transactions                                                                                                                               |
 | nft\_marketplace\_v2\_\*                | Replace with [NFT Aggregator API](/build/indexer/nft-aggregator)                                                                            |

--- a/src/content/docs/build/indexer/txn-stream/aptos-hosted-txn-stream.mdx
+++ b/src/content/docs/build/indexer/txn-stream/aptos-hosted-txn-stream.mdx
@@ -14,13 +14,13 @@ All endpoints are in GCP us-central1 unless otherwise specified.
 - **Testnet:** grpc.testnet.aptoslabs.com:443
 - **Devnet:** grpc.devnet.aptoslabs.com:443
 
-You can learn about the rate limits for this service by reading the [Aptos Build docs](https://build.aptoslabs.com/docs/start/billing).
+You can learn about the rate limits for this service by reading the [Geomi docs](https://geomi.dev/docs/admin/billing).
 
 ## Authorization via API Key
 
 In order to use the Labs-Hosted Transaction Stream Service you must have an API key. To get an API key, do the following:
 
-1. Go to https://build.aptoslabs.com.
+1. Go to https://geomi.dev.
 2. Sign in and select "API Resource".
 3. Create a new key. You will see the API key secret in the first table.
 
@@ -30,7 +30,7 @@ You can provide the API key by setting the `Authorization` HTTP header ([MDN](ht
 curl -H 'Authorization: Bearer aptoslabs_yj4donpaKy_Q6RBP4cdBmjA8T51hto1GcVX5ZS9S65dx'
 ```
 
-Learn more about API keys at the [Aptos Build docs site](https://build.aptoslabs.com/docs/start/api-keys).
+Learn more about API keys at the [Geomi docs site](https://geomi.dev/docs/api-keys).
 
 For more comprehensive information about how to use the Transaction Stream Service, see the docs for the downstream systems:
 

--- a/src/content/docs/es/build/ai/aptos-mcp.mdx
+++ b/src/content/docs/es/build/ai/aptos-mcp.mdx
@@ -17,9 +17,9 @@ El Protocolo de Contexto de Modelo de Aptos (MCP) es un servidor que proporciona
 
 ### Generar una Clave API de Build Bot
 
-Para poder realizar acciones de Aptos Build como gestionar claves API, etc., sigue estas instrucciones para generar una nueva Clave API de Bot para usar con el MCP.
+Para poder realizar acciones de Geomi como gestionar claves API, etc., sigue estas instrucciones para generar una nueva Clave API de Bot para usar con el MCP.
 
-- Ve a https://build.aptoslabs.com/
+- Ve a https://geomi.dev/
 - Haz clic en tu nombre en la esquina inferior izquierda
 - Haz clic en "Bot Keys"
 - Haz clic en el botón "Create Bot Key"

--- a/src/content/docs/es/build/apis.mdx
+++ b/src/content/docs/es/build/apis.mdx
@@ -58,4 +58,4 @@ tal, cualquiera puede operar estas APIs y muchos operadores y constructores inde
 [Aptos Labs](https://aptoslabs.com) opera un despliegue de estas APIs en nombre de [Aptos Foundation](https://aptosfoundation.org/)
 para cada [Red de Aptos](/network/nodes/networks) y las hace disponibles para consumo público.
 
-Estas APIs permiten acceso limitado por IP sin una clave de API (acceso anónimo). Para obtener límites de tasa mucho más altos puedes registrarte para una cuenta de [Aptos Build](https://build.aptoslabs.com/).
+Estas APIs permiten acceso limitado por IP sin una clave de API (acceso anónimo). Para obtener límites de tasa mucho más altos puedes registrarte para una cuenta de [Geomi](https://geomi.dev/).

--- a/src/content/docs/es/build/apis/aptos-labs-developer-portal.mdx
+++ b/src/content/docs/es/build/apis/aptos-labs-developer-portal.mdx
@@ -1,7 +1,7 @@
 ---
-title: "Aptos Build de Aptos Labs"
+title: "Geomi de Aptos Labs"
 ---
 
-[Aptos Build](https://build.aptoslabs.com) es tu puerta de entrada para acceder a las APIs proporcionadas por Aptos Labs de una manera rápida y fácil para potenciar tu dapp. Más allá del acceso a APIs, ofrece servicios de gas station e indexación sin código.
+[Geomi](https://geomi.dev) es tu puerta de entrada para acceder a las APIs proporcionadas por Aptos Labs de una manera rápida y fácil para potenciar tu dapp. Más allá del acceso a APIs, ofrece servicios de gas station e indexación sin código.
 
-Aprende más sobre Aptos Build en el sitio de documentación dedicado [Aptos Build docs](https://build.aptoslabs.com/docs).
+Aprende más sobre Geomi en el sitio de documentación dedicado [Geomi docs](https://geomi.dev/docs).

--- a/src/content/docs/es/build/apis/fullnode-rest-api.mdx
+++ b/src/content/docs/es/build/apis/fullnode-rest-api.mdx
@@ -19,7 +19,7 @@ Para consultas más avanzadas, recomendamos usar la [API GraphQL del Indexador](
 
 ## Entendiendo los límites de tasa
 
-Como con el [Indexador de Aptos](/build/indexer/indexer-api), la API REST de Aptos tiene límites de tasa basados en unidades de cómputo. Puedes aprender más sobre cómo funciona el límite de tasa leyendo la [documentación de Aptos Build](https://build.aptoslabs.com/docs/start/billing).
+Como con el [Indexador de Aptos](/build/indexer/indexer-api), la API REST de Aptos tiene límites de tasa basados en unidades de cómputo. Puedes aprender más sobre cómo funciona el límite de tasa leyendo la [documentación de Geomi](https://geomi.dev/docs/admin/billing).
 
 ## Viendo estado actual e histórico
 

--- a/src/content/docs/es/build/get-started/developer-setup.mdx
+++ b/src/content/docs/es/build/get-started/developer-setup.mdx
@@ -68,8 +68,8 @@ Aquí hay una forma fácil de configurar tu entorno dependiendo del tipo de desa
            />
 
            <LinkCard
-             href="https://build.aptoslabs.com/"
-             title="Aptos Build"
+             href="https://geomi.dev/"
+title="Geomi"
              description="¿Alcanzando límites de tasa para API de Nodo Completo / Indexadores? Obtén
          una Clave de API aquí"
              target="_blank"

--- a/src/content/docs/es/build/indexer/indexer-api.mdx
+++ b/src/content/docs/es/build/indexer/indexer-api.mdx
@@ -44,9 +44,9 @@ Si necesitas hacer consultas GraphQL directamente a la API del Indexador alojada
 
 ### Límites de tasa
 
-Aprende más sobre los límites de tasa que se aplican a la API del indexador alojada por Aptos Labs leyendo la [documentación de Aptos Build](https://build.aptoslabs.com/docs/start/billing).
+Aprende más sobre los límites de tasa que se aplican a la API del indexador alojada por Aptos Labs leyendo la [documentación de Geomi](https://geomi.dev/docs/admin/billing).
 
 Si necesitas un límite de tasa más alto, considera las siguientes soluciones:
 
-1. Obtén una API Key de [Aptos Build](https://build.aptoslabs.com/). Aprende más sobre las API keys en el [sitio de documentación de Aptos Build](https://build.aptoslabs.com/docs/start/api-keys).
+1. Obtén una API Key de [Geomi](https://geomi.dev/). Aprende más sobre las API keys en el [sitio de documentación de Geomi](https://geomi.dev/docs/api-keys).
 2. Ejecuta la API del Indexador de Aptos tú mismo. Consulta la guía para auto-alojamiento [aquí](/build/indexer/txn-stream/self-hosted).

--- a/src/content/docs/es/build/indexer/indexer-api/indexer-reference.mdx
+++ b/src/content/docs/es/build/indexer/indexer-api/indexer-reference.mdx
@@ -412,8 +412,8 @@ The following tables are planned for deprecation, or are already deprecated. See
 | Table                               | Notes                                                                                                                                                           |
 | ----------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | address\_version\_from\_move\_resources | Replace with account\_transactions                                                                                                                               |
-| address\_events\_summary              | To query custom events, you should create a [No-Code Indexer](https://build.aptoslabs.com/docs/no-code-indexing)                                                |
-| address\_version\_from\_events         | To query custom events, you should create a [No-Code Indexer](https://build.aptoslabs.com/docs/no-code-indexing)                                                |
+| address\_events\_summary              | To query custom events, you should create a [No-Code Indexer](https://geomi.dev/docs/no-code-indexing)                                                |
+| address\_version\_from\_events         | To query custom events, you should create a [No-Code Indexer](https://geomi.dev/docs/no-code-indexing)                                                |
 | coin\_activities                     | Replace with fungible\_asset\_activities                                                                                                                          |
 | coin\_balances                       | Replace with current\_fungible\_asset\_balances                                                                                                                    |
 | coin\_infos                          | Replace with fungible\_asset\_metadata                                                                                                                            |
@@ -424,7 +424,7 @@ The following tables are planned for deprecation, or are already deprecated. See
 | current\_collection\_datas            | Replace with current\_collections\_v2                                                                                                                             |
 | current\_token\_datas                 | Replace with current\_token\_datas\_v2                                                                                                                             |
 | current\_token\_ownerships            | Replace with current\_token\_ownerships\_v2                                                                                                                        |
-| events\_view                         | To query custom events, you should create a [No-Code Indexer](https://build.aptoslabs.com/docs/no-code-indexing)                                                |
+| events\_view                         | To query custom events, you should create a [No-Code Indexer](https://geomi.dev/docs/no-code-indexing)                                                |
 | move\_resources                      | Replace with account\_transactions                                                                                                                               |
 | move\_resources\_view                 | Replace with account\_transactions                                                                                                                               |
 | nft\_marketplace\_v2\_\*                | Replace with [NFT Aggregator API](https://aptos.dev/en/build/indexer/nft-aggregator)                                                                            |

--- a/src/content/docs/es/build/indexer/txn-stream/aptos-hosted-txn-stream.mdx
+++ b/src/content/docs/es/build/indexer/txn-stream/aptos-hosted-txn-stream.mdx
@@ -14,13 +14,13 @@ Todos los endpoints están en GCP us-central1 a menos que se especifique lo cont
 - **Testnet:** grpc.testnet.aptoslabs.com:443
 - **Devnet:** grpc.devnet.aptoslabs.com:443
 
-Puedes aprender sobre los límites de tasa para este servicio leyendo la [documentación de Aptos Build](https://build.aptoslabs.com/docs/start/billing).
+Puedes aprender sobre los límites de tasa para este servicio leyendo la [documentación de Geomi](https://geomi.dev/docs/admin/billing).
 
 ## Autorización vía API Key
 
 Para usar el Servicio de Stream de Transacciones Alojado por Labs debes tener una API key. Para obtener una API key, haz lo siguiente:
 
-1. Ve a https://build.aptoslabs.com.
+1. Ve a https://geomi.dev.
 2. Inicia sesión y selecciona "API Resource".
 3. Crea una nueva key. Verás el secreto de la API key en la primera tabla.
 
@@ -30,7 +30,7 @@ Puedes proporcionar la API key configurando el header HTTP `Authorization` ([MDN
 curl -H 'Authorization: Bearer aptoslabs_yj4donpaKy_Q6RBP4cdBmjA8T51hto1GcVX5ZS9S65dx'
 ```
 
-Aprende más sobre las API keys en el [sitio de documentación de Aptos Build](https://build.aptoslabs.com/docs/start/api-keys).
+Aprende más sobre las API keys en el [sitio de documentación de Geomi](https://geomi.dev/docs/api-keys).
 
 Para información más completa sobre cómo usar el Servicio de Stream de Transacciones, consulta la documentación de los sistemas downstream:
 

--- a/src/content/docs/network/nodes/full-node/deployments.mdx
+++ b/src/content/docs/network/nodes/full-node/deployments.mdx
@@ -10,7 +10,7 @@ The following guides provide step-by-step instructions for deploying a PFN on th
   **Do I have to run a PFN?**<br />
   If you do not wish to run a PFN, but still want to interact with the Aptos blockchain, you can use the REST API
   provided by the Aptos Labs' PFNs (see [Aptos APIs](/build/apis)). Note, however, that Aptos Labs-provided PFNs have rate
-  limits, which can impede your development. You can get higher rate limits by creating an [Aptos Build](https://build.aptoslabs.com/) account and attaching a payment method. You can also deploy your own PFN
+  limits, which can impede your development. You can get higher rate limits by creating an [Geomi](https://geomi.dev/) account and attaching a payment method. You can also deploy your own PFN
   and synchronize with the Aptos blockchain directly, or use a different node infrastructure provider.
 </Aside>
 

--- a/src/content/docs/zh/build/ai/aptos-mcp.mdx
+++ b/src/content/docs/zh/build/ai/aptos-mcp.mdx
@@ -17,9 +17,9 @@ Aptos Model Context Protocol (MCP) 是一个服务器，提供了一套工具、
 
 ### 生成 Build Bot Api Key
 
-为了能够执行 Aptos Build 操作（如管理 API 密钥等），请按照以下说明生成一个新的 Bot API Key 以与 MCP 一起使用。
+为了能够执行 Geomi 操作（如管理 API 密钥等），请按照以下说明生成一个新的 Bot API Key 以与 MCP 一起使用。
 
-- 访问 https://build.aptoslabs.com/
+- 访问 https://geomi.dev/
 - 点击左下角的您的姓名
 - 点击 "Bot Keys"
 - 点击 "Create Bot Key" 按钮

--- a/src/content/docs/zh/build/apis/fullnode-rest-api.mdx
+++ b/src/content/docs/zh/build/apis/fullnode-rest-api.mdx
@@ -19,7 +19,7 @@ import { Aside, CardGrid, LinkCard } from '@astrojs/starlight/components';
 
 ## 理解速率限制
 
-与 [Aptos 索引器](/zh/build/indexer/indexer-api) 类似,Aptos REST API 也基于计算单元设有速率限制.您可以通过阅读 [Aptos Build 文档](https://build.aptoslabs.com/docs/start/billing) 了解更多关于速率限制的工作原理.
+与 [Aptos 索引器](/zh/build/indexer/indexer-api) 类似,Aptos REST API 也基于计算单元设有速率限制.您可以通过阅读 [Geomi 文档](https://geomi.dev/docs/admin/billing) 了解更多关于速率限制的工作原理.
 
 ## 查看当前和历史状态
 

--- a/src/content/docs/zh/build/get-started/developer-setup.mdx
+++ b/src/content/docs/zh/build/get-started/developer-setup.mdx
@@ -51,7 +51,7 @@ import { CardGrid, LinkCard, Steps, TabItem, Tabs } from '@astrojs/starlight/com
 
            <LinkCard href="https://github.com/aptos-labs/aptos-ts-sdk/tree/main/examples/typescript" title="TS SDK 示例" description="20+ 个 TS SDK 使用示例" target="_blank" />
 
-           <LinkCard href="https://build.aptoslabs.com/" title="Aptos Build" description="遇到 Fullnode API/索引器速率限制？可在此获取API密钥" target="_blank" />
+           <LinkCard href="https://geomi.dev/" title="Geomi" description="遇到 Fullnode API/索引器速率限制？可在此获取API密钥" target="_blank" />
          </CardGrid>
     </Steps>
   </TabItem>


### PR DESCRIPTION
- Changed all 'Aptos Build' references to 'Geomi' across English, Spanish, and Chinese docs
- Updated build.aptoslabs.com URLs to geomi.dev
- Fixed Geomi documentation URL paths:
  - docs/start/api-keys → docs/api-keys
  - docs/start/billing → docs/admin/billing
- Updated across multiple language versions (en/es/zh)