### PR TITLE
feat(images): Implement starlight-image-zoom

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -19,6 +19,7 @@ import react from "@astrojs/react";
 import starlightLlmsTxt from "starlight-llms-txt";
 import favicons from "astro-favicons";
 import icon from "astro-icon";
+import starlightImageZoom from "starlight-image-zoom";
 import { sidebar } from "./astro.sidebar.ts";
 import { ENV } from "./src/lib/env";
 import { ogImagesIntegration } from "./src/integrations/ogImages";
@@ -128,6 +129,7 @@ export default defineConfig({
         TwoColumnContent: "./src/starlight-overrides/TwoColumnContent.astro",
       },
       plugins: [
+        starlightImageZoom(),
         starlightLinksValidator({
           errorOnFallbackPages: false,
           errorOnInconsistentLocale: true,

--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "react-dom": "^19.1.0",
     "react-markdown": "^10.1.0",
     "react-syntax-highlighter": "^15.6.1",
+    "starlight-image-zoom": "^0.13.0",
     "starlight-links-validator": "^0.17.2",
     "tailwindcss": "^4.1.11"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -125,6 +125,9 @@ importers:
       react-syntax-highlighter:
         specifier: ^15.6.1
         version: 15.6.1(react@19.1.0)
+      starlight-image-zoom:
+        specifier: ^0.13.0
+        version: 0.13.0(@astrojs/starlight@0.35.3(astro@5.13.7(patch_hash=2ca2f7001eeda6def10073a7e027fbe45196b762d139fb275c585006fd222b2c)(@types/node@24.4.0)(@vercel/functions@2.2.12)(jiti@2.4.2)(lightningcss@1.30.1)(rollup@4.50.1)(tsx@4.20.3)(typescript@5.9.2)(yaml@2.8.0)))
       starlight-links-validator:
         specifier: ^0.17.2
         version: 0.17.2(@astrojs/starlight@0.35.3(astro@5.13.7(patch_hash=2ca2f7001eeda6def10073a7e027fbe45196b762d139fb275c585006fd222b2c)(@types/node@24.4.0)(@vercel/functions@2.2.12)(jiti@2.4.2)(lightningcss@1.30.1)(rollup@4.50.1)(tsx@4.20.3)(typescript@5.9.2)(yaml@2.8.0)))
@@ -7097,6 +7100,12 @@ packages:
   stable-hash-x@0.2.0:
     resolution: {integrity: sha512-o3yWv49B/o4QZk5ZcsALc6t0+eCelPc44zZsLtCQnZPDwFpDYSWcDnrv2TtMmMbQ7uKo3J0HTURCqckw23czNQ==}
     engines: {node: '>=12.0.0'}
+
+  starlight-image-zoom@0.13.0:
+    resolution: {integrity: sha512-7K/7gshnKooYd4ePy5vtyv1jFoFVNUb8IoXWDcnY69+nxvmLATNrmOzD2M4TJ/aKynPSBSM6j9ia4s/PPy/JGA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@astrojs/starlight': '>=0.32.0'
 
   starlight-links-validator@0.17.2:
     resolution: {integrity: sha512-d2SRWu04HPiUzrzntuv/uzuXnIu4reJwzX1c+7uvcnqOCuzgpv+tmlUC+dp3VYpmfxQy8RX+xcWtfcEkx905VA==}
@@ -16596,6 +16605,16 @@ snapshots:
   sprintf-js@1.0.3: {}
 
   stable-hash-x@0.2.0: {}
+
+  starlight-image-zoom@0.13.0(@astrojs/starlight@0.35.3(astro@5.13.7(patch_hash=2ca2f7001eeda6def10073a7e027fbe45196b762d139fb275c585006fd222b2c)(@types/node@24.4.0)(@vercel/functions@2.2.12)(jiti@2.4.2)(lightningcss@1.30.1)(rollup@4.50.1)(tsx@4.20.3)(typescript@5.9.2)(yaml@2.8.0))):
+    dependencies:
+      '@astrojs/starlight': 0.35.3(astro@5.13.7(patch_hash=2ca2f7001eeda6def10073a7e027fbe45196b762d139fb275c585006fd222b2c)(@types/node@24.4.0)(@vercel/functions@2.2.12)(jiti@2.4.2)(lightningcss@1.30.1)(rollup@4.50.1)(tsx@4.20.3)(typescript@5.9.2)(yaml@2.8.0))
+      mdast-util-mdx-jsx: 3.2.0
+      rehype-raw: 7.0.0
+      unist-util-visit: 5.0.0
+      unist-util-visit-parents: 6.0.1
+    transitivePeerDependencies:
+      - supports-color
 
   starlight-links-validator@0.17.2(@astrojs/starlight@0.35.3(astro@5.13.7(patch_hash=2ca2f7001eeda6def10073a7e027fbe45196b762d139fb275c585006fd222b2c)(@types/node@24.4.0)(@vercel/functions@2.2.12)(jiti@2.4.2)(lightningcss@1.30.1)(rollup@4.50.1)(tsx@4.20.3)(typescript@5.9.2)(yaml@2.8.0))):
     dependencies:


### PR DESCRIPTION
### Overview

Adds [starlight-image-zoom](https://starlight-image-zoom.vercel.app/)

> A [Starlight](https://starlight.astro.build/) plugin adding zoom capabilities to your documentation images.
> 
> Lightweight UI based on the [<dialog>](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/dialog) element
> No client-side third-party dependencies
> Markdown and MDX images support: Markdown syntax, HTML syntax, and the <Image> or <Picture> components
> Alternate text displayed as a caption
> Accessible buttons to trigger zoom