### PR TITLE
[move book] update language version gate for `__COMPILE_FOR_TESTING__`

### DIFF
--- a/src/content/docs/build/smart-contracts/book/constants.mdx
+++ b/src/content/docs/build/smart-contracts/book/constants.mdx
@@ -121,9 +121,15 @@ other expressions, will be added in the future.
 
 ## Builtin Constants
 
-*Since language version 2.3*
-
 Builtin constants are predefined named values which can be used from anywhere in the code. The following constants are supported:
+
+*since language version 2.2*
+
+| Name                            | Value                                                |
+|---------------------------------|------------------------------------------------------|
+| `__COMPILE_FOR_TESTING__: bool` | `true` when compiling unit tests, `false`  otherwise |
+
+*since language version 2.3*
 
 | Name                            | Value                                                |
 |---------------------------------|------------------------------------------------------|
@@ -145,7 +151,6 @@ Builtin constants are predefined named values which can be used from anywhere in
 | `MIN_I64: i64`                  | -2<sup>63</sup>                                      |
 | `MIN_I128: i128`                | -2<sup>127</sup>                                     |
 | `MIN_I256: i256`                | -2<sup>255</sup>                                     |
-| `__COMPILE_FOR_TESTING__: bool` | `true` when compiling unit tests, `false`  otherwise |
 
 A builtin constant can be shadowed by a user declaration. For example, the below code is valid in language version 2.3, and the builtin constant will simply be shadowed:
 


### PR DESCRIPTION
This PR update the language version we used to gate built-in constant `__COMPILE_FOR_TESTING__`.