### PR TITLE
feat(ui): expand GraphQL editor to full height in fullscreen mode

### DIFF
--- a/src/components/react/GraphQLEditor/styles.css
+++ b/src/components/react/GraphQLEditor/styles.css
@@ -139,3 +139,10 @@
     }
   }
 }
+
+:fullscreen,
+:-webkit-full-screen {
+  .graphiql-container {
+    height: 100vh;
+  }
+}


### PR DESCRIPTION
Ensures the GraphiQL container is full height when document is fullscreen, improving usability.