### PR TITLE
[aptos docs] update comparison operations

### DIFF
--- a/astro.sidebar.ts
+++ b/astro.sidebar.ts
@@ -434,6 +434,7 @@ export const sidebar = [
           "build/smart-contracts/book/tuples",
           "build/smart-contracts/book/abilities",
           "build/smart-contracts/book/equality",
+          "build/smart-contracts/book/comparison",
           "build/smart-contracts/book/abort-and-assert",
           "build/smart-contracts/book/conditionals",
           "build/smart-contracts/book/loops",

--- a/src/content/docs/build/smart-contracts/book/comparison.mdx
+++ b/src/content/docs/build/smart-contracts/book/comparison.mdx
@@ -1,0 +1,142 @@
+---
+title: "Comparison"
+description: "Understand comparison operations and their semantics in Move programming language."
+sidebar:
+  label: "Comparison"
+---
+
+Move supports four comparison operations `<`, `>`, `<=`, and `>=`.
+
+## Operations
+
+| Syntax | Operation                |
+| ------ | ------------------------ |
+| `<`    | less than                |
+| `>`    | greater than             |
+| `<=`   | less than or equal to    |
+| `>=`   | greater than or equal to |
+
+### Typing
+
+Comparison operations only work if both operands have the same type.
+
+```move
+script {
+  fun example() {
+    0 >= 0; // `true`
+    1u128 > 2u128; // `false`
+  }
+}
+```
+
+If the operands have different types, there is a type checking error.
+
+```move
+script {
+  fun example() {
+    1u8 >= 1u128; // ERROR!
+    //     ^^^^^ expected an argument of type `u8`
+  }
+}
+```
+
+Prior to language version 2.2, comparison operations only work with integer types. *Since language 
+version 2.2*, comparison operations work with all types.
+
+| Type             | Semantics                                                                                                   |
+| ---------------- | ----------------------------------------------------------------------------------------------------------- |
+| integer          | compare by the numerical value                                                                              |
+| `bool`           | `true` being larger than `false`                                                                                  |
+| `address`        | compare as 256-bit unsigned integers                                                                        |
+| `signer`         | compare by the `address` wrapped by the `signer`                                                            |
+| `struct`         | compare by field values first, and then by the number of fields.                                            |
+| `vector`         | compare by element values first, and then by the number of elements                                         |
+| function value   | compare in order by module address, module name, function name, argument type list, and captured value list |
+| reference        | compare by the value being referenced |
+
+```move
+module 0x42::example {
+    struct S has copy, drop { f: u64, s: vector<u8> }
+
+    fun true_example(): bool {
+        let s1 = S { f: 0, s: b"" };
+        let s2 = S { f: 1, s: b"" };
+        // return true
+        s1 < s2
+    }
+
+    fun false_example(): bool {
+        let s1 = S { f: 0, s: b"abc" };
+        let s2 = S { f: 0, s: b"" };
+        // return false
+        s1 < s2
+    }
+}
+```
+
+### Typing with references
+
+When comparing [references](/build/smart-contracts/book/references), the values being referenced are compared. The type of the reference (immutable or mutable) does
+not matter. This means that you can compare an immutable `&` reference with a mutable one `&mut` of
+the same underlying type.
+
+```move
+script {
+  fun example() {
+    let i = &0u64;
+    let m = &mut 1u64;
+
+    i > m; // `false`
+    m < i; // `false`
+    m >= m; // `true`
+    i <= i; // `true`
+  }
+}
+```
+
+The above is equivalent to applying an explicit freeze to each mutable reference where needed
+
+```move
+script {
+  fun example() {
+    let i = &0u64;
+    let m = &mut 1u64;
+
+    i > freeze(m); // `false`
+    freeze(m) < i; // `false`
+    m >= m; // `true`
+    i <= i; // `true`
+  }
+}
+```
+
+But again, the underlying type must be the same.
+
+```move
+script {
+  fun example() {
+    let i = &0u64;
+    let s = &b"";
+
+    i > s; // ERROR!
+    //   ^ expected an argument of type '&u64'
+  }
+}
+```
+
+## Comparing to `==` and `!=`
+
+Comparison operations consume operands for integers but automatically borrow them for non-integer types. 
+This differs from the [equality `==` and inequality `!=`](/build/smart-contracts/book/equality#restrictions) operations, which always consume their operands 
+and mandate the [`drop` ability](/build/smart-contracts/book/abilities).
+
+```move
+module 0x42::example {
+  struct Coin has store { value: u64 }
+  fun invalid(c1: Coin, c2: Coin) {
+    c1 <= c2 // OK!
+    c1 == c2 // ERROR!
+//  ^^    ^^ These resources would be destroyed!
+  }
+}
+```

--- a/src/content/docs/build/smart-contracts/book/integers.mdx
+++ b/src/content/docs/build/smart-contracts/book/integers.mdx
@@ -129,7 +129,7 @@ Bit shifts abort if the number of bits to shift by is greater than or equal to `
 
 ### Comparisons
 
-Integer types can use the comparison operators. Both arguments need to be of the same type. If you need to compare integers of different types, you will need to [cast](#casting) one of them first.
+All integer types support the ["comparison"](/build/smart-contracts/book/comparison) operations. Both arguments need to be of the same type. If you need to compare integers of different types, you will need to [cast](#casting) one of them first.
 
 Comparison operations do not abort.
 

--- a/src/content/docs/build/smart-contracts/book/move-2.mdx
+++ b/src/content/docs/build/smart-contracts/book/move-2.mdx
@@ -20,6 +20,7 @@ The Move 2.2 language release adds the following features to Move:
 
 - **Optional Acquires**: The `acquires` annotation on function declarations can be omitted, to be inferred by the compiler.
 - **Function Values**: Move now supports function values, which can be passed around as parameters and stored in resources. See the [reference doc here](/build/smart-contracts/book/functions#function-values).
+- **Comparison Operations**: Move now supports comparison operations (`<`, `>`, `<=`, `>=`) on all types. See the [reference doc here](/build/smart-contracts/book/comparison#typing).
 
 ## Move 2.1
 


### PR DESCRIPTION
This PR documents the updates to comparison operations (`<`, `>`, `<=`, `>=`) we introduced into language version 2.2. 
- It adds a new page for `Comparison` with operational specifics
- It updates `astro.sidebar.ts` to add the new page into index
- It updates `Move V2` page to introduce the new feature.