### PR TITLE
feat(layout): Implement global footer

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -111,6 +111,7 @@ export default defineConfig({
         PageSidebar: "./src/starlight-overrides/PageSidebar.astro",
         PageTitle: "./src/starlight-overrides/PageTitle.astro",
         Sidebar: "./src/starlight-overrides/Sidebar.astro",
+        TwoColumnContent: "./src/starlight-overrides/TwoColumnContent.astro",
       },
       plugins: [
         starlightLlmsTxt({

--- a/src/content/docs/build/smart-contracts/linter.mdx
+++ b/src/content/docs/build/smart-contracts/linter.mdx
@@ -91,7 +91,7 @@ let y = x; // cast removed
 
 ### `infinite_recursion`
 
-Checks for functions or groups of functions that recurse infinitely. Note that the linter cannot detect *conditional* infinite recursion, only inconditional, so a flag is a definite error in the program.
+Checks for functions or groups of functions that recurse infinitely. Note that the linter cannot detect _conditional_ infinite recursion, only inconditional, so a flag is a definite error in the program.
 
 ### `known_to_abort`
 

--- a/src/starlight-overrides/PageFrame.astro
+++ b/src/starlight-overrides/PageFrame.astro
@@ -1,16 +1,126 @@
 ---
-import Default from "@astrojs/starlight/components/PageFrame.astro";
-import Analytics from "@components/Analytics.astro";
-import SpanishBetaBanner from "@components/SpanishBetaBanner.astro";
+import MobileMenuToggle from "virtual:starlight/components/MobileMenuToggle";
+
+const { hasSidebar } = Astro.locals.starlightRoute;
 ---
 
-<Default {...Astro.props}>
-  <div transition:persist="header" slot="header">
-    <slot name="header" />
-  </div>
-  <slot name="sidebar" slot="sidebar" />
-  <SpanishBetaBanner />
-  <slot />
-</Default>
+<div class="page sl-flex">
+  <header class="header"><slot name="header" /></header>
+  {
+    hasSidebar && (
+      <nav class="sidebar print:hidden" aria-label={Astro.locals.t("sidebarNav.accessibleLabel")}>
+        <MobileMenuToggle />
+        <div id="starlight__sidebar" class="sidebar-pane">
+          <div class="sidebar-content sl-flex">
+            <slot name="sidebar" />
+          </div>
+        </div>
+      </nav>
+    )
+  }
+  <div class="main-frame"><slot /></div>
+</div>
+<footer class="global-footer">
+  © {new Date().getFullYear()} Aptos Foundation
+  <a href="https://aptosfoundation.org/privacy" target="_blank">Privacy</a>
+  <a href="https://aptosfoundation.org/terms" target="_blank">Terms</a>
+</footer>
 
-<Analytics />
+<style>
+  @layer starlight.core {
+    .page {
+      /* flex-direction: column; */
+      min-height: 100vh;
+    }
+
+    .header {
+      z-index: var(--sl-z-index-navbar);
+      position: fixed;
+      inset-inline-start: 0;
+      inset-block-start: 0;
+      width: 100%;
+      height: var(--sl-nav-height);
+      border-bottom: 1px solid var(--sl-color-hairline-shade);
+      padding: var(--sl-nav-pad-y) var(--sl-nav-pad-x);
+      padding-inline-end: var(--sl-nav-pad-x);
+      background-color: var(--sl-color-bg-nav);
+    }
+
+    :global([data-has-sidebar]) .header {
+      padding-inline-end: calc(
+        var(--sl-nav-gap) + var(--sl-nav-pad-x) + var(--sl-menu-button-size)
+      );
+    }
+
+    .sidebar-pane {
+      visibility: var(--sl-sidebar-visibility, hidden);
+      position: fixed;
+      height: 100vh;
+      z-index: var(--sl-z-index-menu);
+      inset-block: var(--sl-nav-height) 0;
+      inset-inline-start: 0;
+      width: 100%;
+      background-color: var(--sl-color-black);
+      overflow-y: auto;
+    }
+
+    :global([aria-expanded="true"]) ~ .sidebar-pane {
+      --sl-sidebar-visibility: visible;
+    }
+
+    .sidebar-content {
+      height: 100%;
+      min-height: max-content;
+      padding: 1rem var(--sl-sidebar-pad-x) 0;
+      flex-direction: column;
+      gap: 1rem;
+    }
+
+    @media (min-width: 50rem) {
+      .sidebar-content::after {
+        content: "";
+        padding-bottom: 1px;
+      }
+    }
+
+    .main-frame {
+      padding-top: calc(var(--sl-nav-height) + var(--sl-mobile-toc-height));
+      /* padding-inline-start: var(--sl-content-inline-start); */
+      flex-grow: 1;
+    }
+
+    @media (min-width: 50rem) {
+      :global([data-has-sidebar]) .header {
+        padding-inline-end: var(--sl-nav-pad-x);
+      }
+      .sidebar-pane {
+        --sl-sidebar-visibility: visible;
+        width: var(--sl-sidebar-width);
+        background-color: var(--sl-color-bg-sidebar);
+        border-inline-end: 1px solid var(--sl-color-hairline-shade);
+        position: sticky;
+      }
+    }
+    .global-footer {
+      display: block;
+      width: 100%;
+      border-top: 1px solid var(--sl-color-hairline);
+      text-align: center;
+      padding: 2rem 0;
+      display: flex;
+      justify-content: center;
+      align-items: center;
+      gap: 1rem;
+      font-size: var(--sl-text-xs);
+      color: var(--sl-color-gray-3);
+    }
+
+    .global-footer a {
+      color: var(--sl-color-text);
+      text-decoration: none;
+      &:hover {
+        color: var(--sl-color-white);
+      }
+    }
+  }
+</style>

--- a/src/starlight-overrides/TwoColumnContent.astro
+++ b/src/starlight-overrides/TwoColumnContent.astro
@@ -1,0 +1,54 @@
+<div class="lg:sl-flex">
+  {
+    Astro.locals.starlightRoute.toc && (
+      <aside class="right-sidebar-container print:hidden">
+        <div class="right-sidebar">
+          <slot name="right-sidebar" />
+        </div>
+      </aside>
+    )
+  }
+  <div class="main-pane"><slot /></div>
+</div>
+
+<style>
+  @layer starlight.core {
+    .main-pane {
+      isolation: isolate;
+    }
+
+    @media (min-width: 72rem) {
+      .right-sidebar-container {
+        order: 2;
+        position: relative;
+        width: calc(
+          var(--sl-sidebar-width) + (100% - var(--sl-content-width) - var(--sl-sidebar-width)) / 2
+        );
+      }
+
+      .right-sidebar {
+        position: sticky;
+        inset-block: var(--sl-nav-height) 0;
+        border-inline-start: 1px solid var(--sl-color-hairline);
+        padding-top: 0;
+        width: 100%;
+        height: 100vh;
+        overflow-y: auto;
+        scrollbar-width: none;
+      }
+
+      .main-pane {
+        width: 100%;
+      }
+
+      :global([data-has-sidebar][data-has-toc]) .main-pane {
+        --sl-content-margin-inline: auto 0;
+
+        order: 1;
+        width: calc(
+          var(--sl-content-width) + (100% - var(--sl-content-width) - var(--sl-sidebar-width)) / 2
+        );
+      }
+    }
+  }
+</style>

--- a/starlight.d.ts
+++ b/starlight.d.ts
@@ -28,3 +28,8 @@ declare module "virtual:starlight/components/LanguageSelect" {
   const LanguageSelect: typeof import("@astrojs/starlight/components/LanguageSelect.astro").default;
   export default LanguageSelect;
 }
+
+declare module "virtual:starlight/components/MobileMenuToggle" {
+  const MobileMenuToggle: typeof import("@astrojs/starlight/components/MobileMenuToggle.astro").default;
+  export default MobileMenuToggle;
+}


### PR DESCRIPTION
### Overview

This PR introduces a new global footer that is displayed sitewide, providing a consistent and unified experience across all pages. Previously, the footer was constrained to the MDX content width, which limited its functionality and visual appeal. This change was intentionally made to eventually align with the footer layout of the main network site.

### Key Changes

1. __Global Footer Implementation:__

   - A new global footer has been added to `src/starlight-overrides/PageFrame.astro`, ensuring it appears on every page.
   - The footer includes the copyright notice with a dynamic year, along with links to the Privacy and Terms pages.

2. __Layout Adjustments:__

   - To accommodate the new footer, the positioning of the main sidebar (left) and the MDX content sidebar (right) has been updated from `fixed` to `sticky`.
   - This change prevents the sidebars from bleeding into the footer and ensures they scroll correctly with the page content.

### Motivation

The default footer in Starlight is confined within the MDX content area, which is geared towards the specific document in view and not ideal for a sitewide element. This approach, as seen on sites like [Cloudflare Docs](https://developers.cloudflare.com/workers/), results in a footer that is constrained by the content width and doesn't provide a true sitewide presence that you'd expect from a global footer (just like a global header / nav).

By moving the footer to the main page frame, we achieve a more consistent layout which will allow alignment with the network site. 
