### PR TITLE
fix: update broken create-aptos-dapp template links

### DIFF
--- a/src/content/docs/build/create-aptos-dapp.mdx
+++ b/src/content/docs/build/create-aptos-dapp.mdx
@@ -83,11 +83,11 @@ The goals of the templates are to:
 
 All current templates are available on [Aptos Learn](https://learn.aptoslabs.com/en/dapp-templates). Read more about specific templates below:
 
-- [Boilerplate Template](https://learn.aptoslabs.com/en/dapp-templates/boilerplate-template)
-- [NFT minting dapp Template](https://learn.aptoslabs.com/en/dapp-templates/nft-minting-template)
-- [Token minting dapp Template](https://learn.aptoslabs.com/en/dapp-templates/token-minting-template)
-- [Token staking dapp Template](https://learn.aptoslabs.com/en/dapp-templates/token-staking-template)
-- [Custom indexer template](https://learn.aptoslabs.com/en/dapp-templates/custom-indexer-template)
+- [Boilerplate Template](https://github.com/aptos-labs/create-aptos-dapp/tree/main/templates/boilerplate-template)
+- [NFT minting dapp Template](https://github.com/aptos-labs/create-aptos-dapp/tree/main/templates/nft-minting-dapp-template)
+- [Token minting dapp Template](https://github.com/aptos-labs/create-aptos-dapp/tree/main/templates/token-minting-dapp-template)
+- [Token staking dapp Template](https://github.com/aptos-labs/create-aptos-dapp/tree/main/templates/token-staking-dapp-template)
+- [Custom indexer template](https://github.com/aptos-labs/create-aptos-dapp/tree/main/templates/custom-indexer-template)
 
 ## Tools `create-aptos-dapp` utilizes
 

--- a/src/content/docs/zh/build/create-aptos-dapp.mdx
+++ b/src/content/docs/zh/build/create-aptos-dapp.mdx
@@ -83,11 +83,11 @@ import { Steps, TabItem, Tabs } from '@astrojs/starlight/components';
 
 所有当前模板都可在 [Aptos Learn](https://learn.aptoslabs.com/en/dapp-templates) 上找到。下面阅读更多关于特定模板的信息：
 
-- [样板模板](https://learn.aptoslabs.com/en/dapp-templates/boilerplate-template)
-- [NFT 铸造 dapp 模板](https://learn.aptoslabs.com/en/dapp-templates/nft-minting-template)
-- [代币铸造 dapp 模板](https://learn.aptoslabs.com/en/dapp-templates/token-minting-template)
-- [代币质押 dapp 模板](https://learn.aptoslabs.com/en/dapp-templates/token-staking-template)
-- [自定义索引器模板](https://learn.aptoslabs.com/en/dapp-templates/custom-indexer-template)
+- [样板模板](https://github.com/aptos-labs/create-aptos-dapp/tree/main/templates/boilerplate-template)
+- [NFT 铸造 dapp 模板](https://github.com/aptos-labs/create-aptos-dapp/tree/main/templates/nft-minting-dapp-template)
+- [代币铸造 dapp 模板](https://github.com/aptos-labs/create-aptos-dapp/tree/main/templates/token-minting-dapp-template)
+- [代币质押 dapp 模板](https://github.com/aptos-labs/create-aptos-dapp/tree/main/templates/token-staking-dapp-template)
+- [自定义索引器模板](https://github.com/aptos-labs/create-aptos-dapp/tree/main/templates/custom-indexer-template)
 
 ## `create-aptos-dapp` 使用的工具
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes the broken template links on the `create-aptos-dapp` documentation page. All five individual template pages on `learn.aptoslabs.com/en/dapp-templates/*` are returning HTTP 500 errors, making the links non-functional for users.

## Changes

Updated all template links in both the English and Chinese versions to point to the corresponding GitHub repository template directories, which contain working README documentation:

- **Boilerplate Template** → `github.com/aptos-labs/create-aptos-dapp/tree/main/templates/boilerplate-template`
- **NFT minting dapp Template** → `github.com/aptos-labs/create-aptos-dapp/tree/main/templates/nft-minting-dapp-template`
- **Token minting dapp Template** → `github.com/aptos-labs/create-aptos-dapp/tree/main/templates/token-minting-dapp-template`
- **Token staking dapp Template** → `github.com/aptos-labs/create-aptos-dapp/tree/main/templates/token-staking-dapp-template`
- **Custom indexer template** → `github.com/aptos-labs/create-aptos-dapp/tree/main/templates/custom-indexer-template`

The parent "Aptos Learn" link (`learn.aptoslabs.com/en/dapp-templates`) still works and was left unchanged.

## Files Modified

- `src/content/docs/build/create-aptos-dapp.mdx` (English)
- `src/content/docs/zh/build/create-aptos-dapp.mdx` (Chinese)

Note: No Spanish version of this page exists.

## Testing

- Verified all old `learn.aptoslabs.com` individual template URLs return HTTP 500
- Verified all new GitHub URLs return HTTP 200
- Tested locally with dev server — all 5 links render correctly and point to working destinations
- Linting and formatting checks pass
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-410c2cf1-5c4d-4638-8cb2-26472c23f039"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-410c2cf1-5c4d-4638-8cb2-26472c23f039"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

