### PR TITLE
fix(ui): Correct sidebar height calculation on mobile devices

### DIFF
--- a/src/starlight-overrides/PageFrame.astro
+++ b/src/starlight-overrides/PageFrame.astro
@@ -55,13 +55,13 @@ const { hasSidebar } = Astro.locals.starlightRoute;
     .sidebar-pane {
       visibility: var(--sl-sidebar-visibility, hidden);
       position: fixed;
-      height: 100vh;
+      height: calc(100dvh - var(--sl-nav-height));
       z-index: var(--sl-z-index-menu);
-      inset-block: var(--sl-nav-height) 0;
       inset-inline-start: 0;
       width: 100%;
       background-color: var(--sl-color-black);
       overflow-y: auto;
+      top: var(--sl-nav-height);
     }
 
     :global([aria-expanded="true"]) ~ .sidebar-pane {


### PR DESCRIPTION
## Problem
Mobile sidebar was extending beyond viewport due to conflicting height and positioning styles (`height: 100vh` + `inset-block: var(--sl-nav-height) 0`).

## Solution
- Replace `height: 100vh` with `height: calc(100dvh - var(--sl-nav-height))`
- Use modern `dvh` units for better mobile viewport handling
- Remove `inset-block` positioning

## Result
Sidebar content is now fully visible on mobile.


### Before
<img width="471" height="1006" alt="image" src="https://github.com/user-attachments/assets/3dc2e2a6-8a99-42b6-abab-ca2ee612ab7f" />


### After
<img width="471" height="1006" alt="image" src="https://github.com/user-attachments/assets/65024104-9bbc-476f-b588-fd6c28a68eb0" />

