### PR TITLE
Vercel output optimization

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -42,6 +42,10 @@ const enableApiReference = true;
 
 // https://astro.build/config
 export default defineConfig({
+  // Use server output mode so REST API pages can be rendered on-demand (SSR)
+  // instead of being statically generated at build time.
+  // Starlight pages remain prerendered (static) by default.
+  output: "server",
   build: {
     inlineStylesheets: "never",
   },
@@ -56,6 +60,18 @@ export default defineConfig({
     monacoEditorIntegration(),
     // Custom client directive for on-demand loading
     onDemandDirective(),
+    // Override prerender for OpenAPI REST API routes to use SSR.
+    // This reduces the static output size by ~100+ MB (each page is ~1.69 MB).
+    {
+      name: "openapi-ssr-override",
+      hooks: {
+        "astro:route:setup": ({ route }) => {
+          if (route.component.includes("OpenAPI/Route.astro")) {
+            route.prerender = false;
+          }
+        },
+      },
+    },
     // Check for large files that might exceed Vercel limits
     fileSizeCheckIntegration(),
     // Generate static .md files for each doc page (self-hosted, no GitHub rate limits)

--- a/src/components/OpenAPI/Route.astro
+++ b/src/components/OpenAPI/Route.astro
@@ -2,7 +2,6 @@
 import StarlightPage from "@astrojs/starlight/components/StarlightPage.astro";
 import FallbackContentNotice from "@astrojs/starlight/components/FallbackContentNotice.astro";
 import { dereference } from "@readme/openapi-parser";
-import type { InferGetStaticPropsType } from "astro";
 
 import { getSchemaStaticPaths } from "starlight-openapi/libs/route";
 import { getPageProps } from "starlight-openapi/libs/starlight";
@@ -12,41 +11,55 @@ import OperationTag from "./OperationTag.astro";
 import Overview from "./Overview.astro";
 import OperationScalarModal from "./operation/OperationExamples/OperationScalarModal.astro";
 
-export const prerender = true;
+// Render REST API pages on-demand (SSR) instead of statically at build time.
+// This significantly reduces the Vercel deployment size by removing ~60+ large
+// HTML files (each ~1.69 MB) from the static output.
+export const prerender = false;
 
-export function getStaticPaths() {
-  return getSchemaStaticPaths();
+// Build a lookup map from slug to props for SSR routing.
+// The data comes from the virtual module (compiled into the serverless function),
+// so this is fast and does not involve any external I/O.
+const allRoutes = getSchemaStaticPaths();
+const routeMap = new Map(allRoutes.map((route) => [route.params.openAPISlug, route.props]));
+
+// Match the current request's slug against known API routes
+const slug = Astro.params.openAPISlug as string;
+const matchedProps = routeMap.get(slug);
+
+if (!matchedProps) {
+  return new Response(null, { status: 404 });
 }
 
-type Props = InferGetStaticPropsType<typeof getStaticPaths>;
-
-const { schema, type } = Astro.props;
+const { schema, type } = matchedProps;
 
 schema.document = await dereference(schema.document);
 
 const isOverview = type === "overview";
 const isOperationTag = type === "operation-tag";
 
-const title = isOverview || isOperationTag ? "Overview" : Astro.props.operation.title;
+const operation = type === "operation" ? matchedProps.operation : undefined;
+const tag = type === "operation-tag" ? matchedProps.tag : undefined;
+const title = isOverview || isOperationTag ? "Overview" : (operation?.title ?? "API");
+
+// Cache SSR responses at the CDN edge for performance.
+// s-maxage=86400: CDN caches for 24 hours
+// stale-while-revalidate=604800: serve stale while revalidating for up to 7 days
+Astro.response.headers.set(
+  "Cache-Control",
+  "public, s-maxage=86400, stale-while-revalidate=604800",
+);
 ---
 
-<StarlightPage
-  {...getPageProps(
-    title,
-    schema,
-    isOverview || isOperationTag ? undefined : Astro.props.operation,
-    isOperationTag ? Astro.props.tag : undefined,
-  )}
->
+<StarlightPage {...getPageProps(title, schema, operation, tag)}>
   {Astro.currentLocale !== "en" && <FallbackContentNotice />}
   {
     isOverview ? (
       <Overview {schema} />
-    ) : isOperationTag ? (
-      <OperationTag tag={Astro.props.tag} />
-    ) : (
-      <Operation {schema} operation={Astro.props.operation} />
-    )
+    ) : isOperationTag && tag ? (
+      <OperationTag tag={tag} />
+    ) : operation ? (
+      <Operation {schema} operation={operation} />
+    ) : null
   }
 </StarlightPage>
 <!-- We render it here, because StarlightPage component creates stacking context which breaks modal styles -->


### PR DESCRIPTION
Convert REST API pages to SSR to reduce Vercel output size and avoid deployment failures.

The Vercel deployment was failing with a "Body exceeded 5mb limit" error, largely due to ~60+ statically generated REST API HTML pages, each around 1.69 MB. This change converts these pages to server-side rendering (SSR) with CDN caching, removing them from the static build output and significantly reducing the total deployment size.

---
<p><a href="https://cursor.com/background-agent?bcId=bc-8c33270c-5822-45b0-a0b2-eb081493a12b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-8c33270c-5822-45b0-a0b2-eb081493a12b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

