### PR TITLE
fix(analytics): Resolve missing analytics component within template

### DIFF
--- a/src/starlight-overrides/PageFrame.astro
+++ b/src/starlight-overrides/PageFrame.astro
@@ -1,5 +1,7 @@
 ---
 import MobileMenuToggle from "virtual:starlight/components/MobileMenuToggle";
+import Analytics from "@components/Analytics.astro";
+import SpanishBetaBanner from "@components/SpanishBetaBanner.astro";
 
 const { hasSidebar } = Astro.locals.starlightRoute;
 ---
@@ -18,13 +20,15 @@ const { hasSidebar } = Astro.locals.starlightRoute;
       </nav>
     )
   }
-  <div class="main-frame"><slot /></div>
+  <div class="main-frame"><SpanishBetaBanner /><slot /></div>
 </div>
 <footer class="global-footer">
   © {new Date().getFullYear()} Aptos Foundation
   <a href="https://aptosfoundation.org/privacy" target="_blank">Privacy</a>
   <a href="https://aptosfoundation.org/terms" target="_blank">Terms</a>
 </footer>
+
+<Analytics />
 
 <style>
   @layer starlight.core {


### PR DESCRIPTION
# Problem
Analytics and Spanish Beta Banner were missing due to recent template overrides.

# Solution
Restores `<Analytics>` and `<SpanishBetaBanner>` components