### PR TITLE
Aptos.dev fragments issue

### DIFF
--- a/src/starlight-overrides/LanguageSelect.astro
+++ b/src/starlight-overrides/LanguageSelect.astro
@@ -29,6 +29,14 @@ import Default from "@astrojs/starlight/components/LanguageSelect.astro";
             const expiryDate = new Date();
             expiryDate.setFullYear(expiryDate.getFullYear() + 1);
             document.cookie = `preferred_locale=${locale}; expires=${expiryDate.toUTCString()}; path=/; SameSite=Lax`;
+
+            // Navigate to the new language path while preserving the URL fragment (hash)
+            // This fixes a bug where fragments like #section were lost when switching languages
+            const hash = window.location.hash;
+            window.location.href = pathname + hash;
+
+            // Prevent the default Starlight handler from also executing
+            e.stopImmediatePropagation();
           }
         });
       });


### PR DESCRIPTION
Preserve URL fragments when switching languages to fix a navigation bug.

The default Starlight `LanguageSelect` component's navigation method (`window.location.pathname = value`) discards any existing URL fragment (e.g., `#section`). This PR updates the custom `LanguageSelect` override to explicitly append the fragment to the new URL, ensuring users remain at the correct section after a language change.

---
[Slack Thread](https://aptos-org.slack.com/archives/C03EG004E56/p1766527693029539?thread_ts=1766527693.029539&cid=C03EG004E56)

<a href="https://cursor.com/background-agent?bcId=bc-1ac283c8-6efe-41b6-a205-c955191e9a78"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-1ac283c8-6efe-41b6-a205-c955191e9a78"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

