### PR TITLE
fix: inline unzip install in Aptos CLI installer script

### DIFF
--- a/public/scripts/install_cli.sh
+++ b/public/scripts/install_cli.sh
@@ -23,7 +23,6 @@ ACCEPT_ALL=false
 VERSION=""
 GENERIC_LINUX=false
 FROM_SOURCE=false
-UNIVERSAL_INSTALLER_URL="https://raw.githubusercontent.com/gregnazario/universal-installer/main/scripts/install_pkg.sh"
 APTOS_REPO_URL="https://github.com/aptos-labs/aptos-core.git"
 
 # Print colored message
@@ -75,25 +74,202 @@ retry_command() {
     return $exit_code
 }
 
-# Install required packages using universal installer
-install_required_packages() {
-    # Download universal installer if not present
-    print_message "$YELLOW" "Downloading universal installer..."
-    if command_exists curl; then
-        retry_command curl -s "$UNIVERSAL_INSTALLER_URL" -o /tmp/install_pkg.sh || die "Failed to download universal installer"
-    elif command_exists wget; then
-        retry_command wget -q "$UNIVERSAL_INSTALLER_URL" -O /tmp/install_pkg.sh || die "Failed to download universal installer"
-    else
-        die "Neither curl nor wget is installed. Please install one of them manually."
-    fi
-    chmod +x /tmp/install_pkg.sh
+# --- Inline system package install (replaces external universal-installer) ---
+# Used only to install unzip when it is missing from PATH.
 
-    # Install unzip if not present
-    if ! command_exists unzip; then
-        print_message "$YELLOW" "Installing unzip..."
-        /tmp/install_pkg.sh unzip || die "Failed to install unzip"
-        rm /tmp/install_pkg.sh
+get_package_manager() {
+    case "$(uname -s)" in
+        Darwin)
+            if command_exists brew; then
+                echo brew
+            elif command_exists port; then
+                echo port
+            else
+                die "unzip is required. Install Homebrew (https://brew.sh/) or MacPorts (https://www.macports.org/), then run this script again."
+            fi
+            ;;
+        Linux)
+            if command_exists dnf; then
+                echo dnf
+            elif command_exists yum; then
+                echo yum
+            elif command_exists apt-get; then
+                echo apt-get
+            elif command_exists pacman; then
+                echo pacman
+            elif command_exists apk; then
+                echo apk
+            elif command_exists zypper; then
+                echo zypper
+            elif command_exists emerge; then
+                echo emerge
+            elif command_exists xbps-install; then
+                echo xbps
+            else
+                die "unzip is required. Install unzip with your distribution package manager, then run this script again."
+            fi
+            ;;
+        FreeBSD)
+            if command_exists pkg; then
+                echo pkg
+            else
+                die "unzip is required. Install pkg (https://docs.freebsd.org/en/books/handbook/ports/) and unzip, then run this script again."
+            fi
+            ;;
+        OpenBSD)
+            if command_exists doas; then
+                echo doas
+            else
+                die "unzip is required. Install unzip on OpenBSD (https://www.openbsd.org/faq/faq15.html), then run this script again."
+            fi
+            ;;
+        NetBSD)
+            if command_exists pkgin; then
+                echo pkgin
+            elif command_exists pkg_add; then
+                echo pkg_add
+            else
+                die "unzip is required. Install unzip with pkgin or pkg_add (https://www.netbsd.org/docs/pkgsrc/), then run this script again."
+            fi
+            ;;
+        *)
+            die "Unsupported OS for automatic unzip install: $(uname -s). Install unzip manually, then run this script again."
+            ;;
+    esac
+}
+
+is_system_package_installed() {
+    pkg=$1
+    pm=$2
+
+    case "$pm" in
+        yum|dnf)
+            rpm -q "$pkg" >/dev/null 2>&1
+            ;;
+        apt-get)
+            dpkg -l "$pkg" 2>/dev/null | grep -q '^ii'
+            ;;
+        pacman)
+            pacman -Q "$pkg" >/dev/null 2>&1
+            ;;
+        apk)
+            apk info -e "$pkg" >/dev/null 2>&1
+            ;;
+        brew)
+            brew list "$pkg" >/dev/null 2>&1
+            ;;
+        port)
+            port installed "$pkg" >/dev/null 2>&1
+            ;;
+        xbps)
+            xbps-query "$pkg" >/dev/null 2>&1
+            ;;
+        pkg)
+            pkg info "$pkg" >/dev/null 2>&1
+            ;;
+        emerge)
+            portageq best_version / "$pkg" >/dev/null 2>&1
+            ;;
+        zypper)
+            zypper se -i "$pkg" >/dev/null 2>&1
+            ;;
+        doas)
+            pkg_info -q "$pkg" >/dev/null 2>&1
+            ;;
+        pkgin)
+            pkgin -Q "$pkg" >/dev/null 2>&1
+            ;;
+        pkg_add)
+            pkg_info -q "$pkg" >/dev/null 2>&1
+            ;;
+        *)
+            return 1
+            ;;
+    esac
+}
+
+install_system_package() {
+    pkg=$1
+    pm=$(get_package_manager)
+
+    if is_system_package_installed "$pkg" "$pm"; then
+        return 0
     fi
+
+    pre_cmd=""
+    if [ "$(id -u)" -ne 0 ]; then
+        if command_exists sudo; then
+            pre_cmd="sudo"
+        elif command_exists doas; then
+            pre_cmd="doas"
+        fi
+    fi
+
+    print_message "$YELLOW" "Installing $pkg using $pm..."
+    case "$pm" in
+        yum)
+            $pre_cmd yum install "$pkg" -y || die "Failed to install package: $pkg"
+            ;;
+        dnf)
+            $pre_cmd dnf install "$pkg" -y || die "Failed to install package: $pkg"
+            ;;
+        apt-get)
+            if [ -n "$pre_cmd" ]; then
+                $pre_cmd apt-get update -qq || true
+            else
+                apt-get update -qq || true
+            fi
+            $pre_cmd apt-get install "$pkg" --no-install-recommends -y || die "Failed to install package: $pkg"
+            ;;
+        zypper)
+            $pre_cmd zypper install -y "$pkg" || die "Failed to install package: $pkg"
+            ;;
+        emerge)
+            $pre_cmd emerge "$pkg" || die "Failed to install package: $pkg"
+            ;;
+        port)
+            port install "$pkg" || die "Failed to install package: $pkg"
+            ;;
+        brew)
+            brew install "$pkg" || die "Failed to install package: $pkg"
+            ;;
+        pacman)
+            $pre_cmd pacman -S "$pkg" --noconfirm || die "Failed to install package: $pkg"
+            ;;
+        apk)
+            $pre_cmd apk --update add --no-cache "$pkg" || die "Failed to install package: $pkg"
+            ;;
+        xbps)
+            $pre_cmd xbps-install -y "$pkg" || die "Failed to install package: $pkg"
+            ;;
+        pkg)
+            $pre_cmd pkg install -y "$pkg" || die "Failed to install package: $pkg"
+            ;;
+        doas)
+            if [ "$(id -u)" -eq 0 ]; then
+                pkg_add -I "$pkg" || die "Failed to install package: $pkg"
+            else
+                doas pkg_add -I "$pkg" || die "Failed to install package: $pkg"
+            fi
+            ;;
+        pkgin)
+            $pre_cmd pkgin install "$pkg" || die "Failed to install package: $pkg"
+            ;;
+        pkg_add)
+            $pre_cmd pkg_add -I "$pkg" || die "Failed to install package: $pkg"
+            ;;
+        *)
+            die "Unsupported package manager: $pm"
+            ;;
+    esac
+}
+
+# Install unzip if not present (needed to extract CLI release zips)
+install_required_packages() {
+    if command_exists unzip; then
+        return 0
+    fi
+    install_system_package unzip
 }
 
 # Validate version string contains only safe characters

