### PR TITLE
Security dependency cleanup

### DIFF
--- a/package.json
+++ b/package.json
@@ -154,13 +154,14 @@
       "devalue": ">=5.3.2",
       "prismjs": ">=1.30.0",
       "sitemap": ">=8.0.2",
-      "tar": ">=7.5.2",
+      "tar": ">=7.5.7",
       "js-yaml": ">=4.1.1",
       "mdast-util-to-hast": ">=13.2.1",
       "sharp": ">=0.34.0",
       "preact": ">=10.28.2",
       "lodash": ">=4.17.23",
-      "lodash-es": ">=4.17.23"
+      "lodash-es": ">=4.17.23",
+      "@isaacs/brace-expansion": ">=5.0.1"
     }
   },
   "simple-git-hooks": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,13 +15,14 @@ overrides:
   devalue: '>=5.3.2'
   prismjs: '>=1.30.0'
   sitemap: '>=8.0.2'
-  tar: '>=7.5.2'
+  tar: '>=7.5.7'
   js-yaml: '>=4.1.1'
   mdast-util-to-hast: '>=13.2.1'
   sharp: '>=0.34.0'
   preact: '>=10.28.2'
   lodash: '>=4.17.23'
   lodash-es: '>=4.17.23'
+  '@isaacs/brace-expansion': '>=5.0.1'
 
 patchedDependencies:
   '@astrojs/vercel':
@@ -1715,8 +1716,8 @@ packages:
     resolution: {integrity: sha512-yzMTt9lEb8Gv7zRioUilSglI0c0smZ9k5D65677DLWLtWJaXIS3CqcGyUFByYKlnUj6TkjLVs54fBl6+TiGQDQ==}
     engines: {node: 20 || >=22}
 
-  '@isaacs/brace-expansion@5.0.0':
-    resolution: {integrity: sha512-ZT55BDLV0yv0RBm2czMiZ+SqCGO7AvmOM3G/w2xhVPH+te0aKgFjmBvGlL1dH+ql2tgGO3MVrbb3jCKyvpgnxA==}
+  '@isaacs/brace-expansion@5.0.1':
+    resolution: {integrity: sha512-WMz71T1JS624nWj2n2fnYAuPovhv7EUhk69R6i9dsVyzxt5eM3bjwvgk9L+APE1TRscGysAVMANkB0jh0LQZrQ==}
     engines: {node: 20 || >=22}
 
   '@isaacs/fs-minipass@4.0.1':
@@ -7095,8 +7096,8 @@ packages:
     resolution: {integrity: sha512-g9ljZiwki/LfxmQADO3dEY1CbpmXT5Hm2fJ+QaGKwSXUylMybePR7/67YW7jOrrvjEgL1Fmz5kzyAjWVWLlucg==}
     engines: {node: '>=6'}
 
-  tar@7.5.4:
-    resolution: {integrity: sha512-AN04xbWGrSTDmVwlI4/GTlIIwMFk/XEv7uL8aa57zuvRy6s4hdBed+lVq2fAZ89XDa7Us3ANXcE3Tvqvja1kTA==}
+  tar@7.5.7:
+    resolution: {integrity: sha512-fov56fJiRuThVFXD6o6/Q354S7pnWMJIVlDBYijsTNx6jKSE4pvrDTs6lUnmGvNyfJwFQQwWy3owKz1ucIhveQ==}
     engines: {node: '>=18'}
 
   terminal-link@5.0.0:
@@ -8596,7 +8597,7 @@ snapshots:
       command-exists-promise: 2.0.2
       node-fetch: 2.7.0
       shelljs: 0.10.0
-      tar: 7.5.4
+      tar: 7.5.7
       yauzl: 3.2.0
     transitivePeerDependencies:
       - encoding
@@ -9658,7 +9659,7 @@ snapshots:
       local-pkg: 1.1.2
       pathe: 2.0.3
       svgo: 3.3.2
-      tar: 7.5.4
+      tar: 7.5.7
     transitivePeerDependencies:
       - supports-color
 
@@ -9789,7 +9790,7 @@ snapshots:
 
   '@isaacs/balanced-match@4.0.1': {}
 
-  '@isaacs/brace-expansion@5.0.0':
+  '@isaacs/brace-expansion@5.0.1':
     dependencies:
       '@isaacs/balanced-match': 4.0.1
 
@@ -9875,7 +9876,7 @@ snapshots:
       node-fetch: 2.6.9
       nopt: 8.1.0
       semver: 7.7.3
-      tar: 7.5.4
+      tar: 7.5.7
     transitivePeerDependencies:
       - encoding
       - supports-color
@@ -15036,7 +15037,7 @@ snapshots:
 
   minimatch@10.1.1:
     dependencies:
-      '@isaacs/brace-expansion': 5.0.0
+      '@isaacs/brace-expansion': 5.0.1
 
   minimatch@3.1.2:
     dependencies:
@@ -16459,7 +16460,7 @@ snapshots:
 
   tapable@2.3.0: {}
 
-  tar@7.5.4:
+  tar@7.5.7:
     dependencies:
       '@isaacs/fs-minipass': 4.0.1
       chownr: 3.0.0


### PR DESCRIPTION
Update dependency overrides to fix high-severity vulnerabilities in `tar` and `@isaacs/brace-expansion`.

This PR resolves two high-severity vulnerabilities:
1.  **tar** (CVE-2026-24842): Hardlink path traversal. Updated override from `>=7.5.2` to `>=7.5.7`.
2.  **@isaacs/brace-expansion** (CVE-2026-25547): Uncontrolled resource consumption (DoS). Added override `>=5.0.1`.

---
<p><a href="https://cursor.com/background-agent?bcId=bc-e6447eaf-9c92-4751-bac6-d8ba8ebc9687"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-e6447eaf-9c92-4751-bac6-d8ba8ebc9687"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

