### PR TITLE
CLI upgrade changelog reference

### DIFF
--- a/public/scripts/install_cli.ps1
+++ b/public/scripts/install_cli.ps1
@@ -23,6 +23,42 @@ $ACCEPT_ALL = $false
 $VERSION = ""
 $UNDO = $false
 
+# Show usage information
+function Show-Usage {
+    Write-Host @"
+Usage: install_cli.ps1 [OPTIONS]
+
+Installs the latest version of the Aptos CLI on Windows.
+
+During upgrades, the installer automatically backs up the current binary
+so you can roll back with --undo. If the upgrade crosses a major version
+boundary (e.g. v1.x.x -> v2.x.x), a warning is displayed with a link to
+the CHANGELOG for breaking changes:
+  https://github.com/aptos-labs/aptos-core/blob/main/crates/aptos/CHANGELOG.md
+
+OPTIONS:
+  -f, --force          Install even if the same version is already installed
+  -y, --yes            Accept all prompts automatically
+  --bin-dir DIR        Install the CLI binary to DIR
+                       (default: %USERPROFILE%\.aptoscli\bin)
+  --cli-version VER    Install a specific version instead of the latest
+  --undo               Restore the previous CLI version from the backup
+                       created during the last upgrade. Only one backup is
+                       kept at a time. No network access is required.
+  -h, --help           Show this help message and exit
+
+EXAMPLES:
+  # Install the latest version
+  .\install_cli.ps1
+
+  # Install a specific version
+  .\install_cli.ps1 --cli-version 3.5.0
+
+  # Roll back to the previously installed version
+  .\install_cli.ps1 --undo
+"@
+}
+
 # Print colored message
 function Write-ColorMessage {
     param(
@@ -193,8 +229,16 @@ function Main {
                 }
             }
             '--undo' { $UNDO = $true }
+            '-h' {
+                Show-Usage
+                return
+            }
+            '--help' {
+                Show-Usage
+                return
+            }
             default {
-                Die "Unknown option: $($args[$i])"
+                Die "Unknown option: $($args[$i]). Use --help for usage information."
             }
         }
     }

--- a/public/scripts/install_cli.py
+++ b/public/scripts/install_cli.py
@@ -987,40 +987,58 @@ def main():
         return 1
 
     parser = argparse.ArgumentParser(
-        description="Installs the latest version of the Aptos CLI"
+        description="Installs the latest version of the Aptos CLI.",
+        epilog=(
+            "UPGRADE BEHAVIOR:\n"
+            "  During upgrades, the installer automatically backs up the current\n"
+            "  binary so you can roll back with --undo. If the upgrade crosses a\n"
+            "  major version boundary (e.g. v1.x.x -> v2.x.x), a warning is\n"
+            "  displayed with a link to the CHANGELOG for breaking changes:\n"
+            "    https://github.com/aptos-labs/aptos-core/blob/main/crates/aptos/CHANGELOG.md\n"
+            "\n"
+            "EXAMPLES:\n"
+            "  python install_cli.py                        # Install latest version\n"
+            "  python install_cli.py --cli-version 3.5.0    # Install specific version\n"
+            "  python install_cli.py --undo                 # Roll back last upgrade\n"
+        ),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
     )
     parser.add_argument(
         "-f",
         "--force",
-        help="Forcibly install on top of existing version",
+        help="install even if the same version is already installed",
         action="store_true",
         default=False,
     )
     parser.add_argument(
         "-y",
         "--yes",
-        help="Accept all prompts",
+        help="accept all prompts automatically",
         dest="accept_all",
         action="store_true",
         default=False,
     )
     parser.add_argument(
         "--bin-dir",
-        help="If given, the CLI binary will be downloaded here instead",
+        help="install the CLI binary to this directory instead of the default",
     )
     parser.add_argument(
         "--cli-version",
-        help="If given, the CLI version to install",
+        help="install a specific CLI version instead of the latest",
     )
     parser.add_argument(
         "--from-source",
-        help="Build and install from source instead of downloading pre-built binary",
+        help="build and install from source instead of downloading a pre-built binary (requires git)",
         action="store_true",
         default=False,
     )
     parser.add_argument(
         "--undo",
-        help="Restore the previously installed CLI version from backup",
+        help=(
+            "restore the previous CLI version from the backup created during "
+            "the last upgrade. Only one backup is kept at a time. "
+            "No network access is required"
+        ),
         action="store_true",
         default=False,
     )

--- a/public/scripts/install_cli.sh
+++ b/public/scripts/install_cli.sh
@@ -27,6 +27,45 @@ UNDO=false
 UNIVERSAL_INSTALLER_URL="https://raw.githubusercontent.com/gregnazario/universal-installer/main/scripts/install_pkg.sh"
 APTOS_REPO_URL="https://github.com/aptos-labs/aptos-core.git"
 
+# Show usage information
+show_usage() {
+    cat <<EOF
+Usage: install_cli.sh [OPTIONS]
+
+Installs the latest version of the Aptos CLI.
+
+During upgrades, the installer automatically backs up the current binary
+so you can roll back with --undo. If the upgrade crosses a major version
+boundary (e.g. v1.x.x -> v2.x.x), a warning is displayed with a link to
+the CHANGELOG for breaking changes:
+  https://github.com/aptos-labs/aptos-core/blob/main/crates/aptos/CHANGELOG.md
+
+OPTIONS:
+  -f, --force          Install even if the same version is already installed
+  -y, --yes            Accept all prompts automatically
+  --bin-dir DIR        Install the CLI binary to DIR (default: ~/.local/bin)
+  --cli-version VER    Install a specific version instead of the latest
+  --generic-linux      Use the generic Linux binary instead of a
+                       distro-specific build
+  --from-source        Build and install from source instead of downloading
+                       a pre-built binary (requires git)
+  --undo               Restore the previous CLI version from the backup
+                       created during the last upgrade. Only one backup is
+                       kept at a time. No network access is required.
+  -h, --help           Show this help message and exit
+
+EXAMPLES:
+  # Install the latest version
+  curl -fsSL https://aptos.dev/scripts/install_cli.sh | sh
+
+  # Install a specific version
+  curl -fsSL https://aptos.dev/scripts/install_cli.sh | sh -s -- --cli-version 3.5.0
+
+  # Roll back to the previously installed version
+  curl -fsSL https://aptos.dev/scripts/install_cli.sh | sh -s -- --undo
+EOF
+}
+
 # Print colored message
 print_message() {
     color=$1
@@ -399,8 +438,12 @@ main() {
                 UNDO=true
                 shift
                 ;;
+            -h|--help)
+                show_usage
+                exit 0
+                ;;
             *)
-                die "Unknown option: $1"
+                die "Unknown option: $1. Use --help for usage information."
                 ;;
         esac
     done


### PR DESCRIPTION
Add major version upgrade warnings and a `--undo` option to the CLI installation scripts.

The `--undo` option allows users to easily revert to the previous CLI version if an upgrade introduces issues, by backing up the existing binary before an upgrade. The major version warning informs users of potential breaking changes and directs them to the CHANGELOG.

---
<p><a href="https://cursor.com/background-agent?bcId=bc-01a96ba0-e483-4ca6-b608-c8a997401a31"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-01a96ba0-e483-4ca6-b608-c8a997401a31"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

