### PR TITLE
[aptos docs] remove docs of unmerged linters

### DIFF
--- a/src/content/docs/build/smart-contracts/linter.mdx
+++ b/src/content/docs/build/smart-contracts/linter.mdx
@@ -16,7 +16,7 @@ If you find any issues, please submit [bugs and feedback](https://github.com/apt
 
 ### `aborting_overflow_checks`
 
-Checks for patterns that look like overflow checks done in a C style:
+Checks for patterns that resemble overflow checks done in C code:
 
 ```move
 // Overflow check
@@ -30,7 +30,7 @@ if (x < x - y) {
 };
 ```
 
-This pattern in Move does not make sense, as it either aborts immediately or is always true/false.
+Such checks in Move do not make sense, as they either abort immediately or always return true/false.
 
 ### `almost_swapped`
 
@@ -41,7 +41,7 @@ Checks for expression patterns that look like a failed swap attempt and notifies
 
 ### `assert_const`
 
-Checks for trivial assertions, i.e. `assert!(false)` and `assert!(true)`. The latter is equivalent to a no-op, so can be removed entirely, while the former can be replaced by an abort.
+Checks for trivial assertions, including `assert!(true)` and `assert!(false)`. The former can be replaced by an abort, while the latter is equivalent to a no-op, which can be removed entirely.
 
 ### `avoid_copy_on_identity_comparison`
 
@@ -67,7 +67,7 @@ Note that an `assert!` is translated to a conditional abort, so blocks in `asser
 
 ### `empty_if`
 
-Checks for `if` statements that have no body, which is likely a mistake. For example:
+Checks for `if` statements that have no body, such as:
 
 ```move
 if (x) {
@@ -76,17 +76,15 @@ if (x) {
 
 ### `equal_operands_in_bin_op`
 
-Checks for binary operations where both operands are the same, which is likely a mistake. For example `x % x`, `x ^ x`,  `x > x`, `x >= x`, `x == x`, `x | x`, `x & x`, `x / x`, and `x != x` are all caught by this lint. The lint suggests replacing these with a more appropriate value or expression, such as `0`, `true`, or `false`.
-
-This lint does not catch cases where the operands are vector access.
+Checks for binary operations with identical operands. For example, `x % x`, `x ^ x`,  `x > x`, `x >= x`, `x == x`, `x | x`, `x & x`, `x / x`, and `x != x` are all caught by this lint. The lint also suggests replacing these with a simplified value or expression, such as `0`, `true`, or `false`.
 
 ### `empty_range`
 
 Checks for empty ranges in `for` loops, such as `for i in 0..0 { ... }`, which do not execute the loop body. This can happen when the start of the range is greater than or equal to the end of the range, resulting in an empty iteration.
 
-### `find_unnecessary_casts`
+### `unnecessary_cast`
 
-Checks for unnecessary type casts where the source expression already has the same type as the target type. These casts are redundant and can be removed to improve code readability.
+Checks for unnecessary type casts where the source expression already has the target type. These casts are redundant and can be removed to improve code readability.
 
 For example:
 
@@ -95,7 +93,7 @@ let x: u64 = 42;
 let y = x as u64; // unnecessary cast, x is already u64
 ```
 
-The above can be simplified to:
+can be simplified to:
 
 ```move
 let x: u64 = 42;
@@ -104,11 +102,11 @@ let y = x; // cast removed
 
 ### `known_to_abort`
 
-Checks for expressions that will always abort at runtime due to known constant values that violate runtime constraints. This lint helps identify code that will deterministically fail before it reaches production.
+Checks for expressions where the use of constant values will violate runtime constraints and abort the execution.
 
-The following cases are detected:
+Specifically, the following patterns are detected:
 
-- **Bit shifts with excessive shift amounts**: `x << n` or `x >> n` where `n` is a constant that is greater than or equal to the bit width of `x`'s type. For example, `value << 64` when `value` is of type `u64` will always abort.
+- **Bit shifts with excessive shift amounts**: `x << n` or `x >> n` where `n` is a constant that is greater than or equal to the bit width of `x`'s type. For example, `value << 64`, when `value` has type `u64`, will always abort.
 - **Division or modulo by zero**: `x / 0` or `x % 0` operations will always abort at runtime.
 - **Out-of-range type casting**: `constant as type` where the `constant` value is outside the representable range of the target `type`. For example, `300 as u8` will abort since `u8` can only represent values 0-255.
 
@@ -184,7 +182,7 @@ Checks for patterns where there are needless references taken when accessing a f
 
 ### `needless_return`
 
-Checks for unnecessary `return` statements in functions that can be simplified. This lint identifies cases where a `return` statement is used to return a value that can be directly returned without the `return` keyword.
+Checks for unnecessary `return` statements. This lint detects unnecessary return statements where the value can be returned directly without using the `return` keyword.
 For example, the following function:
 
 ```move
@@ -194,7 +192,7 @@ public fun foo(): bool {
 }
 ```
 
-This pattern can be simplified to:
+can be simplified to:
 
 ```move
 public fun foo(): bool {
@@ -277,7 +275,7 @@ Checks for boolean patterns that can be simplified through different boolean alg
   - `(a && b) || (a && c)` can be simplified to `a && (b || c)`
   - `(a || b) && (a || c)` can be simplified to `a || (b && c)`
 
-Where `a`, `b` and `c` can either be simple or composed expressions.
+where `a`, `b` and `c` can either be simple or composed expressions.
 
 ### `simpler_numeric_expression`
 


### PR DESCRIPTION
A few community-contributed linters have been documented but their implementations haven't landed and may not land eventually. This PR removes those linters from aptos docs. 