### PR TITLE
Vercel 5mb body limit

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,11 +1,5 @@
 {
   "trailingSlash": false,
-  "functions": {
-    "**/*.md.func/**": {
-      "maxDuration": 30,
-      "memory": 1024
-    }
-  },
   "headers": [
     {
       "source": "/(.*)",


### PR DESCRIPTION
Fix Vercel deployment failure due to 5MB body limit by optimizing static path generation for markdown files.

The `getStaticPaths` function was passing the entire document object as props for over 870 MDX files, leading to an excessively large payload during the build process. Since the GET handler reads file content directly, these props were redundant. Removing them significantly reduces the payload size, resolving the Vercel 5MB body limit error. Explicitly setting `prerender = true` ensures these routes are statically generated.

---
[Slack Thread](https://aptos-org.slack.com/archives/C03EG004E56/p1770261219248539?thread_ts=1770261219.248539&cid=C03EG004E56)

<p><a href="https://cursor.com/background-agent?bcId=bc-e9d58795-2c8f-5569-b3d3-498ebe37077b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-e9d58795-2c8f-5569-b3d3-498ebe37077b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

