### PR TITLE
add snarkjs-to-aptos Groth16 tool

### DIFF
--- a/src/content/docs/build/smart-contracts/cryptography.mdx
+++ b/src/content/docs/build/smart-contracts/cryptography.mdx
@@ -224,6 +224,8 @@ An important caveat is that veiled transactions do **not** hide the identities o
 The [`groth16` example](https://github.com/aptos-labs/aptos-core/blob/main/aptos-move/move-examples/groth16_example/sources/groth16.move) demonstrates how to verify Groth16 zkSNARK proofs\[^groth16], which are the shortest, fastest-to-verify, general-purpose zero-knowledge proofs.
 Importantly, as explained [above](#generic-elliptic-curve-arithmetic), this implementation is _generic_ over **any** curve, making it very easy for Move developers to use it with their favorite (supported) curves.
 
+If you need help converting your `snarkjs` Groth16 VK, proof and public inputs to the expected format for the Move verifier above, you can use [this community tool](https://github.com/zjma/snarkjs-to-aptos).
+
 <Aside type="note">
   This code has not been audited by a third-party organization. If using it in a production system, proceed at your own risk.
 </Aside>


### PR DESCRIPTION
Points readers to a tool written by @zjma for converting between `snarkjs` formats and the format expected in the Groth16 verifier example.