### PR TITLE
fix(keyless): update EphemeralKeyPair import for ts-sdk v7

### DIFF
--- a/src/content/docs/build/guides/aptos-keyless/integration-guide.mdx
+++ b/src/content/docs/build/guides/aptos-keyless/integration-guide.mdx
@@ -51,7 +51,7 @@ You can find an example app demonstrating basic Keyless integration with Google 
      1. In the background, we create an ephemeral key pair. Store this in local storage.
 
         ```typescript
-        import {EphemeralKeyPair} from '@aptos-labs/ts-sdk';
+        import {EphemeralKeyPair} from '@aptos-labs/ts-sdk/keyless';
 
         const ephemeralKeyPair = EphemeralKeyPair.generate();
         ```

--- a/src/content/docs/build/guides/aptos-keyless/integration-guide.mdx
+++ b/src/content/docs/build/guides/aptos-keyless/integration-guide.mdx
@@ -56,6 +56,11 @@ You can find an example app demonstrating basic Keyless integration with Google 
         const ephemeralKeyPair = EphemeralKeyPair.generate();
         ```
 
+        <Aside type="note">
+          `EphemeralKeyPair` moved to the `@aptos-labs/ts-sdk/keyless` sub-path in v7.0.0.
+          If you are on v6 or earlier, import from `@aptos-labs/ts-sdk` instead.
+        </Aside>
+
      2. Save the `EphemeralKeyPair` in local storage, keyed by its `nonce`.
 
         ```typescript


### PR DESCRIPTION
## Summary

- `@aptos-labs/ts-sdk` v7.0.0 (merged 2026-04-29) removed `EphemeralKeyPair` from the top-level barrel export to keep the main entry tree-shakeable (avoids pulling in `poseidon-lite` side effects)
- The integration guide still showed `import {EphemeralKeyPair} from '@aptos-labs/ts-sdk'`, which now throws a runtime `SyntaxError: does not provide an export named 'EphemeralKeyPair'`
- Updated to the correct v7 sub-path: `import {EphemeralKeyPair} from '@aptos-labs/ts-sdk/keyless'`

## Test plan

- [ ] Verify the rendered page at `/build/guides/aptos-keyless/integration-guide` shows the updated import

🤖 Generated with [Claude Code](https://claude.com/claude-code)