### PR TITLE
[i18n] Add Chinese translation for External Resources page

### DIFF
--- a/src/content/docs/build/external-resources.mdx
+++ b/src/content/docs/build/external-resources.mdx
@@ -5,8 +5,6 @@ sidebar:
   label: "External Resources"
 ---
 
-# External Resources
-
 import {Aside} from '@astrojs/starlight/components';
 
 <Aside type="note">

--- a/src/content/docs/zh/build/external-resources.mdx
+++ b/src/content/docs/zh/build/external-resources.mdx
@@ -1,0 +1,35 @@
+---
+title: "External Resources"
+description: "了解更多关于 Aptos 区块链的外部资源列表"
+sidebar:
+  label: "External Resources"
+---
+
+import {Aside} from '@astrojs/starlight/components';
+
+<Aside type="note">
+  并非所有这些资源都由 Aptos 核心团队维护。
+</Aside>
+
+## Move Learning Resources
+
+### Tutorials
+
+- [Aptos Learn](https://learn.aptoslabs.com) - 通过各种教程学习如何在 Aptos 区块链上构建。
+
+### Videos
+
+- [Aptos Dev YouTube Channel](https://www.youtube.com/@aptosdev) — 通过各种视频了解如何在 Aptos 区块链上构建。
+
+### Examples
+
+- [Move By Examples](https://github.com/aptos-labs/move-by-examples) — Move 示例集合。
+- [Daily Move](https://github.com/aptos-labs/daily-move) — 展示 Aptos 功能的简短 Move 示例集合。
+- [Aptos-Core Move Examples](https://github.com/aptos-labs/aptos-core/tree/main/aptos-move/move-examples) — 在 Aptos Core 仓库的 CI 中积极测试的 Move 示例集合。
+
+## External Tools
+
+### Developer Tools
+
+- [Surf](https://github.com/ThalaLabs/surf) — 为 Aptos 智能合约生成的 TypeScript 接口和 React hooks。
+


### PR DESCRIPTION
## Summary
Adds Chinese translation for the External Resources page (`/zh/build/external-resources`).

## Changes
- Created `src/content/docs/zh/build/external-resources.mdx` with Chinese translation
- All headings remain in English (title, sidebar label, section headings)
- Content descriptions and list items are translated to Chinese