### PR TITLE
docs: add Move Book SUMMARY page to sidebar

### DIFF
--- a/astro.sidebar.ts
+++ b/astro.sidebar.ts
@@ -438,6 +438,7 @@ export const sidebar = [
       group("smartContracts.group.moveBook", {
         collapsed: true,
         items: [
+          "build/smart-contracts/book/SUMMARY",
           "build/smart-contracts/book/modules-and-scripts",
           "build/smart-contracts/book/structs-and-resources",
           "build/smart-contracts/book/integers",

--- a/astro.sidebar.ts
+++ b/astro.sidebar.ts
@@ -468,6 +468,7 @@ export const sidebar = [
           "build/smart-contracts/book/coding-conventions",
           "build/smart-contracts/book/move-tutorial",
           "build/smart-contracts/book/standard-library",
+          "build/smart-contracts/book/move-2",
         ],
       }),
 
@@ -583,8 +584,6 @@ export const sidebar = [
           "build/smart-contracts/error-codes",
         ],
       }),
-
-      "build/smart-contracts/book/move-2", // Release Notes
     ],
   }),
 

--- a/astro.sidebar.ts
+++ b/astro.sidebar.ts
@@ -438,7 +438,7 @@ export const sidebar = [
       group("smartContracts.group.moveBook", {
         collapsed: true,
         items: [
-          "build/smart-contracts/book/SUMMARY",
+          "build/smart-contracts/book/summary",
           "build/smart-contracts/book/modules-and-scripts",
           "build/smart-contracts/book/structs-and-resources",
           "build/smart-contracts/book/integers",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Two Move Book pages were missing from the `moveBook` sidebar group in `astro.sidebar.ts`. This PR adds them so all Move Book pages appear together in the sidebar.

## What changed

- Added `"build/smart-contracts/book/summary"` (the Move Book Table of Contents) as the first item in the `smartContracts.group.moveBook` sidebar group.
- Moved `"build/smart-contracts/book/move-2"` (Move 2 release notes) from a standalone entry at the bottom of the `smartContracts` section into the `moveBook` group where it belongs.

## Verification

Compared all 33 files under `src/content/docs/build/smart-contracts/book/` against the sidebar entries. Every page is now present in the sidebar -- either in the `moveBook` group, the `development` group (for `packages` and `package-upgrades`), or another appropriate group.

Build, lint, format, and type checks all pass.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a6908a89-dd85-4317-a84f-0c2d072aafda"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a6908a89-dd85-4317-a84f-0c2d072aafda"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