--- a/public/scripts/install_cli.sh
+++ b/public/scripts/install_cli.sh
@@ -117,10 +117,10 @@ get_package_manager() {
             fi
             ;;
         OpenBSD)
-            if command_exists doas; then
-                echo doas
+            if command_exists pkg_add || command_exists pkg_info; then
+                echo pkg_add
             else
-                die "unzip is required. Install unzip on OpenBSD (https://www.openbsd.org/faq/faq15.html), then run this script again."
+                die "unzip is required. Install pkg_add/unzip on OpenBSD (https://www.openbsd.org/faq/faq15.html), then run this script again."
             fi
             ;;
         NetBSD)
@@ -173,9 +173,6 @@ is_system_package_installed() {
         zypper)
             zypper se -i "$pkg" >/dev/null 2>&1
             ;;
-        doas)
-            pkg_info -q "$pkg" >/dev/null 2>&1
-            ;;
         pkgin)
             pkgin -Q "$pkg" >/dev/null 2>&1
             ;;
@@ -205,6 +202,17 @@ install_system_package() {
         fi
     fi
 
+    # Package managers that typically need root when not already root
+    requires_privileges=false
+    case "$pm" in
+        yum|dnf|apt-get|zypper|emerge|pacman|apk|xbps|pkg|pkgin|pkg_add|port)
+            requires_privileges=true
+            ;;
+    esac
+    if [ "$(id -u)" -ne 0 ] && [ -z "$pre_cmd" ] && [ "$requires_privileges" = true ]; then
+        die "Installing system package '$pkg' with '$pm' requires root privileges. Re-run this script as root or install and configure sudo or doas."
+    fi
+
     print_message "$YELLOW" "Installing $pkg using $pm..."
     case "$pm" in
         yum)
