### PR TITLE
fix: improve ListCard NEW badge contrast on home page

### DIFF
--- a/src/components/ListCard.astro
+++ b/src/components/ListCard.astro
@@ -53,6 +53,11 @@ export type Props = Parameters<typeof Card>[0];
     font-size: var(--sl-text-xs);
     padding: 0.125rem 0.375rem;
     margin-inline-end: 0.25rem;
+    /* Invert from the default "tip" pill: index cards use dark tinted *-low
+       backgrounds where purple-low blends in; semantic grays flip with theme. */
+    background-color: var(--sl-color-gray-1);
+    color: var(--sl-color-black);
+    border-color: var(--sl-color-purple);
   }
 
   .link-list :global(a > .link-card-link-text) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Landing page ListCards use dark tinted backgrounds (`*-low` hues). The injected NEW badges reused Starlight’s `tip` variant (purple-low on dark), so they blended into the card.

## Changes

- Override `.list-card-new-badge` to use semantic `--sl-color-gray-1` background and `--sl-color-black` text so the pill inverts correctly when the site switches between light and dark theme.
- Keep a `--sl-color-purple` border so the badge still reads as the same “tip” accent as the sidebar, with stronger separation from the card surface.

## Testing

- `pnpm format`, `pnpm lint`, and `pnpm` prepush (`astro check`) all pass.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-160eb392-7940-40c6-9e78-bcff10befff5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-160eb392-7940-40c6-9e78-bcff10befff5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

