### PR TITLE
[Nodes] Improvements to localnet development docs.

### DIFF
--- a/astro.sidebar.ts
+++ b/astro.sidebar.ts
@@ -572,17 +572,6 @@ export const sidebar = [
     items: [
       "network/nodes", // Added Nodes Overview/Landing page
 
-      // Localnet
-      {
-        label: "Localnet",
-        collapsed: true,
-        items: [
-          "network/nodes/localnet",
-          "network/nodes/localnet/local-development-network",
-          "network/nodes/localnet/run-a-localnet",
-        ],
-      },
-
       // Validator Node
       {
         label: "Validator Node",
@@ -742,6 +731,18 @@ export const sidebar = [
               "network/nodes/configure/node-files-all-networks/node-files-devnet",
             ],
           },
+        ],
+      },
+
+      // Localnet
+      {
+        label: "Local Networks",
+        collapsed: true,
+        items: [
+          "network/nodes/localnet",
+          "network/nodes/localnet/local-development-network",
+          "network/nodes/localnet/run-a-localnet",
+          "network/nodes/localnet/run-a-multinode-localnet",
         ],
       },
     ],

--- a/src/content/docs/build/cli/running-a-local-network.mdx
+++ b/src/content/docs/build/cli/running-a-local-network.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Running a Local Network via Aptos CLI"
+title: "Running a Localnet via Aptos CLI"
 ---
 
 import { Aside, Steps } from '@astrojs/starlight/components';

--- a/src/content/docs/network/nodes/localnet.mdx
+++ b/src/content/docs/network/nodes/localnet.mdx
@@ -2,18 +2,30 @@
 title: "Develop with Localnet"
 ---
 
-## Recommended
+If you want to develop and test your applications on the Aptos blockchain, you can run a
+local network (**localnet**). This network will run on your local machine, and will not be
+connected to any other Aptos network. Running a localnet is the easiest way to test and
+develop Aptos applications, and make changes to the Aptos node software.
 
-Most developers should use the CLI to run a local development network.
-It is simpler and more fully featured than just a single node localnet + faucet.
-If you want a local stack that works just like a production network
-([Node API](/build/apis) + [Transaction Stream](/build/indexer/txn-stream) +
-[Indexer API](/build/indexer) + Faucet), this is the option for you.
+## Recommended Steps
 
-- ### [Run a Local Network Via Aptos CLI](/network/nodes/localnet/local-development-network)
+Most developers should use the Aptos CLI to run a local development network. This is the simplest
+and easiest way to get started. It provides a local deployment that works just like a production network,
+including the [Node API](/build/apis), [Transaction Stream](/build/indexer/txn-stream), [Indexer API](/build/indexer) and [Faucet](/build/apis/faucet-api).
 
-## Specialized
+To get started, follow this guide: [Localnet using the Aptos CLI](/network/nodes/localnet/local-development-network)
 
-If you're developing the core Aptos node software itself or have complex testing needs, consider this guide.
+## Specialized Steps
 
-- ### [Run a Localnet with Validator](/network/nodes/localnet/run-a-localnet)
+If you're developing the core Aptos node software, or have more complex testing needs, consider the
+guides below. The first guide provides a way to run a localnet with a single validator node, and the
+second guide provides a way to run a localnet with multiple validator nodes, and validator
+fullnodes (VFNs).
+
+To run a localnet with a single validator node, directly from the `aptos-core` source code, follow this guide:
+
+- [Localnet from source code](/network/nodes/localnet/run-a-localnet)
+
+To run a localnet with multiple validator nodes and validator fullnodes (VFNs), follow this guide:
+
+- [Multi-node Localnet](/network/nodes/localnet/run-a-multinode-localnet)

--- a/src/content/docs/network/nodes/localnet/local-development-network.mdx
+++ b/src/content/docs/network/nodes/localnet/local-development-network.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Running a Local Network via Aptos CLI"
+title: "Localnet using the Aptos CLI"
 ---
 
 import { Aside, Steps } from '@astrojs/starlight/components';
@@ -15,11 +15,11 @@ Local networks can be helpful when testing your code. They are not connected to 
 # Starting A Local Network
 
 <Steps>
-  1. Ensure you have the  installed.
+  1. Ensure you have the [Aptos CLI](../../../build/cli) installed.
 
      You can verify if the Aptos CLI is installed by running `aptos --version`.
 
-  2. Ensure you have  installed.
+  2. Ensure you have Docker installed.
 
      You can check whether Docker is installed by running `docker --version`.
 
