### PR TITLE
fix: use Astro output dir for markdown file generation

### DIFF
--- a/src/integrations/markdownFiles.ts
+++ b/src/integrations/markdownFiles.ts
@@ -1,15 +1,7 @@
 import fs from "node:fs";
 import path from "node:path";
+import { fileURLToPath } from "node:url";
 import type { AstroIntegration } from "astro";
-
-async function waitForDir(dirPath: string, timeoutMs = 30000, intervalMs = 200) {
-  const start = Date.now();
-  while (Date.now() - start < timeoutMs) {
-    if (fs.existsSync(dirPath)) return true;
-    await new Promise((r) => setTimeout(r, intervalMs));
-  }
-  return false;
-}
 
 function findMdxFiles(dir: string): string[] {
   const files: string[] = [];
@@ -34,13 +26,14 @@ export function markdownFilesIntegration(): AstroIntegration {
   return {
     name: "markdown-files",
     hooks: {
-      "astro:build:done": async ({ logger }) => {
-        const staticDir = path.resolve(".vercel/output/static");
+      "astro:build:done": ({ dir, logger }) => {
+        // dir is the Astro output directory (e.g., dist/client/)
+        // The Vercel adapter will copy this to .vercel/output/static/
+        const outputDir = fileURLToPath(dir);
         const contentDir = path.resolve("src/content/docs");
 
-        const ready = await waitForDir(staticDir);
-        if (!ready) {
-          logger.warn("Vercel static dir not found; skipping markdown generation");
+        if (!fs.existsSync(outputDir)) {
+          logger.warn(`Output directory not found: ${outputDir}`);
           return;
         }
 
@@ -50,7 +43,7 @@ export function markdownFilesIntegration(): AstroIntegration {
         let count = 0;
         for (const mdxPath of mdxFiles) {
           const relativePath = path.relative(contentDir, mdxPath);
-          const outputPath = path.join(staticDir, relativePath.replace(/\.mdx$/, ".md"));
+          const outputPath = path.join(outputDir, relativePath.replace(/\.mdx$/, ".md"));
 
           try {
             fs.mkdirSync(path.dirname(outputPath), { recursive: true });


### PR DESCRIPTION
## Problem

The markdown file generation integration was not working in production because it was waiting for `.vercel/output/static/` which doesn't exist when the `astro:build:done` hook runs.

**Root cause:** The `astro:build:done` hook fires BEFORE the Vercel adapter creates `.vercel/output/static/`. The adapter copies files from Astro's output directory AFTER all hooks complete.

## Solution

Use the `dir` parameter provided by the `astro:build:done` hook instead of hardcoding `.vercel/output/static/`. This directory (typically `dist/client/`) is where Astro outputs static files, and the Vercel adapter will copy them to the final location.

## Changes

- Use `dir` parameter from hook instead of hardcoded path
- Remove unnecessary `waitForDir` polling function
- Add `fileURLToPath` import to convert URL to path

## Test plan

- [ ] Deploy to Vercel preview
- [ ] Verify `.md` URLs work: `/build/cli.md`, `/es/build/cli.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)