### PR TITLE
Fix txn stream service diagram

### DIFF
--- a/src/content/docs/build/indexer/indexer-api/architecture.mdx
+++ b/src/content/docs/build/indexer/indexer-api/architecture.mdx
@@ -47,6 +47,6 @@ You can use the below diagram for a much more in-depth diagram explaining how th
 
 <div style={{textAlign:"center"}}>
   <div style={{marginBottom: 20}}>
-    <iframe style={{border: "1px solid rgba(0, 0, 0, 0.1);"}} width="100%" height="750" src="https://www.figma.com/embed?embed_host=share&url=https%3A%2F%2Fwww.figma.com%2Ffile%2FsVhSOGR7ZT4CdeUzlXyduD%2FIndexer-Overview%3Ftype%3Dwhiteboard%26node-id%3D0%253A1%26t%3DUnUKeEaBE7ETMksb-1" allowfullscreen />
+    <iframe style={{border: "1px solid rgba(0, 0, 0, 0.1)", width: "100%", height: "750px"}} src="https://embed.figma.com/board/sVhSOGR7ZT4CdeUzlXyduD/Detailed-Overview?node-id=18675-303&embed-host=share" allowfullscreen />
   </div>
 </div>


### PR DESCRIPTION
It wasn't loading, and it was also showing grpc v1. I made a new diagram for v2, but you can also select v1 as an option in the embed.

<img width="992" height="1375" alt="image" src="https://github.com/user-attachments/assets/f668e4c8-230e-432d-964d-6d675bba1f4e" />
