### PR TITLE
[Nodes] Refresh the inspection service docs and update identity information.

### DIFF
--- a/src/content/docs/network/nodes/full-node/modify/network-identity-fullnode.mdx
+++ b/src/content/docs/network/nodes/full-node/modify/network-identity-fullnode.mdx
@@ -4,27 +4,27 @@ title: "Generate a PFN Identity"
 
 import { Aside } from '@astrojs/starlight/components';
 
-<Aside type="caution">
+<Aside type="danger">
   Validators and VFNs have their identities initialized when first created and their identities are long-lived (immutable).
-  PFN identities are more ephemeral and can be regenerated on demand. As such, generating an identity using this
+  PFN identities are more ephemeral and can be regenerated. As such, generating an identity using this
   guide **should only be done for PFNs**, and not for validators or VFNs.
 </Aside>
 
 ## Ephemeral vs. Static Identities
 
-<Aside type="danger">
+Public fullnodes (PFNs) will automatically start up with a randomly generated (ephemeral) network identity unless a static identity is provided. This works well for
+regular PFNs. However, there are cases where you may want to generate and assign a static network identity to your PFN (e.g., for monitoring purposes).
+
+<Aside type="caution">
   PFN identities should be unique across the network. If you are running multiple PFNs, make sure to generate a
   unique identity for each PFN. Attempting to share the same identity across multiple PFNs will result in degraded
   node performance.
 </Aside>
 
-Public fullnodes (PFNs) will automatically start up with a randomly generated (ephemeral) network identity unless a static identity is provided. This works well for
-regular PFNs. However, there are cases where you may want to generate and assign a static network identity to your PFN.
-
 ### Ephemeral Identity
 
-- Automatically generated on startup. The same ephemeral identity is used across restarts if the identity key file already exists.
-- Stored at `/opt/aptos/data/db/ephemeral_identity_key`.
+- Automatically generated on node startup. The same ephemeral identity is used across restarts if the identity key file already exists.
+- By default, the identity file is stored at `/opt/aptos/data/db/ephemeral_identity_key`.
 
 ### Static Identity
 
@@ -33,10 +33,6 @@ This is useful when:
 - You wish to advertise your PFN as a seed (i.e., for other Aptos PFNs to connect to).
 - You wish to add your PFN to an allowlist of known identities on an upstream PFN or VFN.
 - You wish to fix the identity of your PFN across restarts and releases so that telemetry and other monitoring tools can track your PFN over time.
-
-<Aside type="caution">
-  Before you proceed, make sure that you already know how to start your local PFN. See [Run a PFN](/network/nodes/full-node) for detailed documentation.
-</Aside>
 
 ## Generate a static identity
 
@@ -219,3 +215,18 @@ full_node_networks:
 ```
 
 Starting your PFN with this configuration will assign your PFN with the static network identity you generated.
+
+## Check your node identity
+
+If you want to check the identity of your node at runtime, there are several ways to do so. Two of the simplest
+methods are:
+
+- **Using the REST API**: You can query the `/v1/info` endpoint of your node's [REST API](/build/apis/fullnode-rest-api)
+  to retrieve the identity information.
+- **Using the Node Inspection Service**: You can query the `/identity_information` endpoint on your node's inspection service
+  to retrieve the identity information of your node. You can read more [here](/network/nodes/measure/node-inspection-service#examine-identity-information).
+
+<Aside type="note">
+  Nodes with multiple network connection types (e.g., `VFN` and `public` networks) will have identities for each connection type.
+  For public fullnodes (PFNs), there is only one network connection type (`public`), so there will be only one identity.
+</Aside>

--- a/src/content/docs/network/nodes/measure/node-inspection-service.mdx
+++ b/src/content/docs/network/nodes/measure/node-inspection-service.mdx
@@ -9,19 +9,40 @@ monitor and inspect the health and performance of the node dynamically, at runti
 information can be queried or exported via an inspection service that runs on each node.
 To see the list of important metrics and counters, see the [Important Node Metrics](/network/nodes/measure/important-metrics) document.
 
-You can configure various aspects of the node inspection service. This document describes how to expose and see the metrics locally, on the respective node. You may also view these metrics remotely by making the port accessible via firewall rules.
-
 <Aside type="caution">
-  If you do make the inspection service port publicly accessible on your node, we
-  recommend disabling access when not in use (to prevent unauthorized access and abuse).
+  We do not recommend making the inspection service publicly accessible, as it may expose potentially sensitive
+  information about your node, such as file paths and directories.
 </Aside>
 
-## Examining node metrics
+## Inspection service features
 
-If you'd like to examine the metrics of your node, start running a
-node and review the inspection service locally by loading this URL in your browser:
+If you'd like to examine all the endpoints provided by the inspection service, visit the following URL
+once you have started your node:
 
-```shellscript
+```sh
+http://localhost:9101/
+```
+
+This will display a directory of all the endpoints and features offered by the service, for example:
+
+```
+Welcome to the Aptos Inspection Service!
+The following endpoints are available:
+	- /configuration
+	- /consensus_health_check
+	- /forge_metrics
+	- /identity_information
+	- /json_metrics
+	- /metrics
+	- /peer_information
+	- /system_information
+```
+
+## Examine node metrics
+
+If you'd like to examine the metrics of your node at runtime, visit the following URL:
+
+```sh
 http://localhost:9101/metrics
 ```
 
