### PR TITLE
Remove Pontem references from documentation

### DIFF
--- a/src/content/docs/build/apis/faucet-api.mdx
+++ b/src/content/docs/build/apis/faucet-api.mdx
@@ -18,7 +18,7 @@ see more information on each individual [SDK's documentation](/build/sdks).
 
 ### Using the faucet in a wallet
 
-Most wallets, such as [Petra](https://aptosnetwork.com/ecosystem/directory/petra) or [Pontem](https://aptosnetwork.com/ecosystem/directory/pontem-wallet)
+Most wallets, such as [Petra](https://aptosnetwork.com/ecosystem/directory/petra),
 will have a faucet button for devnet. See full list of [Aptos Wallets](https://aptosnetwork.com/ecosystem/projects/wallets).
 
 ### Using the faucet in the Aptos CLI

--- a/src/content/docs/build/smart-contracts.mdx
+++ b/src/content/docs/build/smart-contracts.mdx
@@ -52,7 +52,6 @@ Here is a `hello_blockchain` example of move
 - [Aptos Move by Example](https://move-developers-dao.gitbook.io/aptos-move-by-example)
 - [Teach yourself Move on Aptos](https://github.com/econia-labs/teach-yourself-move).
 - [Formal Verification, the Move Language, and the Move Prover](https://www.certik.com/resources/blog/2wSOZ3mC55AB6CYol6Q2rP-formal-verification-the-move-language-and-the-move-prover)
-- [Pontem Move Playground](https://playground.pontem.network/)
 - [Collection of nestable Move resources](https://github.com/taoheorg/taohe)
 
 We have a new Move on Aptos compiler that supports Move 2. See [this page](/build/smart-contracts/compiler_v2) for more information.

--- a/src/content/docs/es/build/apis/faucet-api.mdx
+++ b/src/content/docs/es/build/apis/faucet-api.mdx
@@ -18,7 +18,7 @@ ver más información en la [documentación de cada SDK](/es/build/sdks).
 
 ### Usando el faucet en una wallet
 
-La mayoría de wallets, como [Petra](https://aptosnetwork.com/ecosystem/directory/petra) o [Pontem](https://aptosnetwork.com/ecosystem/directory/pontem-wallet)
+La mayoría de wallets, como [Petra](https://aptosnetwork.com/ecosystem/directory/petra),
 tendrán un botón de faucet para devnet. Ve la lista completa de [Wallets de Aptos](https://aptosnetwork.com/ecosystem/directory/category/wallets).
 
 ### Usando el faucet en la CLI de Aptos

--- a/src/content/docs/es/build/smart-contracts.mdx
+++ b/src/content/docs/es/build/smart-contracts.mdx
@@ -52,7 +52,6 @@ Aquí tienes un ejemplo de `hello_blockchain` en Move:
 - [Aptos Move by Example](https://move-developers-dao.gitbook.io/aptos-move-by-example)
 - [Teach yourself Move on Aptos](https://github.com/econia-labs/teach-yourself-move) (Aprende Move en Aptos por tu cuenta).
 - [Formal Verification, the Move Language, and the Move Prover](https://www.certik.com/resources/blog/2wSOZ3mC55AB6CYol6Q2rP-formal-verification-the-move-language-and-the-move-prover) (Verificación formal, el lenguaje Move y el Move Prover).
-- [Pontem Move Playground](https://playground.pontem.network/)
 - [Collection of nestable Move resources](https://github.com/taoheorg/taohe) (Colección de recursos de Move anidables).
 
 Tenemos un nuevo compilador de Move on Aptos que soporta Move 2. Consulta [esta página](/es/build/smart-contracts/compiler_v2) para más información.

--- a/src/content/docs/zh/build/smart-contracts.mdx
+++ b/src/content/docs/zh/build/smart-contracts.mdx
@@ -52,7 +52,6 @@ Move 允许开发者编写灵活管理和转移资产的程序,同时为这些�
 - [Aptos Move by Example](https://move-developers-dao.gitbook.io/aptos-move-by-example)
 - [在 Aptos 上自学 Move](https://github.com/econia-labs/teach-yourself-move).
 - [形式化验证,Move 语言和 Move Prover](https://www.certik.com/resources/blog/2wSOZ3mC55AB6CYol6Q2rP-formal-verification-the-move-language-and-the-move-prover)
-- [Pontem Move Playground](https://playground.pontem.network/)
 - [可嵌套的 Move 资源集合](https://github.com/taoheorg/taohe)
 
 我们有一个新的支持 Move 2 的 Aptos Move 编译器.查看[此页面](/zh/build/smart-contracts/compiler_v2)了解更多信息.


### PR DESCRIPTION
## Summary
- Remove Pontem Move Playground link from smart contracts docs
- Remove Pontem wallet references from faucet API docs
- Updates EN, ES, and ZH locales

## Test plan
- [ ] Verify documentation pages render correctly
- [ ] Verify links in affected pages still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)