@@ -228,7 +236,11 @@ install_system_package() {
             $pre_cmd emerge "$pkg" || die "Failed to install package: $pkg"
             ;;
         port)
-            port install "$pkg" || die "Failed to install package: $pkg"
+            if [ "$(id -u)" -eq 0 ]; then
+                port install "$pkg" || die "Failed to install package: $pkg"
+            else
+                $pre_cmd port install "$pkg" || die "Failed to install package: $pkg"
+            fi
             ;;
         brew)
             brew install "$pkg" || die "Failed to install package: $pkg"
@@ -245,18 +257,15 @@ install_system_package() {
         pkg)
             $pre_cmd pkg install -y "$pkg" || die "Failed to install package: $pkg"
             ;;
-        doas)
-            if [ "$(id -u)" -eq 0 ]; then
-                pkg_add -I "$pkg" || die "Failed to install package: $pkg"
-            else
-                doas pkg_add -I "$pkg" || die "Failed to install package: $pkg"
-            fi
-            ;;
         pkgin)
             $pre_cmd pkgin install "$pkg" || die "Failed to install package: $pkg"
             ;;
         pkg_add)
-            $pre_cmd pkg_add -I "$pkg" || die "Failed to install package: $pkg"
+            if [ "$(id -u)" -eq 0 ]; then
+                pkg_add -I "$pkg" || die "Failed to install package: $pkg"
+            else
+                $pre_cmd pkg_add -I "$pkg" || die "Failed to install package: $pkg"
+            fi
             ;;
         *)
             die "Unsupported package manager: $pm"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The Aptos CLI install script (`public/scripts/install_cli.sh`) no longer downloads the third-party universal-installer script from GitHub. It now detects the host package manager and installs `unzip` only when it is missing from `PATH`.

## Motivation

- Removes a runtime dependency on an external repository for a small, single-package install path.
- Fixes a bug where `/tmp/install_pkg.sh` was left on disk when `unzip` was already installed (the script only removed the temp file after an install).
- Uses `pacman -S` instead of `pacman -Syu` so installing `unzip` does not trigger a full system upgrade.

## Follow-up (review)

- OpenBSD: use `pkg_add` as the package manager identifier (detect `pkg_add` / `pkg_info`), not `doas`.
- MacPorts: run `port install` under `sudo`/`doas` when not root.
- Clear error when a privileged install is needed but neither `sudo` nor `doas` is available.

## Verification

- `sh -n public/scripts/install_cli.sh`
- `pnpm lint`
- Pre-push `astro check` (from `git push`)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b062facf-4c72-4bab-85b1-597198ad3e2a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b062facf-4c72-4bab-85b1-597198ad3e2a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

