### PR TITLE
feat: add Agent Skills to homepage and sidebar NEW badge

### DIFF
--- a/astro.sidebar.ts
+++ b/astro.sidebar.ts
@@ -828,7 +828,11 @@ export const sidebar = [
         collapsed: true,
         items: ["build/ai/aptos-mcp", "build/ai/aptos-mcp/claude", "build/ai/aptos-mcp/cursor"],
       }),
-      "build/ai/aptos-agent-skills",
+      {
+        label: "Agent Skills",
+        link: "build/ai/aptos-agent-skills",
+        badge: { text: "NEW", variant: "tip" },
+      },
       {
         label: "LLMs.txt",
         link: "llms-txt",

--- a/src/content/docs/index.mdx
+++ b/src/content/docs/index.mdx
@@ -30,7 +30,8 @@ import ListCard from '~/components/ListCard.astro';
   <ListCard title="Getting Started" iconName="star" id="getting-started">
     - [Deploy Your First Move Smart Contract](/build/guides/first-move-module) Compile & publish Move modules to devnet in minutes.
     - [Your First Transaction](/build/guides/first-transaction) Write and read on-chain data using the TypeScript SDK.
-    - [NEW! Code with AI (MCP)](/build/ai/aptos-mcp) Make your AI Agent (Cursor or Claude Code) smarter by using our open-source MCP server.
+    - [Code with AI (MCP)](/build/ai/aptos-mcp) Give Cursor and Claude Code direct access to Aptos APIs.
+    - [NEW! Agent Skills](/build/ai/aptos-agent-skills) Move and TS SDK skills for Claude Code, Cursor, Copilot.
   </ListCard>
 
   <ListCard title="Tools" iconName="terminal">

--- a/src/content/docs/zh/index.mdx
+++ b/src/content/docs/zh/index.mdx
@@ -30,7 +30,8 @@ import ListCard from '~/components/ListCard.astro';
   <ListCard title="入门指南" iconName="star" id="getting-started">
     - [部署你的第一个 Move 智能合约](/zh/build/guides/first-move-module) 几分钟内编译并发布 Move 模块到 devnet。
     - [你的第一笔交易](/zh/build/guides/first-transaction) 使用 TypeScript SDK 写入和读取链上数据。
-    - [新！使用 AI 编程 (MCP)](/zh/build/ai/aptos-mcp) 让你的 AI Agent（Cursor 或 Claude Code）更智能，使用我们的开源 MCP 服务器。
+    - [使用 AI 编程 (MCP)](/zh/build/ai/aptos-mcp) 让 Cursor 和 Claude Code 直接访问 Aptos API。
+    - [新！Agent Skills](/zh/build/ai/aptos-agent-skills) 适用于 Claude Code、Cursor、Copilot 的 Move 和 TS SDK 技能。
   </ListCard>
 
   <ListCard title="工具" iconName="terminal">


### PR DESCRIPTION
## Summary

- Add Agent Skills to the Getting Started section on the homepage (EN + ZH)
- Add a NEW badge to the Agent Skills sidebar nav entry (matching LLMs.txt)
- Tighten the MCP description and remove its NEW flag (been available for a while)

## Test plan

- [ ] Homepage Getting Started card shows all 4 items on single lines
- [ ] Sidebar shows NEW badge on Agent Skills under AI and LLMs
- [ ] ZH homepage matches EN changes
- [ ] Links resolve to /build/ai/aptos-agent-skills