### PR TITLE
Redesign documentation navigation to horizontal top nav bar

### DIFF
--- a/src/components/TopNav.astro
+++ b/src/components/TopNav.astro
@@ -1,0 +1,118 @@
+---
+import { sidebarGroupIcons } from "../../astro.sidebar.ts";
+import labels from "../content/nav/en";
+
+interface SidebarEntry {
+  type: string;
+  label: string;
+  href?: string;
+  isCurrent?: boolean;
+  entries?: SidebarEntry[];
+  [key: string]: unknown;
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const sidebarData = (Astro.locals.starlightRoute?.sidebar ?? []) as any as SidebarEntry[];
+
+const labelToKey: Record<string, string> = {};
+for (const [key, val] of Object.entries(labels)) {
+  if (typeof val === "string") labelToKey[val] = key;
+}
+
+function findFirstLink(entries: SidebarEntry[]): string | null {
+  for (const entry of entries) {
+    if (entry.type === "link" && entry.href) return entry.href;
+    if (entry.type === "group" && entry.entries) {
+      const link = findFirstLink(entry.entries);
+      if (link) return link;
+    }
+  }
+  return null;
+}
+
+function hasCurrentPage(entries: SidebarEntry[]): boolean {
+  return entries.some((entry) => {
+    if (entry.type === "link") return !!entry.isCurrent;
+    if (entry.type === "group" && entry.entries) return hasCurrentPage(entry.entries);
+    return false;
+  });
+}
+
+const topGroups = sidebarData
+  .filter((item): item is SidebarEntry & { entries: SidebarEntry[] } => item.type === "group")
+  .map((group, index) => {
+    let key = labelToKey[group.label] || "";
+    if (!key) {
+      const iconKeys = Object.keys(sidebarGroupIcons);
+      if (index < iconKeys.length) key = iconKeys[index] as string;
+    }
+    if (!key) key = group.label.toLowerCase().replace(/\s+/g, "");
+
+    return {
+      label: group.label,
+      icon: sidebarGroupIcons[key] || "ph:rocket-launch",
+      href: findFirstLink(group.entries) || "#",
+      isActive: hasCurrentPage(group.entries),
+    };
+  });
+---
+
+<nav class="top-nav" aria-label="Main navigation">
+  <div class="top-nav-inner">
+    {
+      topGroups.map(({ label, href, isActive }) => (
+        <a class:list={["top-nav-item", { active: isActive }]} href={href}>
+          {label}
+        </a>
+      ))
+    }
+  </div>
+</nav>
+
+<style>
+  .top-nav {
+    border-bottom: 1px solid var(--sl-color-hairline-shade);
+    background-color: var(--sl-color-bg-nav);
+    overflow-x: auto;
+    overflow-y: hidden;
+    scrollbar-width: none;
+    -ms-overflow-style: none;
+  }
+  .top-nav::-webkit-scrollbar {
+    display: none;
+  }
+
+  .top-nav-inner {
+    display: flex;
+    align-items: center;
+    gap: 0;
+    padding: 0 var(--sl-nav-pad-x);
+    max-width: 100%;
+  }
+
+  .top-nav-item {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.375rem;
+    padding: 0.625rem 0.875rem;
+    font-size: var(--sl-text-sm);
+    font-weight: 500;
+    color: var(--sl-color-gray-3);
+    text-decoration: none;
+    white-space: nowrap;
+    border-bottom: 2px solid transparent;
+    transition:
+      color 0.15s ease,
+      border-color 0.15s ease;
+    margin-bottom: -1px;
+  }
+
+  .top-nav-item:hover {
+    color: var(--sl-color-white);
+  }
+
+  .top-nav-item.active {
+    color: var(--sl-color-white);
+    border-bottom-color: var(--sl-color-text-accent);
+  }
+</style>

--- a/src/starlight-overrides/Header.astro
+++ b/src/starlight-overrides/Header.astro
@@ -18,22 +18,20 @@ const shouldRenderSearch =
   config.pagefind || config.components.Search !== "@astrojs/starlight/components/Search.astro";
 ---
 
-<div class="header-row">
-  <div class="header">
-    <div class="title-wrapper sl-flex">
-      <SiteTitle />
+<div class="header-inner">
+  <div class="title-wrapper sl-flex">
+    <SiteTitle />
+  </div>
+  <div class="sl-flex print:hidden">
+    {shouldRenderSearch && <Search />}
+  </div>
+  <div class="sl-hidden md:sl-flex print:hidden right-group">
+    <div class="sl-flex social-icons">
+      <SocialIcons />
     </div>
-    <div class="sl-flex print:hidden">
-      {shouldRenderSearch && <Search />}
-    </div>
-    <div class="sl-hidden md:sl-flex print:hidden right-group">
-      <div class="sl-flex social-icons">
-        <SocialIcons />
-      </div>
-      <ThemeSelect />
-      <LanguageSelect />
-      <ChatButton />
-    </div>
+    <ThemeSelect />
+    <LanguageSelect />
+    <ChatButton />
   </div>
 </div>
 
@@ -45,16 +43,13 @@ const shouldRenderSearch =
 
 <style>
   @layer starlight.core {
-    .header-row {
-      /* The header row itself — no changes needed */
-    }
-
-    .header {
+    .header-inner {
       display: flex;
       gap: var(--sl-nav-gap);
       justify-content: space-between;
       align-items: center;
-      height: 100%;
+      height: var(--sl-nav-height);
+      flex-shrink: 0;
     }
 
     .title-wrapper {
@@ -78,7 +73,6 @@ const shouldRenderSearch =
     .top-nav-row {
       border-top: 1px solid var(--sl-color-hairline-shade);
       margin: 0 calc(-1 * var(--sl-nav-pad-x));
-      margin-bottom: calc(-1 * var(--sl-nav-pad-y));
     }
 
     @media (min-width: 50rem) {
@@ -88,7 +82,7 @@ const shouldRenderSearch =
       :global(:root:not([data-has-toc])) {
         --__toc-width: 0rem;
       }
-      .header {
+      .header-inner {
         --__sidebar-width: max(0rem, var(--sl-content-inline-start, 0rem) - var(--sl-nav-pad-x));
         --__main-column-fr: calc(
           (

--- a/src/starlight-overrides/Header.astro
+++ b/src/starlight-overrides/Header.astro
@@ -9,6 +9,7 @@ import ThemeSelect from "virtual:starlight/components/ThemeSelect";
 
 import ChatButton from "../components/chat-widget/ChatButton.astro";
 import ChatDialog from "../components/chat-widget/ChatDialog.astro";
+import TopNav from "../components/TopNav.astro";
 
 /**
  * Render the `Search` component if Pagefind is enabled or the default search component has been overridden.
@@ -17,26 +18,37 @@ const shouldRenderSearch =
   config.pagefind || config.components.Search !== "@astrojs/starlight/components/Search.astro";
 ---
 
-<div class="header">
-  <div class="title-wrapper sl-flex">
-    <SiteTitle />
-  </div>
-  <div class="sl-flex print:hidden">
-    {shouldRenderSearch && <Search />}
-  </div>
-  <div class="sl-hidden md:sl-flex print:hidden right-group">
-    <div class="sl-flex social-icons">
-      <SocialIcons />
+<div class="header-row">
+  <div class="header">
+    <div class="title-wrapper sl-flex">
+      <SiteTitle />
     </div>
-    <ThemeSelect />
-    <LanguageSelect />
-    <ChatButton />
+    <div class="sl-flex print:hidden">
+      {shouldRenderSearch && <Search />}
+    </div>
+    <div class="sl-hidden md:sl-flex print:hidden right-group">
+      <div class="sl-flex social-icons">
+        <SocialIcons />
+      </div>
+      <ThemeSelect />
+      <LanguageSelect />
+      <ChatButton />
+    </div>
   </div>
 </div>
 
+<div class="top-nav-row sl-hidden md:sl-block print:hidden">
+  <TopNav />
+</div>
+
 <ChatDialog />
+
 <style>
   @layer starlight.core {
+    .header-row {
+      /* The header row itself — no changes needed */
+    }
+
     .header {
       display: flex;
       gap: var(--sl-nav-gap);
@@ -46,9 +58,7 @@ const shouldRenderSearch =
     }
 
     .title-wrapper {
-      /* Prevent long titles overflowing and covering the search and menu buttons on narrow viewports. */
       overflow: clip;
-      /* Avoid clipping focus ring around link inside title wrapper. */
       padding: 0.25rem;
       margin: -0.25rem;
       min-width: 0;
@@ -63,6 +73,12 @@ const shouldRenderSearch =
       content: "";
       height: 2rem;
       border-inline-end: 1px solid var(--sl-color-gray-5);
+    }
+
+    .top-nav-row {
+      border-top: 1px solid var(--sl-color-hairline-shade);
+      margin: 0 calc(-1 * var(--sl-nav-pad-x));
+      margin-bottom: calc(-1 * var(--sl-nav-pad-y));
     }
 
     @media (min-width: 50rem) {
@@ -84,14 +100,11 @@ const shouldRenderSearch =
         );
         display: grid;
         grid-template-columns:
-        /* 1 (site title): runs up until the main content column’s left edge or the width of the title, whichever is the largest  */
           minmax(
             calc(var(--__sidebar-width) + max(0rem, var(--__main-column-fr) - var(--sl-nav-gap))),
             auto
           )
-          /* 2 (search box): all free space that is available. */
           1fr
-          /* 3 (right items): use the space that these need. */
           auto;
         align-content: center;
       }

--- a/src/starlight-overrides/PageFrame.astro
+++ b/src/starlight-overrides/PageFrame.astro
@@ -33,7 +33,6 @@ const { hasSidebar } = Astro.locals.starlightRoute;
 <style>
   @layer starlight.core {
     .page {
-      /* flex-direction: column; */
       min-height: 100vh;
     }
 
@@ -75,9 +74,9 @@ const { hasSidebar } = Astro.locals.starlightRoute;
     .sidebar-content {
       height: 100%;
       min-height: max-content;
-      padding: 1rem var(--sl-sidebar-pad-x) 0;
+      padding: 0;
       flex-direction: column;
-      gap: 1rem;
+      gap: 0;
     }
 
     @media (min-width: 50rem) {
@@ -89,7 +88,6 @@ const { hasSidebar } = Astro.locals.starlightRoute;
 
     .main-frame {
       padding-top: calc(var(--sl-nav-height) + var(--sl-mobile-toc-height));
-      /* padding-inline-start: var(--sl-content-inline-start); */
       flex-grow: 1;
       max-width: 100%;
     }

--- a/src/starlight-overrides/PageFrame.astro
+++ b/src/starlight-overrides/PageFrame.astro
@@ -55,16 +55,25 @@ const { hasSidebar } = Astro.locals.starlightRoute;
       );
     }
 
+    @media (min-width: 50rem) {
+      .header {
+        display: flex;
+        flex-direction: column;
+        height: var(--sl-header-total-height, var(--sl-nav-height));
+        padding-bottom: 0;
+      }
+    }
+
     .sidebar-pane {
       visibility: var(--sl-sidebar-visibility, hidden);
       position: fixed;
-      height: calc(100dvh - var(--sl-nav-height));
       z-index: var(--sl-z-index-menu);
       inset-inline-start: 0;
       width: 100%;
       background-color: var(--sl-color-black);
       overflow-y: auto;
       top: var(--sl-nav-height);
+      height: calc(100dvh - var(--sl-nav-height));
     }
 
     :global([aria-expanded="true"]) ~ .sidebar-pane {
@@ -102,15 +111,22 @@ const { hasSidebar } = Astro.locals.starlightRoute;
         background-color: var(--sl-color-bg-sidebar);
         border-inline-end: 1px solid var(--sl-color-hairline-shade);
         position: sticky;
+        top: var(--sl-header-total-height, var(--sl-nav-height));
+        height: calc(100dvh - var(--sl-header-total-height, var(--sl-nav-height)));
+      }
+      .main-frame {
+        padding-top: calc(
+          var(--sl-header-total-height, var(--sl-nav-height)) + var(--sl-mobile-toc-height)
+        );
       }
     }
+
     .global-footer {
-      display: block;
+      display: flex;
       width: 100%;
       border-top: 1px solid var(--sl-color-hairline);
       text-align: center;
       padding: 2rem 0;
-      display: flex;
       justify-content: center;
       align-items: center;
       gap: 1rem;

--- a/src/starlight-overrides/Sidebar.astro
+++ b/src/starlight-overrides/Sidebar.astro
@@ -1,33 +1,21 @@
 ---
-// Handle Starlight sidebar integration
-import { Icon } from "astro-icon/components";
 import SidebarPersister from "@astrojs/starlight/components/SidebarPersister.astro";
 import SidebarSublist from "@astrojs/starlight/components/SidebarSublist.astro";
 import MobileMenuFooter from "@astrojs/starlight/components/MobileMenuFooter.astro";
 import { stripLeadingAndTrailingSlashes } from "node_modules/@astrojs/starlight/utils/path";
-import { sidebarGroupIcons } from "../../astro.sidebar.ts";
-import labels from "../../src/content/nav/en";
-import TabbedContent from "~/components/tabs/TabbedContent.astro";
-import TabListItem from "~/components/tabs/TabListItem.astro";
-import TabPanel from "~/components/tabs/TabPanel.astro";
 import { stripLangFromSlug } from "~/utils/path-utils";
 import { isSubPage } from "~/utils/isSubPage";
 import SidebarAutoScroll from "~/components/SidebarAutoScroll.astro";
 import ChatButton from "~/components/chat-widget/ChatButton.astro";
+import TopNav from "~/components/TopNav.astro";
 
-// Constants
 const MOVE_REFERENCE_PATH = "move-reference";
 
-// Get sidebar data
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
 const sidebarData = Astro.locals.starlightRoute ? Astro.locals.starlightRoute.sidebar : [];
 const { id } = Astro.props;
 const currentPath = Astro.url.pathname;
-
-// Simple and direct check for Move Reference pages in any URL format
 const isMoveReference = currentPath.includes(`/${MOVE_REFERENCE_PATH}`);
 
-// Interface for sidebar entries
 interface SidebarEntryType {
   type: string;
   label: string;
@@ -38,7 +26,6 @@ interface SidebarEntryType {
   [key: string]: unknown;
 }
 
-// Process sidebar entries to mark current pages
 function markEntries(i: SidebarEntryType): void {
   if (i.type === "group" && i.entries) {
     i.entries.forEach(markEntries);
@@ -46,27 +33,23 @@ function markEntries(i: SidebarEntryType): void {
     const itemSlug = stripLeadingAndTrailingSlashes(i.href);
     const itemSlugWithoutLang = stripLangFromSlug(itemSlug);
 
-    // Only highlight the specific move-reference page that's currently being visited
     if (
       isMoveReference &&
       (itemSlug.includes(MOVE_REFERENCE_PATH) || itemSlugWithoutLang.includes(MOVE_REFERENCE_PATH))
     ) {
-      // Check if the current path matches or is a subpath of this specific item
       const currentPathWithoutLang = stripLangFromSlug(stripLeadingAndTrailingSlashes(currentPath));
       i.isCurrent =
         currentPathWithoutLang === itemSlugWithoutLang ||
         currentPathWithoutLang.startsWith(itemSlugWithoutLang + "/");
-      if (i.isCurrent) return; // Exit early only if we've found a match
+      if (i.isCurrent) return;
     }
 
     if (i.isCurrent !== undefined) {
-      // Regular check for other pages
       i.isCurrent = i.isCurrent || isSubPage(id, itemSlugWithoutLang);
     }
   }
 }
 
-// Apply markEntries to all sidebar items if they exist
 if (Array.isArray(sidebarData)) {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   (sidebarData as any[]).forEach((item) => {
@@ -74,49 +57,23 @@ if (Array.isArray(sidebarData)) {
   });
 }
 
-// Validate sidebar structure
-function assertGroups(sidebarItems: SidebarEntryType[]): SidebarEntryType[] {
-  for (const entry of sidebarItems) {
-    if (entry.type !== "group") {
-      throw new Error("Top-level links are not permitted in the docs sidebar.");
-    }
-  }
-  return sidebarItems;
-}
-
-// Create sidebar groups with validation
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-const sidebarGroups = Array.isArray(sidebarData) ? assertGroups(sidebarData as any) : [];
-
-// Generate id for tab panel from label
-const makeId = (label: string): string => {
-  if (!label) return "__tab-unknown";
-  return "__tab-" + label.toLowerCase().replaceAll(/\s+/g, "-");
-};
-
-// Check if a sidebar section contains the current page
-function isCurrent(sidebarItems: SidebarEntryType[]): boolean {
-  if (!Array.isArray(sidebarItems) || sidebarItems.length === 0) return false;
-
-  return sidebarItems.some((entry) => {
-    if (!entry) return false;
-
-    if (entry.type === "link") {
-      return !!entry.isCurrent;
-    } else if (entry.type === "group" && Array.isArray(entry.entries) && entry.entries.length > 0) {
-      return isCurrent(entry.entries);
-    }
+function hasCurrentPage(entries: SidebarEntryType[]): boolean {
+  return entries.some((entry) => {
+    if (entry.type === "link") return !!entry.isCurrent;
+    if (entry.type === "group" && entry.entries) return hasCurrentPage(entry.entries);
     return false;
   });
 }
 
-// Create a reverse mapping from label to key
-const labelToKey: Record<string, string> = {};
-Object.entries(labels).forEach(([key, val]) => {
-  if (typeof val === "string") {
-    labelToKey[val] = key;
-  }
-});
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const sidebarGroups = (Array.isArray(sidebarData) ? sidebarData : []) as any as SidebarEntryType[];
+
+const activeGroup = sidebarGroups.find(
+  (group) => group.type === "group" && group.entries && hasCurrentPage(group.entries),
+);
+const activeEntries = activeGroup?.entries ?? sidebarGroups[0]?.entries ?? [];
+const activeSectionLabel = activeGroup?.label ?? "";
 ---
 
 <SidebarPersister {...Astro.props}>
@@ -124,61 +81,30 @@ Object.entries(labels).forEach(([key, val]) => {
   <div class="md:sl-hidden mobile-chat-container">
     <ChatButton isMobile={true} />
   </div>
-  <TabbedContent class="tabbed-sidebar">
-    <Fragment slot="tab-list">
-      {
-        sidebarGroups.map(({ label, entries }, index) => {
-          // Try to find the key by looking at the translations object
-          let sidebarKey = "";
 
-          // First try to look up the key directly from English labels
-          if (label in labelToKey) {
-            sidebarKey = labelToKey[label] as string;
-          }
+  {/* Mobile: show TopNav inside the sidebar drawer */}
+  <div class="md:sl-hidden mobile-top-nav">
+    <TopNav />
+  </div>
 
-          // If that fails, try to find the key by index in the sidebar groups
-          // This assumes the sidebar groups are in the same order as the keys in sidebarGroupIcons
-          if (!sidebarKey) {
-            // Get the keys of sidebarGroupIcons in order
-            const iconKeys = Object.keys(sidebarGroupIcons);
-            // Use the index to get the corresponding key
-            if (index < iconKeys.length) {
-              sidebarKey = iconKeys[index] as string;
-            }
-          }
+  {/* Section title */}
+  {
+    activeSectionLabel && (
+      <div class="sidebar-section-title">
+        <span>{activeSectionLabel}</span>
+      </div>
+    )
+  }
 
-          // If all else fails, fall back to a simple transformation of the label
-          if (!sidebarKey) {
-            sidebarKey = label.toLowerCase().replace(/\s+/g, "");
-          }
-
-          // Look up the icon from the mapping, or use a default
-          const iconName = sidebarGroupIcons[sidebarKey] || "ph:rocket-launch";
-
-          return (
-            <TabListItem
-              id={makeId(label)}
-              initial={entries && isCurrent(entries)}
-              class="tab-item"
-            >
-              <Icon size="24" class="icon" name={iconName} /> {label}
-            </TabListItem>
-          );
-        })
-      }
-    </Fragment>
+  {/* Sub-navigation entries */}
+  <div class="sidebar-entries">
     {
-      sidebarGroups.map(({ label, entries }) => (
-        <TabPanel id={makeId(label)} initial={entries && isCurrent(entries)}>
-          {/* The entries are compatible with what SidebarSublist expects */}
-          {entries && (
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            <SidebarSublist sublist={entries as any} />
-          )}
-        </TabPanel>
-      ))
+      activeEntries && (
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        <SidebarSublist sublist={activeEntries as any} />
+      )
     }
-  </TabbedContent>
+  </div>
 </SidebarPersister>
 
 <div class="md:sl-hidden">
@@ -186,7 +112,6 @@ Object.entries(labels).forEach(([key, val]) => {
 </div>
 
 <style>
-  /** Add "EN" to the end of sidebar items with the `fallback` class. */
   :global(.fallback)::after {
     content: "EN";
     vertical-align: super;
@@ -194,101 +119,27 @@ Object.entries(labels).forEach(([key, val]) => {
     font-weight: 700;
   }
 
-  /** Align sponsors at sidebar bottom when there is room. */
-  .desktop-footer {
-    margin-top: auto;
-  }
-
-  /** Always show the scrollbar gutter. */
   :global(.sidebar-pane) {
     overflow-y: scroll;
   }
 
-  /* Styles for the custom tab switcher. */
-  .tabbed-sidebar {
-    /* Layout variables */
-    --tab-switcher-border-width: 1px;
-    --tab-switcher-padding: calc(0.25rem - var(--tab-switcher-border-width));
-    --tab-item-border-radius: var(--global-radius);
-    --tab-switcher-border-radius: var(--global-radius);
-
-    /* Color variables */
-    --tab-switcher-border-color: var(--sl-color-hairline-light);
-    --tab-switcher-background-color: var(--sl-color-gray-7, var(--sl-color-gray-6));
-    --tab-switcher-text-color: var(--sl-color-gray-3);
-    --tab-switcher-text-color--active: var(--sl-color-white);
-    --tab-switcher-icon-color: var(--sl-color-gray-4);
-    --tab-switcher-icon-color--active: var(--sl-color-text-accent);
-    --tab-item-background-color--hover: var(--sl-color-gray-6);
-    --tab-item-background-color--active: var(--sl-color-black);
-    padding: 1rem var(--sl-sidebar-pad-x) 0;
-  }
-  /* Dark theme variations */
-  :global([data-theme="dark"]) .tabbed-sidebar {
-    --tab-switcher-text-color: var(--sl-color-gray-2);
-    --tab-switcher-icon-color: var(--sl-color-gray-3);
-    --tab-item-background-color--hover: var(--sl-color-gray-5);
-  }
-
-  @media (min-width: 50rem) {
-    /* Dark theme variations with the desktop sidebar visible */
-    :global([data-theme="dark"]) .tabbed-sidebar {
-      --tab-switcher-background-color: color-mix(in srgb, var(--sl-color-white) 1%, transparent);
-      --tab-item-background-color--hover: var(--sl-color-gray-6);
-      --tab-item-background-color--active: var(--sl-color-gray-6);
-    }
-  }
-
-  .tabbed-sidebar.tab-list {
-    /* border: var(--tab-switcher-border-width) solid var(--tab-switcher-border-color); */
-    border-radius: var(--tab-switcher-border-radius);
-    display: flex;
-    flex-direction: column;
-    gap: 0.25rem;
-    padding: var(--tab-switcher-padding);
-    background-color: transparent;
-    /* margin-bottom: 1.5rem; */
-    padding: 1rem var(--sl-sidebar-pad-x);
-    border-bottom: 1px solid var(--sl-color-hairline);
-  }
-
-  .tab-item :global(a) {
-    border: var(--tab-switcher-border-width) solid transparent;
-    border-radius: var(--tab-item-border-radius);
-    display: flex;
-    align-items: center;
-    gap: 0.5rem;
-    padding: calc(0.5rem - var(--tab-switcher-border-width));
-    background-clip: padding-box;
-    line-height: var(--sl-line-height-headings);
-    text-decoration: none;
-    color: var(--tab-switcher-text-color);
-    font-weight: 600;
-    font-size: large;
-  }
-
-  .tab-item :global(a:hover) {
-    color: var(--tab-switcher-text-color--active);
-    background-color: var(--tab-item-background-color--hover);
-  }
-  .tab-item :global(a[aria-selected="true"]) {
-    border-color: var(--tab-switcher-border-color);
-    color: var(--tab-switcher-text-color--active);
-    background-color: var(--tab-item-background-color--active);
-  }
-
-  .icon {
-    margin: 0.25rem;
-    color: var(--tab-switcher-icon-color);
-  }
-  .tab-item :global(a:hover) .icon {
-    color: inherit;
-  }
-  .tab-item :global(a[aria-selected="true"]) .icon {
-    color: var(--tab-switcher-icon-color--active);
-  }
-
   .mobile-chat-container {
     border-bottom: 1px solid var(--sl-color-hairline);
+  }
+
+  .mobile-top-nav {
+    border-bottom: 1px solid var(--sl-color-hairline);
+  }
+
+  .sidebar-section-title {
+    padding: 1rem var(--sl-sidebar-pad-x) 0.5rem;
+    font-size: var(--sl-text-lg);
+    font-weight: 600;
+    color: var(--sl-color-white);
+    line-height: var(--sl-line-height-headings);
+  }
+
+  .sidebar-entries {
+    padding: 0.5rem var(--sl-sidebar-pad-x) 1rem;
   }
 </style>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -14,6 +14,14 @@
   }
 }
 
+/* Top navigation bar height (desktop only) */
+@media (min-width: 50rem) {
+  :root {
+    --sl-top-nav-height: 2.75rem;
+    --sl-header-total-height: calc(var(--sl-nav-height) + var(--sl-top-nav-height));
+  }
+}
+
 /* Chat Widget Styles */
 :root {
   --chat-header-height: 3.5rem;


### PR DESCRIPTION
## Redesign: Move Top-Level Navigation to Horizontal Top Nav Bar

Redesign the documentation navigation to follow the pattern used by [Claude Code Docs](https://docs.anthropic.com/en/docs/claude-code/overview) and other modern documentation sites (e.g. Stripe, Vercel).

### Problem

The current sidebar uses vertical **tabs** for top-level categories (Guides, SDKs & Tools, Smart Contracts, etc.), which takes up significant vertical space and requires users to click a tab before seeing sub-navigation. This pattern is less discoverable and harder to scan than a horizontal top navigation bar.

### Solution

Move top-level categories to a **horizontal navigation bar** positioned below the main header, and simplify the left sidebar to show **only the sub-navigation** for the currently active section.


### Files Changed

| File | Change |
|------|--------|
| `src/components/TopNav.astro` | **New** — Horizontal nav component: reads sidebar data, extracts top-level groups, renders as links with active underline indicator |
| `src/starlight-overrides/Header.astro` | Integrated TopNav as second row; renamed inner div to avoid class conflict with PageFrame |
| `src/starlight-overrides/Sidebar.astro` | **Major simplification** — Removed `TabbedContent` tab switcher (−193 lines), now renders only the active section's entries with a section title |
| `src/starlight-overrides/PageFrame.astro` | Desktop header uses `flex-direction: column` for two-row layout; sidebar/content offset via `--sl-header-total-height` |
| `src/styles/global.css` | Added `--sl-top-nav-height` and `--sl-header-total-height` CSS custom properties |

### Responsive Behavior

- **Desktop (≥50rem)**: TopNav shown in header bar; sidebar shows sub-navigation only
- **Mobile (<50rem)**: TopNav hidden from header; shown inside the sidebar drawer so mobile users can still switch sections

### Verification

- [x] `pnpm check` — 0 errors, 0 warnings, 0 hints (192 files)
- [x] `pnpm lint` — biome + prettier both pass
- [x] `pnpm build` — Full production build succeeds (1150 HTML pages)
- [x] `pnpm test` — 14/14 tests pass
- [x] **Link validation** — `✓ All internal links are valid` (built-in starlight-links-validator)
- [x] **No URL breakage** — No routes were added/removed/renamed; all existing URLs work as before

### What This Does NOT Change

- **No URL changes** — All page URLs remain identical
- **No content changes** — Documentation text/translations are untouched
- **No sidebar config changes** — `astro.sidebar.ts` is not modified; sidebar data structure is the same
- **No dependency changes** — No packages added or removed
