### PR TITLE
Security issues audit

### DIFF
--- a/package.json
+++ b/package.json
@@ -156,7 +156,8 @@
       "tar": ">=7.5.2",
       "js-yaml": ">=4.1.1",
       "mdast-util-to-hast": ">=13.2.1",
-      "sharp": ">=0.34.0"
+      "sharp": ">=0.34.0",
+      "preact": ">=10.28.2"
     }
   },
   "simple-git-hooks": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,6 +18,7 @@ overrides:
   js-yaml: '>=4.1.1'
   mdast-util-to-hast: '>=13.2.1'
   sharp: '>=0.34.0'
+  preact: '>=10.28.2'
 
 patchedDependencies:
   '@astrojs/vercel':
@@ -6336,8 +6337,8 @@ packages:
     resolution: {integrity: sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==}
     engines: {node: ^10 || ^12 || >=14}
 
-  preact@10.28.1:
-    resolution: {integrity: sha512-u1/ixq/lVQI0CakKNvLDEcW5zfCjUQfZdK9qqWuIJtsezuyG6pk9TWj75GMuI/EzRSZB/VAE43sNWWZfiy8psw==}
+  preact@10.28.2:
+    resolution: {integrity: sha512-lbteaWGzGHdlIuiJ0l2Jq454m6kcpI1zNje6d8MlGAFlYvP2GO4ibnat7P74Esfz4sPTdM6UxtTwh/d3pwM9JA==}
 
   prelude-ls@1.2.1:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
@@ -8523,7 +8524,7 @@ snapshots:
   '@docsearch/js@3.9.0(@algolia/client-search@5.46.2)(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(search-insights@2.17.3)':
     dependencies:
       '@docsearch/react': 3.9.0(@algolia/client-search@5.46.2)(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(search-insights@2.17.3)
-      preact: 10.28.1
+      preact: 10.28.2
     transitivePeerDependencies:
       - '@algolia/client-search'
       - '@types/react'
@@ -15307,7 +15308,7 @@ snapshots:
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
-  preact@10.28.1: {}
+  preact@10.28.2: {}
 
   prelude-ls@1.2.1: {}
 

--- a/src/components/MoveReferenceDisabled.astro
+++ b/src/components/MoveReferenceDisabled.astro
@@ -18,14 +18,14 @@ import { Aside, CardGrid, LinkCard } from "@astrojs/starlight/components";
 <CardGrid>
   <LinkCard
     target="_blank"
-    rel="noopener"
+    rel="noopener noreferrer"
     title="Create a GitHub token"
     description="Generate a personal access token with <code>public_repo</code> permissions enabled to build <code class='url-slug'>/move-reference</code> locally"
     href="https://github.com/settings/tokens"
   />
   <LinkCard
     target="_blank"
-    rel="noopener"
+    rel="noopener noreferrer"
     title="Managing your tokens"
     description="Learn about how to create and manage GitHub tokens securely"
     href="https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens"
@@ -37,14 +37,14 @@ import { Aside, CardGrid, LinkCard } from "@astrojs/starlight/components";
 <CardGrid>
   <LinkCard
     target="_blank"
-    rel="noopener"
+    rel="noopener noreferrer"
     title="Move Reference on Aptos.dev"
     description="View this page in live the production environment"
     href="https://aptos.dev/move-reference"
   />
   <LinkCard
     target="_blank"
-    rel="noopener"
+    rel="noopener noreferrer"
     title="View the Source"
     description="Browse the Move framework source code directly on GitHub"
     href="https://github.com/aptos-labs/aptos-core/tree/main/aptos-move/framework"

--- a/src/starlight-overrides/PageFrame.astro
+++ b/src/starlight-overrides/PageFrame.astro
@@ -24,8 +24,8 @@ const { hasSidebar } = Astro.locals.starlightRoute;
 </div>
 <footer class="global-footer">
   © {new Date().getFullYear()} Aptos Foundation
-  <a href="https://aptosnetwork.com/privacy" target="_blank">Privacy</a>
-  <a href="https://aptosnetwork.com/terms" target="_blank">Terms</a>
+  <a href="https://aptosnetwork.com/privacy" target="_blank" rel="noopener noreferrer">Privacy</a>
+  <a href="https://aptosnetwork.com/terms" target="_blank" rel="noopener noreferrer">Terms</a>
 </footer>
 
 <Analytics />


### PR DESCRIPTION
Fixes a high severity `preact` vulnerability and adds `rel="noopener noreferrer"` to external links.

The `preact` dependency was updated to `10.28.2` via a pnpm override to address the JSON VNode Injection vulnerability (GHSA-36hm-qxxp-pg3m). Additionally, `rel="noopener noreferrer"` was added to external links with `target="_blank"` to prevent tabnapping attacks.

---
<a href="https://cursor.com/background-agent?bcId=bc-222412ee-3617-40fa-b464-6b518173e5c3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-222412ee-3617-40fa-b464-6b518173e5c3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

