### PR TITLE
Update wallet adapter links to point to vercel

### DIFF
--- a/src/content/docs/build/sdks/wallet-adapter/browser-extension-wallets.mdx
+++ b/src/content/docs/build/sdks/wallet-adapter/browser-extension-wallets.mdx
@@ -124,7 +124,7 @@ In order for dapp users who are not already using your wallet to get the option 
 ## Resources
 
 - Wallet Adapter Demo App
-  - [Live site](https://aptos-labs.github.io/aptos-wallet-adapter)
+  - [Live site](https://aptos-wallet-adapter-example.vercel.app/)
   - [Source code](https://github.com/aptos-labs/aptos-wallet-adapter/tree/main/apps/nextjs-example)
   - See [`standardWallet.ts`](https://github.com/aptos-labs/aptos-wallet-adapter/blob/main/apps/nextjs-example/src/utils/standardWallet.ts) for an example implementation of an AIP-62 compatible wallet-adapter plugin.
 - [`wallet-standard`](https://github.com/aptos-labs/wallet-standard) source code.

--- a/src/content/docs/build/sdks/wallet-adapter/dapp.mdx
+++ b/src/content/docs/build/sdks/wallet-adapter/dapp.mdx
@@ -118,7 +118,7 @@ For UI components that work out of the box, but are less customizable, choose on
 Otherwise, you should use the [shadcn/ui wallet selector](https://github.com/aptos-labs/aptos-wallet-adapter/blob/main/apps/nextjs-example/README.md#use-shadcnui-wallet-selector-for-your-own-app), as it has the most customization options. For more details on how to customize this wallet selector or build your own wallet selector, see [this guide](https://github.com/aptos-labs/aptos-wallet-adapter/blob/main/packages/wallet-adapter-react/docs/BYO-wallet-selector.md).
 
 <Aside type="note">
-  For an example that shows how these UI options work in practice, see the [live demo app](https://aptos-labs.github.io/aptos-wallet-adapter/) (you can find its reference code [here](https://github.com/aptos-labs/aptos-wallet-adapter/tree/main/apps/nextjs-example)).
+  For an example that shows how these UI options work in practice, see the [live demo app](https://aptos-wallet-adapter-example.vercel.app/) (you can find its reference code [here](https://github.com/aptos-labs/aptos-wallet-adapter/tree/main/apps/nextjs-example)).
 </Aside>
 
 ## `useWallet` Fields and Functions
@@ -153,7 +153,7 @@ _See [`WalletCore.ts`](https://github.com/aptos-labs/aptos-wallet-adapter/blob/m
 
 See the next.js example dapp for a demonstration of how these components are used in practice:
 
-- [Live site](https://aptos-labs.github.io/aptos-wallet-adapter/)
+- [Live site](https://aptos-wallet-adapter-example.vercel.app/)
 - [Source code](https://github.com/aptos-labs/aptos-wallet-adapter/tree/main/apps/nextjs-example)
 
 ### `wallets`

--- a/src/content/docs/build/sdks/wallet-adapter/wallets.mdx
+++ b/src/content/docs/build/sdks/wallet-adapter/wallets.mdx
@@ -128,7 +128,7 @@ In order for dapp users who are not already using your wallet to get the option 
 ## Resources
 
 - Wallet Adapter Demo App
-  - [Live site](https://aptos-labs.github.io/aptos-wallet-adapter)
+  - [Live site](https://aptos-wallet-adapter-example.vercel.app/)
   - [Source code](https://github.com/aptos-labs/aptos-wallet-adapter/tree/main/apps/nextjs-example)
   - See [`standardWallet.ts`](https://github.com/aptos-labs/aptos-wallet-adapter/blob/main/apps/nextjs-example/src/utils/standardWallet.ts) for an example implementation of an AIP-62 compatible wallet-adapter plugin.
 - [`wallet-standard`](https://github.com/aptos-labs/wallet-standard) source code.

--- a/src/content/docs/build/sdks/wallet-adapter/x-chain-accounts.mdx
+++ b/src/content/docs/build/sdks/wallet-adapter/x-chain-accounts.mdx
@@ -307,6 +307,6 @@ Therefore, the dApp should consider maintaining a sponsor account to sponsor the
 ### Resources
 
 - X-Chain Accounts Adapter Demo App
-  - [Live site](https://aptos-labs.github.io/aptos-wallet-adapter/nextjs-cross-chain-example/)
+  - [Live site](https://x-chain-accounts.vercel.app/)
   - [Source code](https://github.com/aptos-labs/aptos-wallet-adapter/tree/main/apps/nextjs-x-chain)
 - [AIP-113 Derivable Account Abstraction](https://github.com/aptos-foundation/AIPs/blob/main/aips/aip-113.md)

--- a/src/content/docs/es/build/sdks/wallet-adapter/browser-extension-wallets.mdx
+++ b/src/content/docs/es/build/sdks/wallet-adapter/browser-extension-wallets.mdx
@@ -121,7 +121,7 @@ Para que los usuarios de dapps que no están usando tu wallet obtengan la opció
 ## Recursos
 
 - Dapp de demostración de Wallet Adapter
-  - [Sitio web en vivo](https://aptos-labs.github.io/aptos-wallet-adapter)
+  - [Sitio web en vivo](https://aptos-wallet-adapter-example.vercel.app/)
   - [Código fuente](https://github.com/aptos-labs/aptos-wallet-adapter/tree/main/apps/nextjs-example)
   - Ver [`standardWallet.ts`](https://github.com/aptos-labs/aptos-wallet-adapter/blob/main/apps/nextjs-example/src/utils/standardWallet.ts) para un ejemplo de implementación de un plugin del adaptador de wallet compatible con AIP-62.
 - [`wallet-standard`](https://github.com/aptos-labs/wallet-standard) código fuente.

--- a/src/content/docs/es/build/sdks/wallet-adapter/dapp.mdx
+++ b/src/content/docs/es/build/sdks/wallet-adapter/dapp.mdx
@@ -115,7 +115,7 @@ Para componentes de UI que funcionan de forma nativa, pero son menos personaliza
 De lo contrario, deberías usar el [selector de wallet de shadcn/ui](https://github.com/aptos-labs/aptos-wallet-adapter/blob/main/apps/nextjs-example/README.md#use-shadcnui-wallet-selector-for-your-own-app), ya que tiene las opciones de personalización más completas. Para más detalles sobre cómo personalizar este selector de wallet o construir tu propio selector de wallet, consulta [esta guía](https://github.com/aptos-labs/aptos-wallet-adapter/blob/main/packages/wallet-adapter-react/docs/BYO-wallet-selector.md).
 
 <Aside type="note">
-  Para un ejemplo que muestra cómo funcionan estas opciones de UI en la práctica, consulta la [aplicación de demostración en vivo](https://aptos-labs.github.io/aptos-wallet-adapter/) (puedes encontrar su código de referencia [aquí](https://github.com/aptos-labs/aptos-wallet-adapter/tree/main/apps/nextjs-example)).
+  Para un ejemplo que muestra cómo funcionan estas opciones de UI en la práctica, consulta la [aplicación de demostración en vivo](https://aptos-wallet-adapter-example.vercel.app/) (puedes encontrar su código de referencia [aquí](https://github.com/aptos-labs/aptos-wallet-adapter/tree/main/apps/nextjs-example)).
 </Aside>
 
 ## `useWallet` Campos y Funciones
@@ -150,7 +150,7 @@ _Ver [`WalletCore.ts`](https://github.com/aptos-labs/aptos-wallet-adapter/blob/m
 
 Consulta el dapp de ejemplo de next.js para ver cómo se utilizan estos componentes en la práctica:
 
-- [Sitio web en vivo](https://aptos-labs.github.io/aptos-wallet-adapter/)
+- [Sitio web en vivo](https://aptos-wallet-adapter-example.vercel.app/)
 - [Código fuente](https://github.com/aptos-labs/aptos-wallet-adapter/tree/main/apps/nextjs-example)
 
 ### `wallets`

--- a/src/content/docs/es/build/sdks/wallet-adapter/wallets.mdx
+++ b/src/content/docs/es/build/sdks/wallet-adapter/wallets.mdx
@@ -125,7 +125,7 @@ Para que los usuarios de dapps que no están usando tu wallet obtengan la opció
 ## Recursos
 
 - App de Demostración del Adaptador de Wallet
-  - [Sitio en vivo](https://aptos-labs.github.io/aptos-wallet-adapter)
+  - [Sitio en vivo](https://aptos-wallet-adapter-example.vercel.app/)
   - [Código fuente](https://github.com/aptos-labs/aptos-wallet-adapter/tree/main/apps/nextjs-example)
   - Ver [`standardWallet.ts`](https://github.com/aptos-labs/aptos-wallet-adapter/blob/main/apps/nextjs-example/src/utils/standardWallet.ts) para un ejemplo de implementación de un plugin de wallet-adapter compatible con AIP-62.
 - Código fuente de [`wallet-standard`](https://github.com/aptos-labs/wallet-standard).

--- a/src/content/docs/es/build/sdks/wallet-adapter/x-chain-accounts.mdx
+++ b/src/content/docs/es/build/sdks/wallet-adapter/x-chain-accounts.mdx
@@ -254,6 +254,6 @@ export default SignAndSubmit;
 ### Resources
 
 - X-Chain Accounts Adapter Demo App
-  - [Live site](https://aptos-labs.github.io/aptos-wallet-adapter/nextjs-cross-chain-example/)
+  - [Live site](https://x-chain-accounts.vercel.app/)
   - [Source code](https://github.com/aptos-labs/aptos-wallet-adapter/tree/main/apps/nextjs-x-chain)
 - [AIP-113 Derivable Account Abstraction](https://github.com/aptos-foundation/AIPs/blob/main/aips/aip-113.md)


### PR DESCRIPTION
We use Vercel to serve the demo dapps https://github.com/aptos-labs/aptos-wallet-adapter/pull/749
This PR updated the links to the new Vercel URLs