### PR TITLE
docs: remove redundant in-page TOC from application integration guide

### DIFF
--- a/src/content/docs/build/guides/application-integration.mdx
+++ b/src/content/docs/build/guides/application-integration.mdx
@@ -103,18 +103,6 @@ Coming from Ethereum? The [Ethereum to Aptos Workshop](https://learn.aptoslabs.c
 
 Install [Agent Skills](https://github.com/aptos-labs/aptos-agent-skills) for Move and TypeScript SDK skills in Claude Code, Cursor, and Copilot. The [MCP server](https://www.npmjs.com/package/@aptos-labs/aptos-mcp) gives AI tools access to Aptos infrastructure APIs through [Geomi](https://geomi.dev).
 
-This guide covers:
-
-{/* TODO: Ask Greg if this TOC is redundant with the "On this page" sidebar, or if it adds value for the reader */}
-
-1. [What's Different on Aptos](#whats-different-on-aptos)
-2. [Infrastructure & Getting Started](#infrastructure--getting-started)
-3. [Accounts & Addresses](#accounts--addresses)
-4. [Asset Standards](#asset-standards)
-5. [Transaction Lifecycle](#transaction-lifecycle)
-6. [Querying Data](#querying-data)
-7. [Testing](#testing)
-
 ## What's Different on Aptos
 
 Many of the problems you solve with external tools and careful engineering on Ethereum are handled by the protocol on Aptos.

--- a/src/content/docs/zh/build/guides/application-integration.mdx
+++ b/src/content/docs/zh/build/guides/application-integration.mdx
@@ -103,18 +103,6 @@ import { Aside, Tabs, TabItem } from '@astrojs/starlight/components';
 
 安装 [Agent Skills](https://github.com/aptos-labs/aptos-agent-skills) 以在 Claude Code、Cursor 和 Copilot 中获取 Move 和 TypeScript SDK 技能。[MCP 服务器](https://www.npmjs.com/package/@aptos-labs/aptos-mcp)通过 [Geomi](https://geomi.dev) 为 AI 工具提供 Aptos 基础设施 API 访问。
 
-本指南涵盖：
-
-{/* TODO: Ask Greg if this TOC is redundant with the "On this page" sidebar, or if it adds value for the reader */}
-
-1. [Aptos 的不同之处](#aptos-的不同之处)
-2. [基础设施与入门](#基础设施与入门)
-3. [账户与地址](#账户与地址)
-4. [资产标准](#资产标准)
-5. [交易生命周期](#交易生命周期)
-6. [数据查询](#数据查询)
-7. [测试](#测试)
-
 ## Aptos 的不同之处
 
 在 Ethereum 上需要通过外部工具和精心工程解决的许多问题，在 Aptos 上由协议本身处理。


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The Application Integration Guide included a numbered table of contents in the page body that duplicated the same section headings already shown in Starlight's **On this page** sidebar.

## Changes

- Removed the inline "This guide covers" / numbered list block from the English guide (`src/content/docs/build/guides/application-integration.mdx`).
- Applied the same removal to the Chinese translation (`src/content/docs/zh/build/guides/application-integration.mdx`).
- Dropped the related TODO comment that asked whether the list was redundant.

## Rationale

Readers still get section navigation from the sidebar; removing the duplicate list tightens the page without losing discoverability.

## Verification

- `pnpm format` and `pnpm lint` passed.
- `astro check` ran successfully on push (pre-push hook).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d8a228ce-282b-4484-8e6e-fbfae77132c0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d8a228ce-282b-4484-8e6e-fbfae77132c0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

