### PR TITLE
fix(css): Remove display:grid for list items causing overflow

### DIFF
--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -227,7 +227,6 @@ header site-search button {
 }
 
 .sl-markdown-content :not(ul, ol) + :is(ul, ol):not(:where(.not-content *, .sl-steps)) {
-  display: grid; /* helps with list markers alignment */
   margin-block: 0.75rem;
   margin-inline: 0;
   padding-inline-start: 1.5rem;


### PR DESCRIPTION
Fixes issue where code blocks were causing overflow issues when nested within lists.

### Before
<img width="1299" height="1102" alt="image" src="https://github.com/user-attachments/assets/1d73b0e4-c758-4865-9e3f-b29b2c55eb1a" />

### After
<img width="1299" height="1102" alt="image" src="https://github.com/user-attachments/assets/d3ab82e5-e1d7-4caf-af6e-5d7c32c0d505" />