@@ -30,37 +51,33 @@ To see updates to these values, simply refresh the page.
 
 Likewise, if you wish to view the metrics in `json` format, visit the following URL:
 
-```shellscript
+```sh
 http://localhost:9101/json_metrics
 ```
 
-<Aside type="note">
-  Inspection service configuration
-  See additional configuration
-  details below.
-</Aside>
+## Configure the inspection service
 
-## Change inspection service port
+You can configure various aspects of the node inspection service, for example, you can change the port it listens on,
+enable or disable certain endpoints, and more. The inspection service is enabled by default, so you do not need to do
+anything special once you start your node.
 
-The inspection service should run on all nodes by default, at port `9101`. To change
-the port the inspection service listens on (e.g., to `1000`), add the following to your node
-configuration file:
+The inspection service should run by default at port `9101`. To change the port the inspection service listens on
+(e.g., to `1000`), add the following to your node configuration file:
 
 ```yaml filename="fullnode.yaml"
 inspection_service:
   port: 1000
 ```
 
-## Expose system configuration
+## Examine node configuration
 
-The inspection service also provides a way to examine the configuration of your node
-at runtime (i.e., the configuration settings that your node started with).
+The inspection service also provides a way to examine the configuration file of your node
+at runtime (i.e., the node configuration file that your node started with).
 
 <Aside type="caution">
-  **Proceed with caution**<br />
   By default, the configuration endpoint is disabled as it may expose potentially sensitive
-  information about the configuration of your node, e.g., file paths and directories. We
-  recommend enabling this endpoint only if the inspection service is not publicly accessible.
+  information about your node, e.g., file paths and directories. We recommend enabling this
+  endpoint only if the inspection service is not publicly accessible.
 </Aside>
 
 To enable this feature, add the following to your node configuration file:
@@ -72,16 +89,16 @@ inspection_service:
 
 And visit the configuration URL:
 
-```shellscript
+```sh
 http://localhost:9101/configuration
 ```
 
-## Expose system information
+## Examine system information
 
 Likewise, the inspection service also provides a way to examine the system information of your node
 at runtime (i.e., build and hardware information). Simply visit the following URL:
 
-```shellscript
+```sh
 http://localhost:9101/system_information
 ```
 
@@ -93,8 +110,22 @@ inspection_service:
 ```
 
 <Aside type="note">
-  **System information accuracy**<br />
   The system information displayed here is not guaranteed to be 100% accurate due to limitations
-  in the way this information is collected. As a result, we recommend not worrying about any
-  inaccuracies and treating the information as an estimate.
+  in the way this information is collected.
 </Aside>
+
+## Examine identity information
+
+The inspection service also provides an easy way to examine the identity of your node
+(i.e., the peer ID for each network) at runtime. Simply visit the following URL:
+
+```sh
+http://localhost:9101/identity_information
+```
+
+If you'd like to disable this endpoint, add the following to your node configuration file:
+
+```yaml filename="fullnode.yaml"
+inspection_service:
+  expose_identity_information: false
+```


### PR DESCRIPTION
This PR offers several improvements to the localnet development docs:
- Refresh the node inspection service guide.
- Add documentation for operators to identify their node identity information at runtime.