### PR TITLE
chore: update cloud agent environment to Node 24+ with pnpm auto-install

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -216,8 +216,10 @@ This is a single-service Astro/Starlight documentation site. No databases, Docke
 
 ### Environment setup
 
+- The VM snapshot provides Node 24+ (via nvm) and pnpm 10.30.3. The update script runs `pnpm install` automatically, so Biome, TypeScript, and Vitest are ready without manual setup.
 - Ensure `.env` exists (copy from `.env.example` if missing). Default values are sufficient for local dev; optional services (Firebase, Algolia, OG images) degrade gracefully when their env vars are empty.
-- Run `pnpm install` to install dependencies. pnpm may warn about ignored build scripts for native packages (`@swc/core`, `esbuild`, `sharp`, etc.) — these warnings are safe to ignore as the packages ship pre-built binaries.
+- pnpm may warn about ignored build scripts for native packages (`@swc/core`, `esbuild`, `sharp`, etc.) — these warnings are safe to ignore as the packages ship pre-built binaries.
+- The repo's `.nvmrc` says `v22` and `engines` says `>=22`, but Node 24 is fully compatible and is what this environment uses.
 
 ### Running the dev server
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Updates the Cursor Cloud agent environment to use **Node 24+** (v24.14.0 LTS Krypton) with **pnpm 10.30.3**, and automatically runs `pnpm install` on startup so Biome, TypeScript, and Vitest are ready without manual setup.

### Changes

- Updated `AGENTS.md` Cursor Cloud specific instructions to document Node 24+ environment
- Noted that the repo's `.nvmrc` (v22) and `engines` (>=22) are fully compatible with Node 24

### Update script (runs on VM startup)

```bash
. "$NVM_DIR/nvm.sh"
nvm install 24 --default
npm install -g pnpm@10.30.3
pnpm install
test -f .env || cp .env.example .env
```

### Verified on Node 24

| Check | Command | Result |
|---|---|---|
| Biome | `pnpm lint:biome` | 120 files, no issues |
| Prettier | `pnpm lint:prettier` | All files pass |
| TypeScript | `pnpm check` | 192 files, 0 errors |
| Vitest | `pnpm test` | 9 passed, 4 skipped |
| Dev server | `pnpm dev` | Running at localhost:4321 |
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9384793a-d1eb-4335-b459-a8b5d02be131"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9384793a-d1eb-4335-b459-a8b5d02be131"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

