### PR TITLE
fix: regenerate @astrojs/vercel patch for v9.0.4

### DIFF
--- a/patches/@astrojs__vercel.patch
+++ b/patches/@astrojs__vercel.patch
@@ -19,16 +19,15 @@ index 2f2ec366c9816a861d1ee145923a32f46070af32..1e3c569cacaa8b345c7d27358d80859d
  interface VercelISRConfig {
      /**
 diff --git a/dist/index.js b/dist/index.js
-index d54b7b9b013b96e2a9dba1328b412260f2c295ac..f3ae10b373aa599f8de67597c8e98ae53ad1d0a0 100644
+index 77a4965d20328c3f0fb89547719eb0c73ecd9f66..c3ce83904f299b10def203fc3c1c2cde620b0d82 100644
 --- a/dist/index.js
 +++ b/dist/index.js
-@@ -418,8 +418,20 @@ function vercelAdapter({
+@@ -421,8 +421,19 @@ function vercelAdapter({
            if (!normalized.routes) {
              normalized.routes = [];
            }
 -          if (experimentalStaticHeaders) {
 -            const routesWithConfigHeaders = createRoutesWithStaticHeaders(_routeToHeaders, _config);
-+          // Normalize `experimentalStaticHeaders` into flags we can use.
 +          const _staticHeadersEnabled =
 +            experimentalStaticHeaders === true || typeof experimentalStaticHeaders === 'object';
 +          const _cspMode =
@@ -45,16 +44,15 @@ index d54b7b9b013b96e2a9dba1328b412260f2c295ac..f3ae10b373aa599f8de67597c8e98ae5
              const fileSystemRouteIndex = normalized.routes.findIndex(
                (r) => "handle" in r && r.handle === "filesystem"
              );
-@@ -560,20 +572,31 @@ function getRuntime(process2, logger) {
+@@ -563,20 +574,29 @@ function getRuntime(process2, logger) {
    }
-   return "nodejs22.x";
+   return "nodejs24.x";
  }
 -function createRoutesWithStaticHeaders(staticHeaders, config) {
 +function createRoutesWithStaticHeaders(staticHeaders, config, cspMode = 'per-route') {
    const vercelHeaders = [];
 +  if (!config.experimental.csp) return vercelHeaders;
 +
-+  // GLOBAL MODE — collapse to a single catch-all CSP header
 +  if (cspMode === 'global') {
 +    let csp;
 +    for (const { headers } of staticHeaders.values()) {
@@ -67,7 +65,6 @@ index d54b7b9b013b96e2a9dba1328b412260f2c295ac..f3ae10b373aa599f8de67597c8e98ae5
 +    return vercelHeaders;
 +  }
 +
-+  // PER-ROUTE MODE — existing behavior
    for (const [pathname, { headers }] of staticHeaders.entries()) {
 -    if (config.experimental.csp) {
 -      const csp = headers.get("Content-Security-Policy");

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,7 +12,7 @@ overrides:
 
 patchedDependencies:
   '@astrojs/vercel':
-    hash: 1da962e6d07ae633b3193351f8aebc9172860429b2a0dbba63868eaf575dca04
+    hash: c22f3e6f7ef636ebf4d9aa9ca72b29e63c92cab60f4a319c03111ba6abafb8b5
     path: patches/@astrojs__vercel.patch
   astro:
     hash: 386a5b6c1c031ad8b1c2c74a36bf3db1d6bd6cdc4adab389147f24792c7a752e
@@ -57,7 +57,7 @@ importers:
         version: 6.0.2(astro@5.18.0(patch_hash=386a5b6c1c031ad8b1c2c74a36bf3db1d6bd6cdc4adab389147f24792c7a752e)(@types/node@25.3.1)(@vercel/functions@2.2.13)(jiti@2.6.1)(lightningcss@1.31.1)(rollup@4.59.0)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2))(tailwindcss@4.2.1)(ts-node@10.9.1(@swc/core@1.15.13(@swc/helpers@0.5.19))(@types/node@25.3.1)(typescript@5.9.3))
       '@astrojs/vercel':
         specifier: ^9.0.4
-        version: 9.0.4(patch_hash=1da962e6d07ae633b3193351f8aebc9172860429b2a0dbba63868eaf575dca04)(astro@5.18.0(patch_hash=386a5b6c1c031ad8b1c2c74a36bf3db1d6bd6cdc4adab389147f24792c7a752e)(@types/node@25.3.1)(@vercel/functions@2.2.13)(jiti@2.6.1)(lightningcss@1.31.1)(rollup@4.59.0)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2))(react@19.2.4)(rollup@4.59.0)(vue-router@4.6.3(vue@3.5.29(typescript@5.9.3)))(vue@3.5.29(typescript@5.9.3))
+        version: 9.0.4(patch_hash=c22f3e6f7ef636ebf4d9aa9ca72b29e63c92cab60f4a319c03111ba6abafb8b5)(astro@5.18.0(patch_hash=386a5b6c1c031ad8b1c2c74a36bf3db1d6bd6cdc4adab389147f24792c7a752e)(@types/node@25.3.1)(@vercel/functions@2.2.13)(jiti@2.6.1)(lightningcss@1.31.1)(rollup@4.59.0)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2))(react@19.2.4)(rollup@4.59.0)(vue-router@4.6.3(vue@3.5.29(typescript@5.9.3)))(vue@3.5.29(typescript@5.9.3))
       '@iconify/json':
         specifier: ^2.2.443
         version: 2.2.443
@@ -7867,7 +7867,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@astrojs/vercel@9.0.4(patch_hash=1da962e6d07ae633b3193351f8aebc9172860429b2a0dbba63868eaf575dca04)(astro@5.18.0(patch_hash=386a5b6c1c031ad8b1c2c74a36bf3db1d6bd6cdc4adab389147f24792c7a752e)(@types/node@25.3.1)(@vercel/functions@2.2.13)(jiti@2.6.1)(lightningcss@1.31.1)(rollup@4.59.0)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2))(react@19.2.4)(rollup@4.59.0)(vue-router@4.6.3(vue@3.5.29(typescript@5.9.3)))(vue@3.5.29(typescript@5.9.3))':
+  '@astrojs/vercel@9.0.4(patch_hash=c22f3e6f7ef636ebf4d9aa9ca72b29e63c92cab60f4a319c03111ba6abafb8b5)(astro@5.18.0(patch_hash=386a5b6c1c031ad8b1c2c74a36bf3db1d6bd6cdc4adab389147f24792c7a752e)(@types/node@25.3.1)(@vercel/functions@2.2.13)(jiti@2.6.1)(lightningcss@1.31.1)(rollup@4.59.0)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2))(react@19.2.4)(rollup@4.59.0)(vue-router@4.6.3(vue@3.5.29(typescript@5.9.3)))(vue@3.5.29(typescript@5.9.3))':
     dependencies:
       '@astrojs/internal-helpers': 0.7.5
       '@vercel/analytics': 1.6.1(react@19.2.4)(vue-router@4.6.3(vue@3.5.29(typescript@5.9.3)))(vue@3.5.29(typescript@5.9.3))


### PR DESCRIPTION
## Summary

- Regenerates the `@astrojs/vercel` patch to work with v9.0.4 (previously written against v9.0.2)
- The deps update in #382 bumped the adapter version, causing the `dist/index.js` hunk of the patch to silently fail while the `.d.ts` hunk still applied — so `cspMode: "global"` passed type-checking but was ignored at runtime
- Without the patch, every static page gets its own CSP route entry in Vercel's `config.json`, exceeding the 5MB deployment body limit

Deploy is failing on Vercel https://vercel.com/aptoslabs/aptos-docs/8iC9BK3YT8LJ1x2SYN8qfHcnk6UG

## Test plan

- [ ] Verify Vercel preview deployment succeeds (no "Body exceeded 5mb limit" error)
- [ ] Verify CSP headers are still present on deployed pages

Made with [Cursor](https://cursor.com)