### PR TITLE
fix: correct Kotlin transaction spelling

### DIFF
--- a/src/content/docs/build/sdks/community-sdks/kotlin-sdk/building-transactions.mdx
+++ b/src/content/docs/build/sdks/community-sdks/kotlin-sdk/building-transactions.mdx
@@ -78,20 +78,20 @@ The typical flow for sending a transaction is as follows:
      Finally, you can submit the transaction to the network using the `submit` method.
 
      ```kotlin
-     val commitedTransaction = aptos.submitTransaction.simple(
-           transaction = signedTransaction,
-           senderAuthenticator = aliceAuthenticator,
-     )
+    val committedTransaction = aptos.submitTransaction.simple(
+          transaction = signedTransaction,
+          senderAuthenticator = aliceAuthenticator,
+    )
      ```
 
      <Aside type="note" emoji="ℹ️">
        You can collapse the signing and submitting steps into one by using the `signAndSubmitTransaction` method.
 
        ```kotlin
-       val executedTransaction = aptos.signAndSubmitTransaction(
-             signer = aliceAccount,
-             transaction = commitedTransaction,
-       )
+      val executedTransaction = aptos.signAndSubmitTransaction(
+            signer = aliceAccount,
+            transaction = committedTransaction,
+      )
        ```
      </Aside>
 
@@ -100,8 +100,8 @@ The typical flow for sending a transaction is as follows:
      Then you can wait for the transaction to be executed by using the `waitForTransaction` method.
 
      ```kotlin
-     val executedTransaction = aptos.waitForTransaction(HexInput.fromString(commitedTransaction.expect("Transaction failed").hash))
-     ```
+    val executedTransaction = aptos.waitForTransaction(HexInput.fromString(committedTransaction.expect("Transaction failed").hash))
+    ```
 </Steps>
 
 ### Full Kotlin Example
@@ -161,11 +161,11 @@ fun main() = runBlocking {
     )
 
   // Sign and submit the transaction
-  val commitedTransaction = aptos.signAndSubmitTransaction(alice, txn)
+  val committedTransaction = aptos.signAndSubmitTransaction(alice, txn)
 
   val executedTransaction =
     aptos.waitForTransaction(
-      HexInput.fromString(commitedTransaction.expect("Transaction failed").hash)
+      HexInput.fromString(committedTransaction.expect("Transaction failed").hash)
     )
 
   println(

--- a/src/content/docs/build/sdks/community-sdks/kotlin-sdk/quickstart.mdx
+++ b/src/content/docs/build/sdks/community-sdks/kotlin-sdk/quickstart.mdx
@@ -140,7 +140,7 @@ fetching data, and sending a transaction on the Aptos blockchain.
           Finally, you can submit the transaction to the network using the `submitTransaction.simple` method.
 
           ```kotlin
-          val commitedTransaction = aptos.submitTransaction.simple(
+          val committedTransaction = aptos.submitTransaction.simple(
                 transaction = signedTransaction,
                 senderAuthenticator = aliceAuthenticator,
           )
@@ -151,7 +151,7 @@ fetching data, and sending a transaction on the Aptos blockchain.
           Then you can wait for the transaction to be executed by using the `waitForTransaction` method.
 
           ```kotlin
-          val executedTransaction = aptos.waitForTransaction(HexInput.fromString(commitedTransaction.expect("Transaction failed").hash))
+          val executedTransaction = aptos.waitForTransaction(HexInput.fromString(committedTransaction.expect("Transaction failed").hash))
           ```
      </Steps>
 </Steps>


### PR DESCRIPTION
## Summary
- fix typo in Kotlin SDK quickstart doc
- fix typo in Kotlin SDK building transactions doc

## Testing
- `pnpm lint` *(fails: Unsafe assignment of an error typed value ...)*
- `pnpm check`


------
https://chatgpt.com/codex/tasks/task_b_689a876944f0832091928edd7311a962