### PR TITLE
docs: remove broken Aptos Keyless StackBlitz demo

### DIFF
--- a/src/content/docs/build/guides/aptos-keyless.mdx
+++ b/src/content/docs/build/guides/aptos-keyless.mdx
@@ -17,23 +17,3 @@ sidebar:
 ## Using an IAM Provider? Integrate with Aptos Federated Keyless
 
 - [Federated Keyless](/build/guides/aptos-keyless/federated-keyless)
-
-## Example
-
-Visit this page to learn more [Simple Example](/build/guides/aptos-keyless/simple-example)
-
-<br />
-
-<iframe
-  src="https://stackblitz.com/edit/vitejs-vite-3fuvtu?embed=1&file=README.md"
-  style={{
-width: "100%",
-height: "800px",
-border: "0",
-borderRadius: "4px",
-overflow: "hidden",
-}}
-  title="aptos-keyless-example"
-  allow="accelerometer; ambient-light-sensor; camera; encrypted-media; geolocation; gyroscope; hid; microphone; midi; payment; usb; vr; xr-spatial-tracking"
-  sandbox="allow-forms allow-modals allow-popups allow-presentation allow-same-origin allow-scripts"
-/>

--- a/src/content/docs/build/guides/aptos-keyless/federated-keyless/simple-example.mdx
+++ b/src/content/docs/build/guides/aptos-keyless/federated-keyless/simple-example.mdx
@@ -7,6 +7,6 @@ sidebar:
 
 The Federated Keyless Example shows how to set up a Federated Keyless account using Auth0 as the IAM provider.
 
-Explore the code in [aptos-keyless-example repository](https://github.com/aptos-labs/aptos-keyless-example/tree/main/examples/federated-keyless-example/).
+Explore the code in the [aptos-keyless-example repository](https://github.com/aptos-labs/aptos-keyless-example/tree/main/examples/federated-keyless-example/).
 
-The Keyless Simple Example is currently undergoing maintenance. Please check back later.
+Follow the instructions in the repository's `README.md` to set up and run the example locally.

--- a/src/content/docs/build/guides/aptos-keyless/simple-example.mdx
+++ b/src/content/docs/build/guides/aptos-keyless/simple-example.mdx
@@ -1,28 +1,10 @@
 ---
 title: "Keyless Simple Example"
-description: "Interactive StackBlitz example demonstrating Keyless account integration with Google authentication and practical code samples."
+description: "Example demonstrating Keyless account integration with Google authentication and practical code samples."
 sidebar:
   label: "Simple Example"
 ---
 
-Explore the code in [aptos-keyless-example repository](https://github.com/aptos-labs/aptos-keyless-example/tree/main/examples/keyless-example/).
+Explore the code in the [aptos-keyless-example repository](https://github.com/aptos-labs/aptos-keyless-example/tree/main/examples/keyless-example/).
 
-The Keyless Simple Example is currently undergoing maintenance. Please check back later.
-
-This is a live Keyless example on StackBlitz. Follow the instructions in the `README.md` to add your own Google `client_id`. Explore the code in [aptos-keyless-example repository](https://github.com/aptos-labs/aptos-keyless-example/tree/main/examples/keyless-example/).
-
-<br />
-
-<iframe
-  src="https://stackblitz.com/edit/vitejs-vite-3fuvtu?embed=1&file=README.md"
-  style={{
-width: "100%",
-height: "800px",
-border: "0",
-borderRadius: "4px",
-overflow: "hidden",
-}}
-  title="aptos-keyless-example"
-  allow="accelerometer; ambient-light-sensor; camera; encrypted-media; geolocation; gyroscope; hid; microphone; midi; payment; usb; vr; xr-spatial-tracking"
-  sandbox="allow-forms allow-modals allow-popups allow-presentation allow-same-origin allow-scripts"
-/>
+Follow the instructions in the repository's `README.md` to set up and run the example locally with your own Google `client_id`.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Removes the broken StackBlitz iframe demo from the Aptos Keyless documentation pages. The embedded demo at `https://stackblitz.com/edit/vitejs-vite-3fuvtu` was inaccessible (access blocked), causing a poor user experience as reported in the linked issue.

## Changes

- **`src/content/docs/build/guides/aptos-keyless.mdx`** — Removed the entire "Example" section containing the broken StackBlitz iframe embed
- **`src/content/docs/build/guides/aptos-keyless/simple-example.mdx`** — Removed the StackBlitz iframe embed and stale maintenance notice; updated page to point users to the GitHub repository with instructions to run the example locally
- **`src/content/docs/build/guides/aptos-keyless/federated-keyless/simple-example.mdx`** — Replaced stale maintenance notice with instructions to run the example locally from the GitHub repository

## Testing

- All linting checks pass (`pnpm lint`)
- Astro type checking passes (`astro check --noSync`, 0 errors)
- Dev server tested: all three affected pages render correctly with no broken embeds

Closes the linked issue.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b9d170ba-6d19-4a2a-ac16-286e96ef9ee9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b9d170ba-6d19-4a2a-ac16-286e96ef9ee9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