@@ -35,7 +35,7 @@ Local networks can be helpful when testing your code. They are not connected to 
      ```
 
      <Aside type="caution">
-       Note: Despite the name (`local-testnet`), this has nothing to do with the Aptos testnet, it will run a network entirely local to your machine.
+       Note: Despite using the name `local-testnet` above, this has nothing to do with the official Aptos testnet. This command will run a network entirely local to your machine.
      </Aside>
 
      You should expect to see an output similar to this:

--- a/src/content/docs/network/nodes/localnet/run-a-localnet.mdx
+++ b/src/content/docs/network/nodes/localnet/run-a-localnet.mdx
@@ -1,32 +1,28 @@
 ---
-title: "Run a Localnet with Validator"
+title: "Localnet from source code"
 ---
 
 import { Aside } from '@astrojs/starlight/components';
 
+You can run a localnet using the [aptos-core](https://github.com/aptos-labs/aptos-core) source code. This approach is useful for testing modifications to the aptos-core codebase or to the Aptos Framework.
+
 <Aside type="note">
-  **Using the CLI to run a local development network** <br />
-  Running a localnet with the Aptos CLI is simpler and more fully featured. Learn how by following this guide: [Run a Local Development Network with the CLI](/network/nodes/localnet/local-development-network).
+  It is easier to run a localnet using the [Aptos CLI](/network/nodes/localnet/local-development-network) than it is to run it from source code. The CLI also provides a more user-friendly experience and additional features.
+  Learn how by following this guide: [Localnet using the Aptos CLI](/network/nodes/localnet/local-development-network).
 </Aside>
-
-You can run a localnet of the Aptos blockchain. This localnet will not be connected to the Aptos devnet. It will run on your local machine, independent of other Aptos networks. You can use this localnet for testing and development purposes.
-
-You can run a localnet using the Aptos-core source code. This approach is useful for testing modifications to the Aptos-core codebase or to the Aptos Framework.
 
 The rest of this document describes:
 
-- How to start your localnet with a single validator node, and
+- How to start your localnet with a single validator node.
 - How to start a Faucet service and attach it to your localnet.
 
 ## Using the Aptos-core source code
 
 1. Follow steps in [Building Aptos From Source](/network/nodes/building-from-source)
 
-2. With your development environment ready, now you can start your localnet. Before you proceed, make a note of the following:
+2. With your development environment ready, you can start your localnet.
 
    <Aside type="note">
-     **NOTE**
-
      - When you run the below command to start the localnet, your terminal will enter into an interactive mode, with a message `Aptos is running, press ctrl-c to exit`. Hence, you will need to open another shell terminal for the subsequent steps described in this section.
      - After the below command runs, copy the `Test dir` information from the terminal output for the next step.
    </Aside>
@@ -55,11 +51,13 @@ The rest of this document describes:
    Aptos is running, press ctrl-c to exit
    ```
 
-**NOTE**: The above command starts a localnet with a single validator node. The command runs `aptos-node` from a genesis-only ledger state. If you want to reuse the ledger state produced by a previous run of `aptos-node`, then use:
+<Aside type="tip">
+  The above command starts a localnet with a single validator node. The command runs `aptos-node` from a genesis-only ledger state. If you want to reuse the ledger state produced by a previous run of `aptos-node`, then use:
 
-```shellscript filename="Terminal"
-cargo run -p aptos-node -- --test --config <config-path>
-```
+  ```shellscript filename="Terminal"
+  cargo run -p aptos-node -- --test --config <config-path>
+  ```
+</Aside>
 
 ### Attaching a Faucet to your localnet
 

