### PR TITLE
fix(layout): Set max width on content to prevent overflow

### DIFF
--- a/src/starlight-overrides/PageFrame.astro
+++ b/src/starlight-overrides/PageFrame.astro
@@ -87,6 +87,7 @@ const { hasSidebar } = Astro.locals.starlightRoute;
       padding-top: calc(var(--sl-nav-height) + var(--sl-mobile-toc-height));
       /* padding-inline-start: var(--sl-content-inline-start); */
       flex-grow: 1;
+      max-width: 100%;
     }
 
     @media (min-width: 50rem) {


### PR DESCRIPTION
Content was overflowing on mobile forcing horizontal scrollbar.

### Before

<img width="594" height="1038" alt="image" src="https://github.com/user-attachments/assets/7c03a163-9875-48d9-bc9b-1cb832164807" />

### After

<img width="556" height="1023" alt="image" src="https://github.com/user-attachments/assets/b96ae47c-5ac7-4be4-8749-4e06e91b2be6" />
