### PR TITLE
Markdown page access

### DIFF
--- a/src/middlewares/en-redirect.ts
+++ b/src/middlewares/en-redirect.ts
@@ -10,6 +10,11 @@ export default function middleware(request: Request): Response | void {
   const url = new URL(request.url);
   const pathname = url.pathname;
 
+  // Skip .md file requests - these should be served directly without redirect
+  if (pathname.endsWith(".md")) {
+    return undefined;
+  }
+
   // Check if the path starts with /en
   const enPathMatch = /^\/en(\/.*|$)/.exec(pathname);
 

--- a/src/middlewares/i18n-redirect.ts
+++ b/src/middlewares/i18n-redirect.ts
@@ -70,6 +70,11 @@ export default function middleware(request: Request): Response | void {
   const url = new URL(request.url);
   const pathname = url.pathname;
 
+  // Skip .md file requests - these should be served directly without i18n redirect
+  if (pathname.endsWith(".md")) {
+    return undefined;
+  }
+
   // Check if the request is from a crawler
   const userAgent = request.headers.get("user-agent");
 

--- a/src/pages/[...slug].md.ts
+++ b/src/pages/[...slug].md.ts
@@ -1,0 +1,66 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import type { APIRoute, GetStaticPaths } from "astro";
+import { getCollection } from "astro:content";
+
+// Cache control settings
+const CACHE_CONTROL_TTL = 60 * 60; // 1 hour for markdown files
+
+/**
+ * Get static paths for all documentation pages
+ * This generates .md endpoints for every docs page
+ */
+export const getStaticPaths: GetStaticPaths = async () => {
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-call
+  const docs = await getCollection("docs");
+
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-return, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
+  return docs.map((doc: { id: string }) => ({
+    params: { slug: doc.id },
+    props: { doc },
+  }));
+};
+
+/**
+ * API route handler to serve raw markdown content
+ * Accessible by appending .md to any documentation page URL
+ */
+export const GET: APIRoute = async ({ params }) => {
+  const slug = params.slug;
+
+  if (!slug) {
+    return new Response("Not found", { status: 404 });
+  }
+
+  try {
+    // Construct the path to the MDX file
+    const mdxPath = path.resolve(process.cwd(), "src/content/docs", `${slug}.mdx`);
+
+    // Try to read the MDX file
+    let content: string;
+    try {
+      content = await fs.readFile(mdxPath, "utf-8");
+    } catch {
+      // Try with /index.mdx for directory-style routes
+      const indexPath = path.resolve(process.cwd(), "src/content/docs", slug, "index.mdx");
+      try {
+        content = await fs.readFile(indexPath, "utf-8");
+      } catch {
+        return new Response(`Markdown file not found for: ${slug}`, { status: 404 });
+      }
+    }
+
+    // Return the raw markdown/MDX content
+    return new Response(content, {
+      status: 200,
+      headers: {
+        "Content-Type": "text/markdown; charset=utf-8",
+        "Cache-Control": `public, max-age=${String(CACHE_CONTROL_TTL)}`,
+        "X-Content-Type-Options": "nosniff",
+      },
+    });
+  } catch (error) {
+    console.error(`Error serving markdown for ${slug}:`, error);
+    return new Response("Internal server error", { status: 500 });
+  }
+};


### PR DESCRIPTION
Add a feature to serve documentation pages as raw markdown by appending `.md` to their URL.

This provides direct access to the source content, bypassing standard page rendering and internationalization redirects.

---
[Slack Thread](https://aptos-org.slack.com/archives/C03EG004E56/p1770261219248539?thread_ts=1770261219.248539&cid=C03EG004E56)

<p><a href="https://cursor.com/background-agent?bcId=bc-9d346341-4384-5f8a-9764-32dbb7b28a1a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-9d346341-4384-5f8a-9764-32dbb7b28a1a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

