### PR TITLE
feat: improve AI documentation discoverability

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -155,10 +155,15 @@ export default defineConfig({
           rawContent: true,
           description:
             "Developer documentation for the Aptos blockchain — Move smart contracts, SDKs, APIs, indexer, node operations, and AI tools.",
+          details: [
+            "For AI coding tools, install the Aptos MCP server: `npx @aptos-labs/aptos-mcp`",
+            "It gives your IDE direct access to Aptos APIs, on-chain data, and Move contract helpers.",
+            "See <https://aptos.dev/build/ai> for setup guides (Claude Code, Cursor, and more).",
+          ].join("\n"),
           optionalLinks: [
             {
               label: "Aptos MCP Server",
-              url: "https://www.npmjs.com/package/@anthropic-ai/aptos-mcp",
+              url: "https://www.npmjs.com/package/@aptos-labs/aptos-mcp",
               description: "MCP server for AI coding tools",
             },
             {

--- a/src/starlight-overrides/Head.astro
+++ b/src/starlight-overrides/Head.astro
@@ -149,6 +149,9 @@ const breadcrumbItems = [
 {/* Critical CSS with high fetch priority */}
 <link rel="preload" href={globalCssUrl} as="style" fetchpriority="high" />
 
+{/* LLMs.txt discovery: lets any LLM fetching any page find the machine-readable docs */}
+<link rel="llms-txt" href="/llms.txt" />
+
 {/* hreflang x-default: tells search engines which URL to serve when no locale matches */}
 <link rel="alternate" hreflang="x-default" href={getLanguageUrl("en")} />
 

--- a/vercel.json
+++ b/vercel.json
@@ -25,6 +25,21 @@
   ],
   "redirects": [
     {
+      "source": "/.well-known/llms.txt",
+      "destination": "/llms.txt",
+      "permanent": true
+    },
+    {
+      "source": "/en",
+      "destination": "/",
+      "permanent": true
+    },
+    {
+      "source": "/en/:path*",
+      "destination": "/:path*",
+      "permanent": true
+    },
+    {
       "source": "/tutorials/:path*",
       "destination": "/build/guides/:path*",
       "permanent": true


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Four changes to help AI agents and LLMs discover and navigate the Aptos docs more efficiently:

### 1. `<link rel="llms-txt">` in every page's `<head>`

Any LLM that fetches _any_ page on aptos.dev will now see:

```html
<link rel="llms-txt" href="/llms.txt" />
```

This is the emerging convention for LLMs.txt discovery (analogous to `<link rel="sitemap">`).

**File:** `src/starlight-overrides/Head.astro`

### 2. `/.well-known/llms.txt` redirect

Added a permanent (301) redirect from `/.well-known/llms.txt` → `/llms.txt` at the CDN level.  
This is the emerging standard well-known path for LLMs.txt, and currently returns a 404.

**File:** `vercel.json`

### 3. `/en/*` → `/*` permanent redirects at CDN level

Old `/en/build`-style URLs (from the previous docs site) now 301-redirect to the correct path at the CDN edge, instead of relying solely on the server middleware (which returns a 302). This eliminates dead ends for LLM agents that still have cached `/en/` URLs.

**File:** `vercel.json`

### 4. MCP server mentioned in `llms.txt`

The generated `llms.txt` now includes a `details` section that tells LLMs:

> For AI coding tools, install the Aptos MCP server: `npx @aptos-labs/aptos-mcp`  
> It gives your IDE direct access to Aptos APIs, on-chain data, and Move contract helpers.  
> See https://aptos.dev/build/ai for setup guides (Claude Code, Cursor, and more).

This complements the `description` and `optionalLinks` added in #379.

**File:** `astro.config.mjs` (starlightLlmsTxt `details` option)

### Bonus fix

Fixed the MCP server npm URL in `optionalLinks` from `@anthropic-ai/aptos-mcp` to `@aptos-labs/aptos-mcp` (introduced in #379).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d6a79aa5-79ab-4a31-af52-f017c569e529"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d6a79aa5-79ab-4a31-af52-f017c569e529"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