--- a/src/content/docs/network/nodes/localnet/run-a-multinode-localnet.mdx
+++ b/src/content/docs/network/nodes/localnet/run-a-multinode-localnet.mdx
@@ -1,0 +1,99 @@
+---
+title: "Multi-node Localnet"
+---
+
+import { Aside } from '@astrojs/starlight/components';
+
+This guide describes how to run a local network with multiple validator nodes and validator fullnodes. You will use [Aptos Forge](https://github.com/aptos-labs/aptos-core/tree/main/testsuite/forge-cli/src) in the [aptos-core](https://github.com/aptos-labs/aptos-core) source code for this.
+
+<Aside type="note">
+  The steps described in this guide should only be used for test networks of multi-node local networks. Do not use this guide for deploying networks in production environments.
+  This guide also assumes that you have completed the steps in [Building Aptos From Source](/network/nodes/building-from-source).
+</Aside>
+
+## Localnet with multiple validators
+
+To deploy a localnet with multiple local validators, run this command from the root directory of the [aptos-core](https://github.com/aptos-labs/aptos-core) source code:
+
+```sh
+cargo run -p aptos-forge-cli \
+        -- \
+        --suite "run_forever" \
+        --num-validators 4 test local-swarm
+```
+
+This will start a local network of 4 validators, each running in their own process. The network will run forever unless you manually terminate it.
+
+The terminal output will display the locations of the validator files (for example, the genesis files, logs, node configurations, etc.) and the commands that were run to start each node. The process id (PID) of each node and server addresses (e.g., REST APIs) are also displayed when it starts. For example, if you run the above command you should see:
+
+```text
+...
+2022-09-01T15:41:27.228289Z [main] INFO crates/aptos-genesis/src/builder.rs:462 Building genesis with 4 validators. Directory of output: "/private/var/folders/dx/c0l2rrkn0656gfx6v5_dy_p80000gn/T/.tmpq9uPMJ"
+...
+2022-09-01T15:41:28.090606Z [main] INFO testsuite/forge/src/backend/local/swarm.rs:207 The root (or mint) key for the swarm is: 0xf9f...
+...
+2022-09-01T15:41:28.094800Z [main] INFO testsuite/forge/src/backend/local/node.rs:129 Started node 0 (PID: 78939) with command: ".../aptos-core/target/debug/aptos-node" "-f" "/private/var/folders/dx/c0l2rrkn0656gfx6v5_dy_p80000gn/T/.tmpq9uPMJ/0/node.yaml"
+2022-09-01T15:41:28.094825Z [main] INFO testsuite/forge/src/backend/local/node.rs:137 Node 0: REST API is listening at: http://127.0.0.1:64566
+2022-09-01T15:41:28.094838Z [main] INFO testsuite/forge/src/backend/local/node.rs:142 Node 0: Inspection service is listening at http://127.0.0.1:64568
+...
+```
+
+Using the information from this output, you can stop a single node and restart
+it. For example, to stop and restart the node `0`, execute the below commands:
+
+```sh
+kill -9 <Node 0 PID>
+cargo run -p aptos-node \
+        -- \
+        -f <Location to the node 0 configuration file displayed above>
+```
+
+## Faucet and minting
+
+In order to mint coins in this test network you need to run a faucet. You can do that with this command:
+
+```sh
+cargo run -p aptos-faucet-service -- run-simple --key <key> --node-url <node_url>
+```
+
+You can get the values above like this:
+
+- `key`: When you started the swarm, there was output like this: `The root (or mint) key for the swarm is: 0xf9f...`. This is the `key`.
+- `node_url`: When you started the swarm, there was output like this: `REST API is listening at: http://127.0.0.1:64566`. This is the `node_url`.
+
+The above command will run a faucet locally, listening on port `8081`. Using this faucet, you can then mint tokens to your test accounts, for example:
+
+```sh
+curl -X POST http://127.0.0.1:8081/mint?amount=<amount to mint>&pub_key=<public key to mint tokens to>
+```
+
+As an alternative to using the faucet service, you may use the faucet CLI directly:
+
+```sh
+cargo run -p aptos-faucet-cli -- --amount 10 --accounts <account_address> --key <private_key>
+```
+
+<Aside type="tip">
+  See more on how the faucet works in the [README](https://github.com/aptos-labs/aptos-core/tree/main/crates/aptos-faucet).
+  Also see how to use the [Aptos CLI](../../../build/cli) with an existing faucet.
+</Aside>
+
+## Validator fullnodes
+
+To also run validator fullnodes inside the network, use the `--num-validator-fullnodes` flag. For example:
+
+```sh
+cargo run -p aptos-forge-cli \
+        -- \
+        --suite "run_forever" \
+        --num-validators 3 \
+        --num-validator-fullnodes 1 test local-swarm
+```
+
+## Additional usage
+
+To see all tool usage options, run:
+
+```sh
+cargo run -p aptos-forge-cli --help
+```


### PR DESCRIPTION
This PR offers several improvements to the localnet development docs:
- Add a new doc for multi-node deployments (original was here: https://legacy.aptos.dev/guides/running-a-local-multi-node-network/)
- Rearranged the NAV bar to make more sense in the section.
- Wording changes and shuffles.