### PR TITLE
fix(perf): implement reusable client:on-demand directive for lazy loading chat widget

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -225,23 +225,6 @@ export default defineConfig({
         "~/images": fileURLToPath(new URL("./src/assets/images", import.meta.url)),
       },
     },
-    build: {
-      rollupOptions: {
-        output: {
-          // Split vendor chunks to reduce main bundle size
-          manualChunks: {
-            // React and related libraries
-            "react-vendor": ["react", "react-dom"],
-            // Chat widget as separate chunk since it's lazy loaded
-            "chat-widget": ["@aptos-labs/ai-chatbot-client"],
-            // Large utility libraries
-            utils: ["lodash", "date-fns"],
-          },
-        },
-      },
-      // Enable compression and minification
-      minify: "esbuild",
-    },
   },
   markdown: {
     remarkPlugins: [

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -108,6 +108,7 @@ export default defineConfig({
       components: {
         Head: "./src/starlight-overrides/Head.astro",
         Header: "./src/starlight-overrides/Header.astro",
+        Hero: "./src/starlight-overrides/Hero.astro",
         LanguageSelect: "./src/starlight-overrides/LanguageSelect.astro",
         MobileMenuToggle: "./src/starlight-overrides/MobileMenuToggle.astro",
         PageFrame: "./src/starlight-overrides/PageFrame.astro",

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -221,6 +221,23 @@ export default defineConfig({
         "~/images": fileURLToPath(new URL("./src/assets/images", import.meta.url)),
       },
     },
+    build: {
+      rollupOptions: {
+        output: {
+          // Split vendor chunks to reduce main bundle size
+          manualChunks: {
+            // React and related libraries
+            "react-vendor": ["react", "react-dom"],
+            // Chat widget as separate chunk since it's lazy loaded
+            "chat-widget": ["@aptos-labs/ai-chatbot-client"],
+            // Large utility libraries
+            utils: ["lodash", "date-fns"],
+          },
+        },
+      },
+      // Enable compression and minification
+      minify: "esbuild",
+    },
   },
   markdown: {
     remarkPlugins: [

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -24,6 +24,7 @@ import { SUPPORTED_LANGUAGES, SITE_TITLES } from "./src/config/18n";
 import { firebaseIntegration } from "./src/integrations/firebase";
 import { remarkClientOnly } from "./src/plugins";
 import { devServerFileWatcher } from "./src/integrations/dev-server-file-watcher";
+import onDemandDirective from "./src/integrations/client-on-demand/register.js";
 // import { isMoveReferenceEnabled } from "./src/utils/isMoveReferenceEnabled";
 // import { rehypeAddDebug } from "./src/plugins";
 
@@ -44,6 +45,8 @@ export default defineConfig({
         : "http://localhost:4321",
   trailingSlash: "never",
   integrations: [
+    // Custom client directive for on-demand loading
+    onDemandDirective(),
     // Only include devServerFileWatcher in development mode
     ...(process.env.NODE_ENV === "development" || !process.env.VERCEL
       ? [

--- a/src/components/chat-widget/ChatButton.astro
+++ b/src/components/chat-widget/ChatButton.astro
@@ -40,22 +40,24 @@ const { isMobile = false } = Astro.props;
   const mobileButton = document.getElementById("mobile-chat-trigger");
   const desktopButton = document.getElementById("chat-trigger");
 
-  if (mobileButton) {
-    mobileButton.addEventListener("click", () => {
-      window.dispatchEvent(new CustomEvent("toggle-chat"));
-      // Close the mobile menu when opening chat
+  function handleChatToggle() {
+    window.dispatchEvent(new CustomEvent("toggle-chat"));
+    // Close the mobile menu when opening chat
+    if (document.body.hasAttribute("data-mobile-menu-expanded")) {
       document.body.removeAttribute("data-mobile-menu-expanded");
       const menuButton = document.querySelector("starlight-menu-button");
       if (menuButton) {
         menuButton.setAttribute("aria-expanded", "false");
       }
-    });
+    }
+  }
+
+  if (mobileButton) {
+    mobileButton.addEventListener("click", handleChatToggle);
   }
 
   if (desktopButton) {
-    desktopButton.addEventListener("click", () => {
-      window.dispatchEvent(new CustomEvent("toggle-chat"));
-    });
+    desktopButton.addEventListener("click", handleChatToggle);
   }
 </script>
 

--- a/src/components/chat-widget/ChatButton.astro
+++ b/src/components/chat-widget/ChatButton.astro
@@ -22,6 +22,7 @@ const { isMobile = false } = Astro.props;
       alt="Aptos Logo"
       width={20}
       height={20}
+      fetchpriority="high"
     />
     <Image
       src={aptosLogoDark}
@@ -29,6 +30,7 @@ const { isMobile = false } = Astro.props;
       alt="Aptos Logo"
       width={20}
       height={20}
+      fetchpriority="high"
     />
   </div>
   <span class="text-sm font-semibold">AskAptos</span>

--- a/src/components/chat-widget/ChatDialog.astro
+++ b/src/components/chat-widget/ChatDialog.astro
@@ -5,7 +5,7 @@ const apiKey = process.env.PUBLIC_CHATBOT_API_KEY ?? "";
 const apiUrl = process.env.PUBLIC_CHATBOT_URL ?? "http://localhost:8080";
 ---
 
-<ChatWidget client:only="react" apiKey={apiKey} apiUrl={apiUrl} />
+<ChatWidget client:idle apiKey={apiKey} apiUrl={apiUrl} />
 
 <style>
   :root {

--- a/src/components/chat-widget/ChatDialog.astro
+++ b/src/components/chat-widget/ChatDialog.astro
@@ -5,7 +5,7 @@ const apiKey = process.env.PUBLIC_CHATBOT_API_KEY ?? "";
 const apiUrl = process.env.PUBLIC_CHATBOT_URL ?? "http://localhost:8080";
 ---
 
-<ChatWidget client:idle apiKey={apiKey} apiUrl={apiUrl} />
+<ChatWidget client:on-demand="toggle-chat" apiKey={apiKey} apiUrl={apiUrl} />
 
 <style>
   :root {
@@ -14,12 +14,3 @@ const apiUrl = process.env.PUBLIC_CHATBOT_URL ?? "http://localhost:8080";
     --chat-border: #1f1f1f;
   }
 </style>
-
-<script>
-  window.addEventListener("toggle-chat", () => {
-    const trigger = document.querySelector("[aria-controls]");
-    if (trigger) {
-      trigger.dispatchEvent(new MouseEvent("click", { bubbles: true }));
-    }
-  });
-</script>

--- a/src/integrations/client-on-demand/README.md
+++ b/src/integrations/client-on-demand/README.md
@@ -1,0 +1,74 @@
+# Custom `client:on-demand` Directive
+
+A reusable Astro client directive that enables true lazy loading of React components based on custom events.
+
+## Features
+
+- **Configurable Event Names**: Specify which events trigger hydration
+- **Multiple Event Support**: Listen to multiple events with comma separation
+- **Modern Browser APIs**: Uses `requestAnimationFrame` double-RAF pattern
+- **Auto-Trigger**: Automatically triggers the primary event after hydration
+- **Error Handling**: Robust error recovery with state reset
+- **Memory Efficient**: Proper cleanup with event listener removal
+
+## Usage Examples
+
+### Basic Usage
+
+```astro
+<!-- Hydrates when "toggle-chat" event is dispatched -->
+<ChatWidget client:on-demand="toggle-chat" />
+
+<!-- Hydrates when "play-video" event is dispatched -->
+<VideoPlayer client:on-demand="play-video" />
+
+<!-- Hydrates when "open-gallery" event is dispatched -->
+<ImageGallery client:on-demand="open-gallery" />
+```
+
+### Multiple Event Triggers
+
+```astro
+<!-- Hydrates on any of these events -->
+<ComplexWidget client:on-demand="activate,show,toggle" />
+```
+
+### Default Event
+
+```astro
+<!-- Uses default "activate" event if no parameter provided -->
+<SomeComponent client:on-demand />
+```
+
+## How It Works
+
+1. **Initial State**: Component is in DOM but not hydrated (no JavaScript loaded)
+2. **Event Trigger**: When specified event is dispatched, directive calls Astro's `load()` function
+3. **Hydration**: Astro loads and hydrates the React component
+4. **Render Wait**: Uses modern `requestAnimationFrame` double-RAF to wait for render completion
+5. **Auto-Trigger**: Dispatches the primary event to trigger component behavior
+6. **Subsequent Events**: Component is hydrated and handles events directly
+
+## Implementation Details
+
+- **Event Parsing**: Supports comma-separated event names
+- **Fallback**: Uses "activate" as default event name
+- **Modern Timing**: `requestAnimationFrame` double-RAF pattern for optimal performance
+- **Cross-Browser**: Compatible with all modern browsers including Safari
+- **TypeScript**: Full type safety with configurable string parameter
+
+## Example Integration
+
+```javascript
+// Button that triggers lazy loading
+document.getElementById("my-button").addEventListener("click", () => {
+  window.dispatchEvent(new CustomEvent("my-custom-event"));
+});
+```
+
+```astro
+<!-- Component that loads on button click -->
+<MyComponent client:on-demand="my-custom-event" />
+```
+
+This directive provides the most efficient way to implement lazy loading for resource-intensive React components in Astro applications.

--- a/src/integrations/client-on-demand/index.d.ts
+++ b/src/integrations/client-on-demand/index.d.ts
@@ -1,0 +1,7 @@
+import "astro";
+
+declare module "astro" {
+  interface AstroClientDirectives {
+    "client:on-demand"?: string;
+  }
+}

--- a/src/integrations/client-on-demand/on-demand.js
+++ b/src/integrations/client-on-demand/on-demand.js
@@ -1,0 +1,66 @@
+/**
+ * Modern timing utility using requestAnimationFrame double-RAF pattern
+ * Ensures execution after the next browser paint cycle
+ */
+const waitForRender = () =>
+  new Promise((resolve) => {
+    requestAnimationFrame(() => {
+      requestAnimationFrame(resolve);
+    });
+  });
+
+/**
+ * Reusable on-demand hydration directive
+ * Supports configurable event names for maximum flexibility
+ * @type {import('astro').ClientDirective}
+ */
+const onDemandDirective = (load, opts, el) => {
+  let hasHydrated = false;
+
+  // Get event name(s) from directive value, data attribute, or default
+  let eventName = "activate";
+
+  if (typeof opts === "string") {
+    eventName = opts;
+  } else if (opts && typeof opts === "object" && opts.value) {
+    eventName = opts.value;
+  } else if (el.dataset.triggerEvent) {
+    eventName = el.dataset.triggerEvent;
+  }
+
+  const events = eventName.split(",").map((e) => e.trim());
+
+  const handleTrigger = async () => {
+    if (!hasHydrated) {
+      hasHydrated = true;
+
+      try {
+        const hydrate = await load();
+        await hydrate();
+
+        // Wait for React to complete its render cycle using modern browser APIs
+        await waitForRender();
+
+        // After hydration and render completion, trigger the primary event
+        window.dispatchEvent(new CustomEvent(events[0]));
+      } catch (error) {
+        console.error(`client:on-demand - Failed to hydrate component:`, error);
+        hasHydrated = false;
+      }
+    }
+  };
+
+  // Listen to all specified events
+  events.forEach((event) => {
+    window.addEventListener(event, handleTrigger);
+  });
+
+  // Cleanup function
+  return () => {
+    events.forEach((event) => {
+      window.removeEventListener(event, handleTrigger);
+    });
+  };
+};
+
+export default onDemandDirective;

--- a/src/integrations/client-on-demand/register.js
+++ b/src/integrations/client-on-demand/register.js
@@ -1,0 +1,16 @@
+/**
+ * @type {() => import('astro').AstroIntegration}
+ */
+const onDemandDirective = () => ({
+  name: "client:on-demand",
+  hooks: {
+    "astro:config:setup": ({ addClientDirective }) => {
+      addClientDirective({
+        name: "on-demand",
+        entrypoint: "./src/integrations/client-on-demand/on-demand.js",
+      });
+    },
+  },
+});
+
+export default onDemandDirective;

--- a/src/starlight-overrides/Head.astro
+++ b/src/starlight-overrides/Head.astro
@@ -4,6 +4,7 @@ import Default from "@astrojs/starlight/components/Head.astro";
 import { Schema } from "astro-seo-schema";
 import { Font } from "astro:assets";
 import TextSizeProvider from "../components/TextSizeProvider.astro";
+import globalCssUrl from "../styles/global.css?url";
 import { SUPPORTED_LANGUAGES } from "~/config/18n";
 import { getImageUrl } from "~/lib/og-image/getImageUrl";
 
@@ -96,7 +97,7 @@ const lastUpdatedDate = lastUpdated ? lastUpdated.toISOString() : new Date().toI
 
 <link rel="preconnect" href="https://api.testnet.staging.aptoslabs.com" />
 <link rel="dns-prefetch" href="https://api.testnet.staging.aptoslabs.com" />
-<link rel="preload" href="/src/styles/global.css" as="style" />
+<link rel="preload" href={globalCssUrl} as="style" />
 
 <Schema
   item={{

--- a/src/starlight-overrides/Head.astro
+++ b/src/starlight-overrides/Head.astro
@@ -94,6 +94,10 @@ const lastUpdatedDate = lastUpdated ? lastUpdated.toISOString() : new Date().toI
 
 <Font cssVariable="--font-atkinson-hyperlegible-next" preload />
 
+<link rel="preconnect" href="https://api.testnet.staging.aptoslabs.com" />
+<link rel="dns-prefetch" href="https://api.testnet.staging.aptoslabs.com" />
+<link rel="preload" href="/src/styles/global.css" as="style" />
+
 <Schema
   item={{
     "@context": "https://schema.org",

--- a/src/starlight-overrides/Hero.astro
+++ b/src/starlight-overrides/Hero.astro
@@ -1,0 +1,140 @@
+---
+import { Image } from "astro:assets";
+import type { ImageMetadata } from "astro";
+import { LinkButton } from "@astrojs/starlight/components";
+
+const { data } = Astro.locals.starlightRoute.entry;
+const { title = data.title, tagline, image, actions = [] } = data.hero || {};
+
+const imageAttrs = {
+  loading: "eager" as const,
+  decoding: "async" as const,
+  width: 400,
+  height: 400,
+  alt: image?.alt || "",
+  fetchpriority: "high" as const,
+};
+
+let darkImage: ImageMetadata | undefined;
+let lightImage: ImageMetadata | undefined;
+let rawHtml: string | undefined;
+if (image) {
+  if ("file" in image) {
+    darkImage = image.file;
+  } else if ("dark" in image) {
+    darkImage = image.dark;
+    lightImage = image.light;
+  } else {
+    rawHtml = image.html;
+  }
+}
+---
+
+<div class="hero">
+  {
+    darkImage && (
+      <Image src={darkImage} {...imageAttrs} class={lightImage ? "light:sl-hidden" : undefined} />
+    )
+  }
+  {lightImage && <Image src={lightImage} {...imageAttrs} class="dark:sl-hidden" />}
+  {rawHtml && <div class="hero-html sl-flex" set:html={rawHtml} />}
+  <div class="sl-flex stack">
+    <div class="sl-flex copy">
+      <h1 id="_top" data-page-title set:html={title} />
+      {tagline && <div class="tagline" set:html={tagline} />}
+    </div>
+    {
+      actions.length > 0 && (
+        <div class="sl-flex actions">
+          {actions.map(
+            ({ attrs: { class: className, ...attrs } = {}, icon, link: href, text, variant }) => (
+              <LinkButton {href} {variant} icon={icon?.name} class:list={[className]} {...attrs}>
+                {text}
+                {icon?.html && <Fragment set:html={icon.html} />}
+              </LinkButton>
+            ),
+          )}
+        </div>
+      )
+    }
+  </div>
+</div>
+
+<style>
+  @layer starlight.core {
+    .hero {
+      display: grid;
+      align-items: center;
+      gap: 1rem;
+      padding-bottom: 1rem;
+    }
+
+    .hero > img,
+    .hero > .hero-html {
+      object-fit: contain;
+      width: min(70%, 20rem);
+      height: auto;
+      margin-inline: auto;
+    }
+
+    .stack {
+      flex-direction: column;
+      gap: clamp(1.5rem, calc(1.5rem + 1vw), 2rem);
+      text-align: center;
+    }
+
+    .copy {
+      flex-direction: column;
+      gap: 1rem;
+      align-items: center;
+    }
+
+    .copy > * {
+      max-width: 50ch;
+    }
+
+    h1 {
+      font-size: clamp(var(--sl-text-3xl), calc(0.25rem + 5vw), var(--sl-text-6xl));
+      line-height: var(--sl-line-height-headings);
+      font-weight: 600;
+      color: var(--sl-color-white);
+    }
+
+    .tagline {
+      font-size: clamp(var(--sl-text-base), calc(0.0625rem + 2vw), var(--sl-text-xl));
+      color: var(--sl-color-gray-2);
+    }
+
+    .actions {
+      gap: 1rem 2rem;
+      flex-wrap: wrap;
+      justify-content: center;
+    }
+
+    @media (min-width: 50rem) {
+      .hero {
+        grid-template-columns: 7fr 4fr;
+        gap: 3%;
+        padding-block: clamp(2.5rem, calc(1rem + 10vmin), 10rem);
+      }
+
+      .hero > img,
+      .hero > .hero-html {
+        order: 2;
+        width: min(100%, 25rem);
+      }
+
+      .stack {
+        text-align: start;
+      }
+
+      .copy {
+        align-items: flex-start;
+      }
+
+      .actions {
+        justify-content: flex-start;
+      }
+    }
+  }
+</style>


### PR DESCRIPTION
## Problem
The ChatWidget was loading scripts automatically on page load, negatively impacting Google PageSpeed scores. Additionally optimized resource loading within the `<head>`.

## Solution
- Created custom `client:on-demand` directive that loads React components only when specific events are triggered
- Implemented configurable event names for maximum reusability across different components
- Used modern `requestAnimationFrame` double-RAF pattern for optimal timing
- Fixed CSS preload path by properly importing global.css with ?url parameter
- Override Hero component to set `fetchpriority="high"` on image


## Benefits
- Improved PageSpeed scores by eliminating unnecessary JavaScript on initial page load (hydrates upon interaction): `29 requests + 601 kB transferred / 1.9 MB resources`
↓
`23 requests + 276 kB transferred / 909 kB resources`
- Reusable directive for any React component with custom trigger events



# Before 

### (mobile)
<img width="938" height="799" alt="image" src="https://github.com/user-attachments/assets/aac2c30c-5b08-4a8d-851f-addac6349691" />

### (desktop)
<img width="886" height="791" alt="image" src="https://github.com/user-attachments/assets/8864d194-c03b-4bf6-9879-65252bae05fd" />


# After

### (mobile)
<img width="892" height="799" alt="image" src="https://github.com/user-attachments/assets/425d172a-c388-4e75-b24f-6a70925210e8" />

### (desktop)
<img width="886" height="790" alt="image" src="https://github.com/user-attachments/assets/08aafee2-e73b-48c4-bd69-d916b866df44" />
