### PR TITLE
add vscode extension link to the landing

### DIFF
--- a/src/content/docs/index.mdx
+++ b/src/content/docs/index.mdx
@@ -38,6 +38,7 @@ import ListCard from '~/components/ListCard.astro';
 
   <ListCard title="Tooling" iconName="terminal">
     - [Aptos CLI](/build/cli)
+    - [VSCode Extension](/build/smart-contracts/move-vscode-extension)
     - [Indexer API](/build/indexer/indexer-api)
     - [Official SDKs](/build/sdks)
     - [Testnet Faucet](/network/faucet)


### PR DESCRIPTION
Adds a link to the VSCode extension docs to the docs landing page
<img width="302" height="208" alt="image" src="https://github.com/user-attachments/assets/11683391-3778-4427-b8de-79ce2ffe6c90" />
