### PR TITLE
fix(csp): allow StackBlitz framing and add Google Fonts support

### DIFF
--- a/src/config/csp.ts
+++ b/src/config/csp.ts
@@ -28,6 +28,8 @@ const FIREBASE_HOSTS = withHttps("aptos-api-gateway-prod.firebaseapp.com");
 const VIDEO_HOSTS = withHttps(["player.vimeo.com", "www.youtube.com"]);
 const CDN_HOSTS = withHttps("cdn.jsdelivr.net");
 const PUSHER_HOSTS = "wss://ws-us3.pusher.com"; // WebSocket, no schema needed
+const STACKBLITZ_HOST = withHttps("stackblitz.com");
+const GOOGLE_FONTS_HOSTS = withHttps(["fonts.googleapis.com", "fonts.gstatic.com"]);
 
 /**
  * Content Security Policy configuration for Astro
@@ -36,14 +38,14 @@ export const cspConfig = {
   directives: [
     "default-src 'self'",
     `img-src 'self' ${TWITTER_HOSTS} ${GOOGLE_HOSTS} ${GTM_HOST} ${GA_HOSTS} ${VERCEL_HOSTS} data: blob:`,
-    `font-src 'self' ${VERCEL_HOSTS} data:`,
+    `font-src 'self' ${VERCEL_HOSTS} ${GOOGLE_FONTS_HOSTS} data:`,
     "worker-src 'self'",
     `connect-src 'self' ${APTOS_HOSTS} ${ALGOLIA_HOSTS} ${GOOGLE_HOSTS} ${GTM_HOST} ${GA_HOSTS} ${VERCEL_HOSTS} ${PUSHER_HOSTS} ${VERCEL_ANALYTICS_HOSTS}`,
-    `frame-src 'self' ${FIREBASE_HOSTS} ${VERCEL_HOSTS} ${VIDEO_HOSTS}`,
+    `frame-src 'self' ${FIREBASE_HOSTS} ${VERCEL_HOSTS} ${VIDEO_HOSTS} ${STACKBLITZ_HOST}`,
     `media-src 'self' ${TWITTER_HOSTS}`,
     "style-src-attr 'unsafe-inline'",
     `script-src-elem 'self' 'unsafe-inline' ${CDN_HOSTS} ${GOOGLE_HOSTS} ${GTM_HOST} ${VERCEL_HOSTS}`,
-    `style-src-elem 'self' 'unsafe-inline' ${VERCEL_HOSTS}`,
+    `style-src-elem 'self' 'unsafe-inline' ${VERCEL_HOSTS} ${GOOGLE_FONTS_HOSTS}`,
   ] as CspDirective[],
   styleDirective: {
     resources: ["'self'", VERCEL_HOSTS, "'unsafe-inline'"],


### PR DESCRIPTION
- Add stackblitz.com to `frame-src` directive to fix CSP violation
- Add `fonts.googleapis.com` and `fonts.gstatic.com` to `font-src` directive