### PR TITLE
Fix variable font mapping for Atkinson Hyperlegible Next in Chrome

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -330,17 +330,17 @@ export default defineConfig({
         cssVariable: "--font-atkinson-hyperlegible-next",
         variants: [
           {
-            weight: "100 900",
+            weight: "200 800",
             style: "normal",
             src: ["./src/assets/fonts/AtkinsonHyperlegibleNext-VariableFont_wght.woff2"],
-            variationSettings: "'wght' 400",
+            variationSettings: "normal",
             display: "swap",
           },
           {
-            weight: "100 900",
+            weight: "200 800",
             style: "italic",
             src: ["./src/assets/fonts/AtkinsonHyperlegibleNext-Italic-VariableFont_wght.woff2"],
-            variationSettings: "'wght' 400",
+            variationSettings: "normal",
             display: "swap",
           },
         ],


### PR DESCRIPTION
### Overview

After a recent Chrome update, `font-weight` values stopped affecting Atkinson Hyperlegible Next. Root cause: our Astro font config pinned the variable `wght` axis to 400 via `variationSettings`, and also declared an out-of-range weight span.

Chrome now follows the spec more strictly, so explicit `font-variation-settings` wins over `font-weight` - which was leading to `font-weight` not applying globally.

### Changes:

- Set weight to the real axis range: "200 800" (was "100 900").
- Replaced variationSettings: "'wght' 400" with "normal" so the axis is driven by CSS font-weight.
- Applied to both normal and italic variable variants.

### Before:
<img width="1672" height="1169" alt="image" src="https://github.com/user-attachments/assets/2b028bc6-0646-4f79-a24b-4fb12b6a1d16" />


### After:
<img width="1672" height="1169" alt="image" src="https://github.com/user-attachments/assets/e9d60fae-8361-4035-8028-9415b7ef8f8f" />
