### PR TITLE
docs: validator trusted-setup setup and rotation guide

### DIFF
--- a/astro.sidebar.ts
+++ b/astro.sidebar.ts
@@ -672,6 +672,7 @@ export const sidebar = [
             items: [
               "network/nodes/validator-node/modify-nodes",
               "network/nodes/validator-node/modify-nodes/update-validator-node",
+              "network/nodes/validator-node/modify-nodes/update-trusted-setup",
               "network/nodes/validator-node/modify-nodes/shutting-down-nodes",
               "network/nodes/validator-node/modify-nodes/rotate-consensus-key",
               "network/nodes/validator-node/modify-nodes/shutdown-vfn",

--- a/src/content/docs/network/glossary.mdx
+++ b/src/content/docs/network/glossary.mdx
@@ -702,6 +702,18 @@ for the associated Aptos source file.
 
 - See [Move script](#move-script)
 
+### Trusted Setup
+
+- The **trusted setup** is the pair of binary blobs (`digest_key.bin` and `pp.bin`) consumed by Aptos validator
+  consensus before participating in distributed key generation (DKG).
+- Aptos Labs publishes the blobs in the
+  [`aptos-labs/aptos-networks`](https://github.com/aptos-labs/aptos-networks) repository and rotates them
+  periodically. All validators in a network must load the same bytes.
+- VFNs and PFNs do not need these files.
+
+See [Update Trusted Setup](/network/nodes/validator-node/modify-nodes/update-trusted-setup) for the operator
+runbook covering download, CLI verification, and rotation.
+
 ## V
 
 ### Validator

--- a/src/content/docs/network/nodes/configure/node-files-all-networks/node-files-testnet.mdx
+++ b/src/content/docs/network/nodes/configure/node-files-all-networks/node-files-testnet.mdx
@@ -69,10 +69,12 @@ Validator-only trusted-setup material consumed by consensus. VFNs and PFNs do no
 
 <Aside type="note">
   This file is stored via Git LFS, so the download URL uses `github.com/.../raw/main/...` (which follows the LFS
-  redirect) rather than `raw.githubusercontent.com`. Point `consensus.digest_key_blob_path` in `validator.yaml`
-  at the on-disk location (for example `/opt/aptos/genesis/digest_key.bin`). See
-  [Update Trusted Setup](/network/nodes/validator-node/modify-nodes/update-trusted-setup) for verification and
-  rotation steps.
+  redirect) rather than `raw.githubusercontent.com`. The `wget` above is for **self-managed** deployments
+  (source code or Docker); point `consensus.digest_key_blob_path` in `validator.yaml` at the on-disk location
+  (for example `/opt/aptos/genesis/digest_key.bin`). **Helm/k8s** deployments do not download manually — the
+  `aptos-node` chart fetches the blob via its init container. See
+  [Update Trusted Setup](/network/nodes/validator-node/modify-nodes/update-trusted-setup) for the full
+  per-deployment flow and verification steps.
 </Aside>
 
 ### pp.bin
@@ -88,10 +90,12 @@ Validator-only public-parameters blob consumed by consensus. VFNs and PFNs do no
 
 <Aside type="note">
   This file is stored via Git LFS, so the download URL uses `github.com/.../raw/main/...` (which follows the LFS
-  redirect) rather than `raw.githubusercontent.com`. Point `consensus.public_parameters_blob_path` in
-  `validator.yaml` at the on-disk location (for example `/opt/aptos/genesis/pp.bin`). See
-  [Update Trusted Setup](/network/nodes/validator-node/modify-nodes/update-trusted-setup) for verification and
-  rotation steps.
+  redirect) rather than `raw.githubusercontent.com`. The `wget` above is for **self-managed** deployments
+  (source code or Docker); point `consensus.public_parameters_blob_path` in `validator.yaml` at the on-disk
+  location (for example `/opt/aptos/genesis/pp.bin`). **Helm/k8s** deployments do not download manually — the
+  `aptos-node` chart fetches the blob via its init container. See
+  [Update Trusted Setup](/network/nodes/validator-node/modify-nodes/update-trusted-setup) for the full
+  per-deployment flow and verification steps.
 </Aside>
 
 ### docker-compose-src.yaml

--- a/src/content/docs/network/nodes/configure/node-files-all-networks/node-files-testnet.mdx
+++ b/src/content/docs/network/nodes/configure/node-files-all-networks/node-files-testnet.mdx
@@ -56,6 +56,44 @@ All the files listed below are for validator nodes.
   wget -O waypoint.txt https://raw.githubusercontent.com/aptos-labs/aptos-networks/main/testnet/waypoint.txt
   ```
 
+### digest\_key.bin
+
+Validator-only trusted-setup material consumed by consensus. VFNs and PFNs do not need this file.
+
+- **Git repo:** `aptos-networks`
+- **Git branch:** `main` on [https://github.com/aptos-labs/aptos-networks](https://github.com/aptos-labs/aptos-networks)
+- **Command to download:**
+  ```shellscript filename="Terminal"
+  wget -O digest_key.bin https://github.com/aptos-labs/aptos-networks/raw/main/testnet/digest_key.bin
+  ```
+
+<Aside type="note">
+  This file is stored via Git LFS, so the download URL uses `github.com/.../raw/main/...` (which follows the LFS
+  redirect) rather than `raw.githubusercontent.com`. Point `consensus.digest_key_blob_path` in `validator.yaml`
+  at the on-disk location (for example `/opt/aptos/genesis/digest_key.bin`). See
+  [Update Trusted Setup](/network/nodes/validator-node/modify-nodes/update-trusted-setup) for verification and
+  rotation steps.
+</Aside>
+
+### pp.bin
+
+Validator-only public-parameters blob consumed by consensus. VFNs and PFNs do not need this file.
+
+- **Git repo:** `aptos-networks`
+- **Git branch:** `main` on [https://github.com/aptos-labs/aptos-networks](https://github.com/aptos-labs/aptos-networks)
+- **Command to download:**
+  ```shellscript filename="Terminal"
+  wget -O pp.bin https://github.com/aptos-labs/aptos-networks/raw/main/testnet/pp.bin
+  ```
+
+<Aside type="note">
+  This file is stored via Git LFS, so the download URL uses `github.com/.../raw/main/...` (which follows the LFS
+  redirect) rather than `raw.githubusercontent.com`. Point `consensus.public_parameters_blob_path` in
+  `validator.yaml` at the on-disk location (for example `/opt/aptos/genesis/pp.bin`). See
+  [Update Trusted Setup](/network/nodes/validator-node/modify-nodes/update-trusted-setup) for verification and
+  rotation steps.
+</Aside>
+
 ### docker-compose-src.yaml
 
 - **Git repo:** `aptos-core`

--- a/src/content/docs/network/nodes/validator-node/deploy-nodes/using-aws.mdx
+++ b/src/content/docs/network/nodes/validator-node/deploy-nodes/using-aws.mdx
@@ -167,6 +167,8 @@ the validator and VFN will be deployed on separate machines.
 
     - `genesis.blob`
     - `waypoint.txt`
+    - `digest_key.bin` and `pp.bin` (validators only; see
+      [Update Trusted Setup](/network/nodes/validator-node/modify-nodes/update-trusted-setup) for verification steps)
 
 13. To recap, in your working directory (`~/$WORKSPACE`), you should have a list of files:
 

--- a/src/content/docs/network/nodes/validator-node/deploy-nodes/using-aws.mdx
+++ b/src/content/docs/network/nodes/validator-node/deploy-nodes/using-aws.mdx
@@ -167,8 +167,13 @@ the validator and VFN will be deployed on separate machines.
 
     - `genesis.blob`
     - `waypoint.txt`
-    - `digest_key.bin` and `pp.bin` (validators only; see
-      [Update Trusted Setup](/network/nodes/validator-node/modify-nodes/update-trusted-setup) for verification steps)
+
+    <Aside type="note">
+      The DKG trusted-setup blobs (`digest_key.bin`, `pp.bin`) required by validators are **not** downloaded here.
+      The `aptos-node` Helm chart fetches them into a persistent volume via its init container — configure the
+      `trustedSetup.*` chart values per
+      [Update Trusted Setup → Kubernetes deployment](/network/nodes/validator-node/modify-nodes/update-trusted-setup#kubernetes-deployment-helm-chart).
+    </Aside>
 
 13. To recap, in your working directory (`~/$WORKSPACE`), you should have a list of files:
 

--- a/src/content/docs/network/nodes/validator-node/deploy-nodes/using-azure.mdx
+++ b/src/content/docs/network/nodes/validator-node/deploy-nodes/using-azure.mdx
@@ -167,6 +167,8 @@ the validator and VFN will be deployed on separate machines.
 
     - `genesis.blob`
     - `waypoint.txt`
+    - `digest_key.bin` and `pp.bin` (validators only; see
+      [Update Trusted Setup](/network/nodes/validator-node/modify-nodes/update-trusted-setup) for verification steps)
 
 13. To recap, in your working directory (`~/$WORKSPACE`), you should have a list of files:
 

--- a/src/content/docs/network/nodes/validator-node/deploy-nodes/using-azure.mdx
+++ b/src/content/docs/network/nodes/validator-node/deploy-nodes/using-azure.mdx
@@ -167,8 +167,13 @@ the validator and VFN will be deployed on separate machines.
 
     - `genesis.blob`
     - `waypoint.txt`
-    - `digest_key.bin` and `pp.bin` (validators only; see
-      [Update Trusted Setup](/network/nodes/validator-node/modify-nodes/update-trusted-setup) for verification steps)
+
+    <Aside type="note">
+      The DKG trusted-setup blobs (`digest_key.bin`, `pp.bin`) required by validators are **not** downloaded here.
+      The `aptos-node` Helm chart fetches them into a persistent volume via its init container — configure the
+      `trustedSetup.*` chart values per
+      [Update Trusted Setup → Kubernetes deployment](/network/nodes/validator-node/modify-nodes/update-trusted-setup#kubernetes-deployment-helm-chart).
+    </Aside>
 
 13. To recap, in your working directory (`~/$WORKSPACE`), you should have a list of files:
 

--- a/src/content/docs/network/nodes/validator-node/deploy-nodes/using-docker.mdx
+++ b/src/content/docs/network/nodes/validator-node/deploy-nodes/using-docker.mdx
@@ -132,9 +132,8 @@ and VFN will be deployed on separate machines.
    wget -O pp.bin https://github.com/aptos-labs/aptos-networks/raw/main/<network>/pp.bin
    ```
 
-   Replace `<network>` with `testnet` (mainnet trusted-setup blobs are not yet published — see
-   [Update Trusted Setup → Published checksums](/network/nodes/validator-node/modify-nodes/update-trusted-setup#published-checksums)).
-   See [Update Trusted Setup → Docker (compose) deployment](/network/nodes/validator-node/modify-nodes/update-trusted-setup#docker-compose-deployment)
+   Replace `<network>` with the appropriate network (`testnet` or `mainnet`). See
+   [Update Trusted Setup → Docker (compose) deployment](/network/nodes/validator-node/modify-nodes/update-trusted-setup#docker-compose-deployment)
    for the verification step (`aptos node validate-digest-key` / `validate-public-parameters`).
 
 6. To recap, in your working directory (`~/$WORKSPACE`), you should have a list of files:

--- a/src/content/docs/network/nodes/validator-node/deploy-nodes/using-docker.mdx
+++ b/src/content/docs/network/nodes/validator-node/deploy-nodes/using-docker.mdx
@@ -123,7 +123,8 @@ and VFN will be deployed on separate machines.
    - `genesis.blob`
    - `waypoint.txt`
    - `digest_key.bin` and `pp.bin` (validators only; see
-     [Update Trusted Setup](/network/nodes/validator-node/modify-nodes/update-trusted-setup) for verification steps)
+     [Update Trusted Setup → Self-managed deployment](/network/nodes/validator-node/modify-nodes/update-trusted-setup#self-managed-deployment-source-code-or-docker)
+     for verification and the `validator.yaml` paths these files must match)
 
 5. To recap, in your working directory (`~/$WORKSPACE`), you should have a list of files:
 

--- a/src/content/docs/network/nodes/validator-node/deploy-nodes/using-docker.mdx
+++ b/src/content/docs/network/nodes/validator-node/deploy-nodes/using-docker.mdx
@@ -122,12 +122,21 @@ and VFN will be deployed on separate machines.
    - `blocked.ips`
    - `genesis.blob`
    - `waypoint.txt`
-   - `digest_key.bin` and `pp.bin` (validators only; place these alongside `genesis.blob` and `waypoint.txt`
-     in your working directory — the upstream `docker-compose.yaml` bind-mounts them from there. See
-     [Update Trusted Setup → Docker (compose) deployment](/network/nodes/validator-node/modify-nodes/update-trusted-setup#docker-compose-deployment)
-     for verification steps)
 
-5. To recap, in your working directory (`~/$WORKSPACE`), you should have a list of files:
+5. **Validators only:** download the trusted-setup blobs into your working directory, alongside `genesis.blob`
+   and `waypoint.txt`. The upstream `docker-compose.yaml` bind-mounts them from there into the container:
+
+   ```shellscript filename="Terminal"
+   cd ~/$WORKSPACE
+   wget -O digest_key.bin https://github.com/aptos-labs/aptos-networks/raw/main/testnet/digest_key.bin
+   wget -O pp.bin https://github.com/aptos-labs/aptos-networks/raw/main/testnet/pp.bin
+   ```
+
+   Replace `testnet` with the network you operate on. See
+   [Update Trusted Setup → Docker (compose) deployment](/network/nodes/validator-node/modify-nodes/update-trusted-setup#docker-compose-deployment)
+   for the verification step (`aptos node validate-digest-key` / `validate-public-parameters`).
+
+6. To recap, in your working directory (`~/$WORKSPACE`), you should have a list of files:
 
    - `docker-compose.yaml`: The docker compose file to run the validator.
    - `docker-compose-fullnode.yaml`: The docker compose file to run the VFN.
@@ -142,7 +151,7 @@ and VFN will be deployed on separate machines.
    - `waypoint.txt`: The waypoint for the genesis transaction on the network you are connecting to.
    - `genesis.blob` The genesis blob for the network you are connecting to.
 
-6. To start the validator node, run the following command in your working directory:
+7. To start the validator node, run the following command in your working directory:
 
    ```shellscript filename="Terminal"
    docker-compose up (or `docker compose up` depends on your version)
@@ -152,7 +161,7 @@ and VFN will be deployed on separate machines.
    `docker-compose.yaml` file. If you wish to change the network you are connecting to, you will need to modify
    the file to use the correct docker images by network name.
 
-7. Before you can start the VFN, you will need to modify the `fullnode.yaml` file to update the host address for the
+8. Before you can start the VFN, you will need to modify the `fullnode.yaml` file to update the host address for the
    validator node. For example, if you are using IP addresses, you will need to update the `full_node_networks`
    `addresses` for the `vfn` network as follows:
 
@@ -170,7 +179,7 @@ and VFN will be deployed on separate machines.
      - "/dns/example.com/tcp/6181/noise-ik/..." # Set the DNS Address of the validator
    ```
 
-8. To start your VFN, run the following commands on a separate, dedicated VFN machine. You will need to copy across
+9. To start your VFN, run the following commands on a separate, dedicated VFN machine. You will need to copy across
    the keys, configuration and docker compose files from the validator machine.
 
    <Aside type="caution">

--- a/src/content/docs/network/nodes/validator-node/deploy-nodes/using-docker.mdx
+++ b/src/content/docs/network/nodes/validator-node/deploy-nodes/using-docker.mdx
@@ -122,9 +122,10 @@ and VFN will be deployed on separate machines.
    - `blocked.ips`
    - `genesis.blob`
    - `waypoint.txt`
-   - `digest_key.bin` and `pp.bin` (validators only; see
-     [Update Trusted Setup → Self-managed deployment](/network/nodes/validator-node/modify-nodes/update-trusted-setup#self-managed-deployment-source-code-or-docker)
-     for verification and the `validator.yaml` paths these files must match)
+   - `digest_key.bin` and `pp.bin` (validators only; place these alongside `genesis.blob` and `waypoint.txt`
+     in your working directory — the upstream `docker-compose.yaml` bind-mounts them from there. See
+     [Update Trusted Setup → Docker (compose) deployment](/network/nodes/validator-node/modify-nodes/update-trusted-setup#docker-compose-deployment)
+     for verification steps)
 
 5. To recap, in your working directory (`~/$WORKSPACE`), you should have a list of files:
 

--- a/src/content/docs/network/nodes/validator-node/deploy-nodes/using-docker.mdx
+++ b/src/content/docs/network/nodes/validator-node/deploy-nodes/using-docker.mdx
@@ -128,12 +128,13 @@ and VFN will be deployed on separate machines.
 
    ```shellscript filename="Terminal"
    cd ~/$WORKSPACE
-   wget -O digest_key.bin https://github.com/aptos-labs/aptos-networks/raw/main/testnet/digest_key.bin
-   wget -O pp.bin https://github.com/aptos-labs/aptos-networks/raw/main/testnet/pp.bin
+   wget -O digest_key.bin https://github.com/aptos-labs/aptos-networks/raw/main/<network>/digest_key.bin
+   wget -O pp.bin https://github.com/aptos-labs/aptos-networks/raw/main/<network>/pp.bin
    ```
 
-   Replace `testnet` with the network you operate on. See
-   [Update Trusted Setup → Docker (compose) deployment](/network/nodes/validator-node/modify-nodes/update-trusted-setup#docker-compose-deployment)
+   Replace `<network>` with `testnet` (mainnet trusted-setup blobs are not yet published — see
+   [Update Trusted Setup → Published checksums](/network/nodes/validator-node/modify-nodes/update-trusted-setup#published-checksums)).
+   See [Update Trusted Setup → Docker (compose) deployment](/network/nodes/validator-node/modify-nodes/update-trusted-setup#docker-compose-deployment)
    for the verification step (`aptos node validate-digest-key` / `validate-public-parameters`).
 
 6. To recap, in your working directory (`~/$WORKSPACE`), you should have a list of files:

--- a/src/content/docs/network/nodes/validator-node/deploy-nodes/using-docker.mdx
+++ b/src/content/docs/network/nodes/validator-node/deploy-nodes/using-docker.mdx
@@ -149,7 +149,9 @@ and VFN will be deployed on separate machines.
      - `owner.yaml`: The owner, operator and voter mappings.
      - `operator.yaml`: Validator and VFN operator information.
    - `waypoint.txt`: The waypoint for the genesis transaction on the network you are connecting to.
-   - `genesis.blob` The genesis blob for the network you are connecting to.
+   - `genesis.blob`: The genesis blob for the network you are connecting to.
+   - `digest_key.bin`: Validators only. DKG digest-key blob loaded by consensus.
+   - `pp.bin`: Validators only. DKG public-parameters blob loaded by consensus.
 
 7. To start the validator node, run the following command in your working directory:
 

--- a/src/content/docs/network/nodes/validator-node/deploy-nodes/using-docker.mdx
+++ b/src/content/docs/network/nodes/validator-node/deploy-nodes/using-docker.mdx
@@ -122,6 +122,8 @@ and VFN will be deployed on separate machines.
    - `blocked.ips`
    - `genesis.blob`
    - `waypoint.txt`
+   - `digest_key.bin` and `pp.bin` (validators only; see
+     [Update Trusted Setup](/network/nodes/validator-node/modify-nodes/update-trusted-setup) for verification steps)
 
 5. To recap, in your working directory (`~/$WORKSPACE`), you should have a list of files:
 

--- a/src/content/docs/network/nodes/validator-node/deploy-nodes/using-gcp.mdx
+++ b/src/content/docs/network/nodes/validator-node/deploy-nodes/using-gcp.mdx
@@ -167,8 +167,13 @@ Using this guide, the validator and VFN will be deployed on separate machines.
 
     - `genesis.blob`
     - `waypoint.txt`
-    - `digest_key.bin` and `pp.bin` (validators only; see
-      [Update Trusted Setup](/network/nodes/validator-node/modify-nodes/update-trusted-setup) for verification steps)
+
+    <Aside type="note">
+      The DKG trusted-setup blobs (`digest_key.bin`, `pp.bin`) required by validators are **not** downloaded here.
+      The `aptos-node` Helm chart fetches them into a persistent volume via its init container — configure the
+      `trustedSetup.*` chart values per
+      [Update Trusted Setup → Kubernetes deployment](/network/nodes/validator-node/modify-nodes/update-trusted-setup#kubernetes-deployment-helm-chart).
+    </Aside>
 
 13. To recap, in your working directory (`~/$WORKSPACE`), you should have a list of files:
 

--- a/src/content/docs/network/nodes/validator-node/deploy-nodes/using-gcp.mdx
+++ b/src/content/docs/network/nodes/validator-node/deploy-nodes/using-gcp.mdx
@@ -167,6 +167,8 @@ Using this guide, the validator and VFN will be deployed on separate machines.
 
     - `genesis.blob`
     - `waypoint.txt`
+    - `digest_key.bin` and `pp.bin` (validators only; see
+      [Update Trusted Setup](/network/nodes/validator-node/modify-nodes/update-trusted-setup) for verification steps)
 
 13. To recap, in your working directory (`~/$WORKSPACE`), you should have a list of files:
 

--- a/src/content/docs/network/nodes/validator-node/deploy-nodes/using-source-code.mdx
+++ b/src/content/docs/network/nodes/validator-node/deploy-nodes/using-source-code.mdx
@@ -181,20 +181,20 @@ and VFN will be deployed on separate machines.
 
 10. To recap, in your working directory (`~/$WORKSPACE`), you should have a list of files:
 
-- `config` folder containing:
-  - `validator.yaml`: The validator config file.
-  - `fullnode.yaml`: The VFN config file.
-- `keys` folder containing:
-  - `public-keys.yaml`: Public keys for both nodes.
-  - `private-keys.yaml`: Private keys for both nodes.
-  - `validator-identity.yaml`: Key and account information for the validator.
-  - `validator-full-node-identity.yaml`: Key and account information for the VFN.
-- `$username` folder containing:
-  - `owner.yaml`: The owner, operator and voter mappings.
-  - `operator.yaml`: Validator and VFN operator information.
-- `waypoint.txt`: The waypoint for the genesis transaction on the network you are connecting to.
-- `genesis.blob`: The genesis blob for the network you are connecting to.
-- `digest_key.bin` and `pp.bin` (validators only): DKG trusted-setup blobs at the paths chosen in step 7 (may live outside the working directory).
+    - `config` folder containing:
+      - `validator.yaml`: The validator config file.
+      - `fullnode.yaml`: The VFN config file.
+    - `keys` folder containing:
+      - `public-keys.yaml`: Public keys for both nodes.
+      - `private-keys.yaml`: Private keys for both nodes.
+      - `validator-identity.yaml`: Key and account information for the validator.
+      - `validator-full-node-identity.yaml`: Key and account information for the VFN.
+    - `$username` folder containing:
+      - `owner.yaml`: The owner, operator and voter mappings.
+      - `operator.yaml`: Validator and VFN operator information.
+    - `waypoint.txt`: The waypoint for the genesis transaction on the network you are connecting to.
+    - `genesis.blob`: The genesis blob for the network you are connecting to.
+    - `digest_key.bin` and `pp.bin` (validators only): DKG trusted-setup blobs at the paths chosen in step 7 (may live outside the working directory).
 
 11. Now that you have set up your configuration files, you can start your validator and VFN.
     To start your validator, run the following commands, with the paths assuming you are in the root of the `aptos-core` directory:

--- a/src/content/docs/network/nodes/validator-node/deploy-nodes/using-source-code.mdx
+++ b/src/content/docs/network/nodes/validator-node/deploy-nodes/using-source-code.mdx
@@ -114,11 +114,24 @@ and VFN will be deployed on separate machines.
    - `fullnode.yaml`
    - `genesis.blob`
    - `waypoint.txt`
-   - `digest_key.bin` and `pp.bin` (validators only; see
-     [Update Trusted Setup → Source code deployment](/network/nodes/validator-node/modify-nodes/update-trusted-setup#source-code-deployment)
-     for verification and the `validator.yaml` paths these files must match)
 
-7. Next, copy the `validator.yaml` and `fullnode.yaml` template files (that were just downloaded) into the
+7. **Validators only:** download the trusted-setup blobs to a path on persistent local storage. The example
+   below uses `/opt/aptos/genesis/`, alongside `genesis.blob` and `waypoint.txt`. Use the same paths when you
+   set `consensus.digest_key_blob_path` and `consensus.public_parameters_blob_path` in `validator.yaml`
+   (step 9).
+
+   ```shellscript filename="Terminal"
+   wget -O /opt/aptos/genesis/digest_key.bin \
+     https://github.com/aptos-labs/aptos-networks/raw/main/testnet/digest_key.bin
+   wget -O /opt/aptos/genesis/pp.bin \
+     https://github.com/aptos-labs/aptos-networks/raw/main/testnet/pp.bin
+   ```
+
+   Replace `testnet` with the network you operate on. See
+   [Update Trusted Setup → Source code deployment](/network/nodes/validator-node/modify-nodes/update-trusted-setup#source-code-deployment)
+   for the verification step (`aptos node validate-digest-key` / `validate-public-parameters`).
+
+8. Next, copy the `validator.yaml` and `fullnode.yaml` template files (that were just downloaded) into the
    `~/$WORKSPACE/config/` directory. This can be done by running the following commands:
 
    ```shellscript filename="Terminal"
@@ -129,7 +142,7 @@ and VFN will be deployed on separate machines.
 
    These will be the primary configuration files for your validator and VFN, respectively.
 
-8. Now, modify the `validator.yaml` and `fullnode.yaml` template files to contain the appropriate information
+9. Now, modify the `validator.yaml` and `fullnode.yaml` template files to contain the appropriate information
    and working directories for your validator and VFN.
 
    For the `validator.yaml` file, you will need to modify the following fields:
@@ -166,23 +179,23 @@ and VFN will be deployed on separate machines.
        - "/dns/example.com/tcp/6181/noise-ik/..." # Set the DNS Address of the validator
      ```
 
-9. To recap, in your working directory (`~/$WORKSPACE`), you should have a list of files:
+10. To recap, in your working directory (`~/$WORKSPACE`), you should have a list of files:
 
-   - `config` folder containing:
-     - `validator.yaml`: The validator config file.
-     - `fullnode.yaml`: The VFN config file.
-   - `keys` folder containing:
-     - `public-keys.yaml`: Public keys for both nodes.
-     - `private-keys.yaml`: Private keys for both nodes.
-     - `validator-identity.yaml`: Key and account information for the validator.
-     - `validator-full-node-identity.yaml`: Key and account information for the VFN.
-   - `$username` folder containing:
-     - `owner.yaml`: The owner, operator and voter mappings.
-     - `operator.yaml`: Validator and VFN operator information.
-   - `waypoint.txt`: The waypoint for the genesis transaction on the network you are connecting to.
-   - `genesis.blob` The genesis blob for the network you are connecting to.
+- `config` folder containing:
+  - `validator.yaml`: The validator config file.
+  - `fullnode.yaml`: The VFN config file.
+- `keys` folder containing:
+  - `public-keys.yaml`: Public keys for both nodes.
+  - `private-keys.yaml`: Private keys for both nodes.
+  - `validator-identity.yaml`: Key and account information for the validator.
+  - `validator-full-node-identity.yaml`: Key and account information for the VFN.
+- `$username` folder containing:
+  - `owner.yaml`: The owner, operator and voter mappings.
+  - `operator.yaml`: Validator and VFN operator information.
+- `waypoint.txt`: The waypoint for the genesis transaction on the network you are connecting to.
+- `genesis.blob` The genesis blob for the network you are connecting to.
 
-10. Now that you have set up your configuration files, you can start your validator and VFN.
+11. Now that you have set up your configuration files, you can start your validator and VFN.
     To start your validator, run the following commands, with the paths assuming you are in the root of the `aptos-core` directory:
 
     ```shellscript filename="Terminal"

--- a/src/content/docs/network/nodes/validator-node/deploy-nodes/using-source-code.mdx
+++ b/src/content/docs/network/nodes/validator-node/deploy-nodes/using-source-code.mdx
@@ -115,7 +115,8 @@ and VFN will be deployed on separate machines.
    - `genesis.blob`
    - `waypoint.txt`
    - `digest_key.bin` and `pp.bin` (validators only; see
-     [Update Trusted Setup](/network/nodes/validator-node/modify-nodes/update-trusted-setup) for verification steps)
+     [Update Trusted Setup → Self-managed deployment](/network/nodes/validator-node/modify-nodes/update-trusted-setup#self-managed-deployment-source-code-or-docker)
+     for verification and the `validator.yaml` paths these files must match)
 
 7. Next, copy the `validator.yaml` and `fullnode.yaml` template files (that were just downloaded) into the
    `~/$WORKSPACE/config/` directory. This can be done by running the following commands:

--- a/src/content/docs/network/nodes/validator-node/deploy-nodes/using-source-code.mdx
+++ b/src/content/docs/network/nodes/validator-node/deploy-nodes/using-source-code.mdx
@@ -114,6 +114,8 @@ and VFN will be deployed on separate machines.
    - `fullnode.yaml`
    - `genesis.blob`
    - `waypoint.txt`
+   - `digest_key.bin` and `pp.bin` (validators only; see
+     [Update Trusted Setup](/network/nodes/validator-node/modify-nodes/update-trusted-setup) for verification steps)
 
 7. Next, copy the `validator.yaml` and `fullnode.yaml` template files (that were just downloaded) into the
    `~/$WORKSPACE/config/` directory. This can be done by running the following commands:

--- a/src/content/docs/network/nodes/validator-node/deploy-nodes/using-source-code.mdx
+++ b/src/content/docs/network/nodes/validator-node/deploy-nodes/using-source-code.mdx
@@ -115,7 +115,7 @@ and VFN will be deployed on separate machines.
    - `genesis.blob`
    - `waypoint.txt`
    - `digest_key.bin` and `pp.bin` (validators only; see
-     [Update Trusted Setup → Self-managed deployment](/network/nodes/validator-node/modify-nodes/update-trusted-setup#self-managed-deployment-source-code-or-docker)
+     [Update Trusted Setup → Source code deployment](/network/nodes/validator-node/modify-nodes/update-trusted-setup#source-code-deployment)
      for verification and the `validator.yaml` paths these files must match)
 
 7. Next, copy the `validator.yaml` and `fullnode.yaml` template files (that were just downloaded) into the

--- a/src/content/docs/network/nodes/validator-node/deploy-nodes/using-source-code.mdx
+++ b/src/content/docs/network/nodes/validator-node/deploy-nodes/using-source-code.mdx
@@ -193,7 +193,8 @@ and VFN will be deployed on separate machines.
   - `owner.yaml`: The owner, operator and voter mappings.
   - `operator.yaml`: Validator and VFN operator information.
 - `waypoint.txt`: The waypoint for the genesis transaction on the network you are connecting to.
-- `genesis.blob` The genesis blob for the network you are connecting to.
+- `genesis.blob`: The genesis blob for the network you are connecting to.
+- `digest_key.bin` and `pp.bin` (validators only): DKG trusted-setup blobs at the paths chosen in step 7 (may live outside the working directory).
 
 11. Now that you have set up your configuration files, you can start your validator and VFN.
     To start your validator, run the following commands, with the paths assuming you are in the root of the `aptos-core` directory:

--- a/src/content/docs/network/nodes/validator-node/deploy-nodes/using-source-code.mdx
+++ b/src/content/docs/network/nodes/validator-node/deploy-nodes/using-source-code.mdx
@@ -122,13 +122,14 @@ and VFN will be deployed on separate machines.
 
    ```shellscript filename="Terminal"
    wget -O /opt/aptos/genesis/digest_key.bin \
-     https://github.com/aptos-labs/aptos-networks/raw/main/testnet/digest_key.bin
+     https://github.com/aptos-labs/aptos-networks/raw/main/<network>/digest_key.bin
    wget -O /opt/aptos/genesis/pp.bin \
-     https://github.com/aptos-labs/aptos-networks/raw/main/testnet/pp.bin
+     https://github.com/aptos-labs/aptos-networks/raw/main/<network>/pp.bin
    ```
 
-   Replace `testnet` with the network you operate on. See
-   [Update Trusted Setup → Source code deployment](/network/nodes/validator-node/modify-nodes/update-trusted-setup#source-code-deployment)
+   Replace `<network>` with `testnet` (mainnet trusted-setup blobs are not yet published — see
+   [Update Trusted Setup → Published checksums](/network/nodes/validator-node/modify-nodes/update-trusted-setup#published-checksums)).
+   See [Update Trusted Setup → Source code deployment](/network/nodes/validator-node/modify-nodes/update-trusted-setup#source-code-deployment)
    for the verification step (`aptos node validate-digest-key` / `validate-public-parameters`).
 
 8. Next, copy the `validator.yaml` and `fullnode.yaml` template files (that were just downloaded) into the

--- a/src/content/docs/network/nodes/validator-node/deploy-nodes/using-source-code.mdx
+++ b/src/content/docs/network/nodes/validator-node/deploy-nodes/using-source-code.mdx
@@ -127,9 +127,8 @@ and VFN will be deployed on separate machines.
      https://github.com/aptos-labs/aptos-networks/raw/main/<network>/pp.bin
    ```
 
-   Replace `<network>` with `testnet` (mainnet trusted-setup blobs are not yet published — see
-   [Update Trusted Setup → Published checksums](/network/nodes/validator-node/modify-nodes/update-trusted-setup#published-checksums)).
-   See [Update Trusted Setup → Source code deployment](/network/nodes/validator-node/modify-nodes/update-trusted-setup#source-code-deployment)
+   Replace `<network>` with the appropriate network (`testnet` or `mainnet`). See
+   [Update Trusted Setup → Source code deployment](/network/nodes/validator-node/modify-nodes/update-trusted-setup#source-code-deployment)
    for the verification step (`aptos node validate-digest-key` / `validate-public-parameters`).
 
 8. Next, copy the `validator.yaml` and `fullnode.yaml` template files (that were just downloaded) into the

--- a/src/content/docs/network/nodes/validator-node/modify-nodes/update-trusted-setup.mdx
+++ b/src/content/docs/network/nodes/validator-node/modify-nodes/update-trusted-setup.mdx
@@ -3,6 +3,9 @@ title: "Update Trusted Setup"
 description: "Download, verify, and rotate the DKG trusted-setup blobs (digest_key.bin and pp.bin) used by Aptos validator consensus."
 sidebar:
   label: "Update Trusted Setup"
+  badge:
+    text: New
+    variant: tip
 ---
 
 import { Aside } from '@astrojs/starlight/components';

--- a/src/content/docs/network/nodes/validator-node/modify-nodes/update-trusted-setup.mdx
+++ b/src/content/docs/network/nodes/validator-node/modify-nodes/update-trusted-setup.mdx
@@ -1,0 +1,110 @@
+---
+title: "Update Trusted Setup"
+description: "Download, verify, and rotate the DKG trusted-setup blobs (digest_key.bin and pp.bin) used by Aptos validator consensus."
+sidebar:
+  label: "Update Trusted Setup"
+---
+
+import { Aside } from '@astrojs/starlight/components';
+
+Aptos validators consume two trusted-setup blobs at startup: `digest_key.bin` and `pp.bin` (public parameters).
+The blobs are published by Aptos Labs in the [`aptos-labs/aptos-networks`](https://github.com/aptos-labs/aptos-networks)
+repository and are loaded by consensus before the node begins participating in DKG. VFNs and PFNs do **not** need
+these files.
+
+This page covers the steps an existing validator operator should take to download a new revision of the blobs,
+verify their integrity, and roll the change out to their node.
+
+<Aside type="caution">
+  Every validator in the fleet must load the **same** bytes. Loading a stale or mismatched blob on a subset of
+  validators will prevent the affected nodes from participating in consensus. Always verify the `blake3` checksum
+  against the values published below before restarting your node.
+</Aside>
+
+<Aside type="note">
+  These files are currently published for **testnet** only. Mainnet instructions will be added once the blobs are
+  published upstream.
+</Aside>
+
+## 1. Download the blobs
+
+Both files are stored via Git LFS, so the download URL uses `github.com/.../raw/main/...` (which follows the LFS
+redirect) rather than `raw.githubusercontent.com`.
+
+```shellscript filename="Terminal"
+wget -O /opt/aptos/genesis/digest_key.bin \
+  https://github.com/aptos-labs/aptos-networks/raw/main/testnet/digest_key.bin
+wget -O /opt/aptos/genesis/pp.bin \
+  https://github.com/aptos-labs/aptos-networks/raw/main/testnet/pp.bin
+```
+
+Adjust the destination paths to wherever your deployment stores `genesis.blob` and `waypoint.txt`. The path you
+choose must match the `consensus.digest_key_blob_path` and `consensus.public_parameters_blob_path` entries in
+`validator.yaml` (see step 3).
+
+## 2. Verify with the Aptos CLI
+
+Use the `aptos` CLI to confirm each file deserializes correctly and to compute its `blake3` checksum:
+
+```shellscript filename="Terminal"
+aptos node validate-digest-key --file /opt/aptos/genesis/digest_key.bin
+aptos node validate-public-parameters --file /opt/aptos/genesis/pp.bin
+```
+
+Each command prints JSON of the following shape:
+
+```json
+{
+  "size": 4002048590,
+  "blake3": "ffff6ab738c58c1c7eeb697eecbc369205e111c9ef271ab2cbe524869671b441"
+}
+```
+
+Compare the `size` and `blake3` fields against the values below.
+
+### Expected testnet checksums
+
+The following checksums correspond to the blobs at
+[`aptos-networks@92b13bf`](https://github.com/aptos-labs/aptos-networks/tree/92b13bf7844a0630cf5688ce8d309c46f712bbf2/testnet)
+(current as of 2026-05-14). This page is updated whenever Aptos Labs publishes a new revision.
+
+| File             | Size (bytes) | blake3                                                             |
+| ---------------- | ------------ | ------------------------------------------------------------------ |
+| `digest_key.bin` | `4002048590` | `ffff6ab738c58c1c7eeb697eecbc369205e111c9ef271ab2cbe524869671b441` |
+| `pp.bin`         | `201655505`  | `a01c219766c4190f7d1b77836c0efd41b96486f7d46902f93e9b15260ea05cbc` |
+
+If either value differs, **do not restart the validator** — re-download the file (the most common cause is a
+truncated transfer or fetching the LFS pointer text via `raw.githubusercontent.com` instead of the LFS-redirected
+`github.com/.../raw/...` URL).
+
+## 3. Configure validator.yaml
+
+Confirm that the `consensus` block in your `validator.yaml` references both files. The paths must match the
+locations you wrote to in step 1.
+
+```yaml
+consensus:
+  digest_key_blob_path: /opt/aptos/genesis/digest_key.bin
+  public_parameters_blob_path: /opt/aptos/genesis/pp.bin
+```
+
+If your deployment is managed by Helm using the official `aptos-node` chart, the init container will curl these
+blobs into `/opt/aptos/genesis/` for you when `digest_key_blob_url` and `public_parameters_blob_url` are set on
+the chart values. In that case the only operator action required is bumping the URLs and triggering a pod
+restart.
+
+## 4. Confirm fleet consistency (optional)
+
+Once the node restarts, two Prometheus metrics expose the `blake3` of each loaded blob as a label:
+
+- `aptos_dkg_digest_key_blake3{blake3="<hex>"} 1`
+- `aptos_dkg_public_params_blake3{blake3="<hex>"} 1`
+
+Group by the `blake3` label in Grafana across your validator fleet. A healthy rollout shows a single label value
+per metric matching the table above. Multiple values indicate at least one validator is running a stale blob.
+
+## 5. Restart the validator
+
+Follow your normal restart procedure (see [Upgrade Nodes](/network/nodes/validator-node/modify-nodes/update-validator-node)
+for deployment-specific steps). The node loads the blobs once during startup; subsequent rotations require
+another restart.

--- a/src/content/docs/network/nodes/validator-node/modify-nodes/update-trusted-setup.mdx
+++ b/src/content/docs/network/nodes/validator-node/modify-nodes/update-trusted-setup.mdx
@@ -21,15 +21,16 @@ verify their integrity, and roll the change out to their node.
   against the values published below before restarting your node.
 </Aside>
 
-<Aside type="note">
-  These files are currently published for **testnet** only. Mainnet instructions will be added once the blobs are
-  published upstream.
-</Aside>
-
 ## 1. Download the blobs
 
 Both files are stored via Git LFS, so the download URL uses `github.com/.../raw/main/...` (which follows the LFS
 redirect) rather than `raw.githubusercontent.com`.
+
+Adjust the destination paths to wherever your deployment stores `genesis.blob` and `waypoint.txt`. The path you
+choose must match the `consensus.digest_key_blob_path` and `consensus.public_parameters_blob_path` entries in
+`validator.yaml` (see step 3).
+
+### Testnet
 
 ```shellscript filename="Terminal"
 wget -O /opt/aptos/genesis/digest_key.bin \
@@ -38,9 +39,19 @@ wget -O /opt/aptos/genesis/pp.bin \
   https://github.com/aptos-labs/aptos-networks/raw/main/testnet/pp.bin
 ```
 
-Adjust the destination paths to wherever your deployment stores `genesis.blob` and `waypoint.txt`. The path you
-choose must match the `consensus.digest_key_blob_path` and `consensus.public_parameters_blob_path` entries in
-`validator.yaml` (see step 3).
+### Mainnet
+
+<Aside type="note">
+  Mainnet trusted-setup blobs are not yet published. The commands below are the expected form; this page will
+  be updated with working URLs and checksums once Aptos Labs publishes the files.
+</Aside>
+
+```shellscript filename="Terminal"
+wget -O /opt/aptos/genesis/digest_key.bin \
+  https://github.com/aptos-labs/aptos-networks/raw/main/mainnet/digest_key.bin
+wget -O /opt/aptos/genesis/pp.bin \
+  https://github.com/aptos-labs/aptos-networks/raw/main/mainnet/pp.bin
+```
 
 ## 2. Verify with the Aptos CLI
 
@@ -60,22 +71,24 @@ Each command prints JSON of the following shape:
 }
 ```
 
-Compare the `size` and `blake3` fields against the values below.
+Compare the `size` and `blake3` fields against the values below for the network you are operating on.
 
-### Expected testnet checksums
+### Expected checksums
 
-The following checksums correspond to the blobs at
+Testnet checksums correspond to the blobs at
 [`aptos-networks@92b13bf`](https://github.com/aptos-labs/aptos-networks/tree/92b13bf7844a0630cf5688ce8d309c46f712bbf2/testnet)
-(current as of 2026-05-14). This page is updated whenever Aptos Labs publishes a new revision.
+(current as of 2026-05-14). This table is updated whenever Aptos Labs publishes a new revision.
 
-| File             | Size (bytes) | blake3                                                             |
-| ---------------- | ------------ | ------------------------------------------------------------------ |
-| `digest_key.bin` | `4002048590` | `ffff6ab738c58c1c7eeb697eecbc369205e111c9ef271ab2cbe524869671b441` |
-| `pp.bin`         | `201655505`  | `a01c219766c4190f7d1b77836c0efd41b96486f7d46902f93e9b15260ea05cbc` |
+| Network | File             | Size (bytes)              | blake3                                                             |
+| ------- | ---------------- | ------------------------- | ------------------------------------------------------------------ |
+| testnet | `digest_key.bin` | `4002048590`              | `ffff6ab738c58c1c7eeb697eecbc369205e111c9ef271ab2cbe524869671b441` |
+| testnet | `pp.bin`         | `201655505`               | `a01c219766c4190f7d1b77836c0efd41b96486f7d46902f93e9b15260ea05cbc` |
+| mainnet | `digest_key.bin` | _TBD — not yet published_ | _TBD — not yet published_                                          |
+| mainnet | `pp.bin`         | _TBD — not yet published_ | _TBD — not yet published_                                          |
 
-If either value differs, **do not restart the validator** — re-download the file (the most common cause is a
-truncated transfer or fetching the LFS pointer text via `raw.githubusercontent.com` instead of the LFS-redirected
-`github.com/.../raw/...` URL).
+If either value differs from the row for your network, **do not restart the validator** — re-download the file
+(the most common cause is a truncated transfer or fetching the LFS pointer text via `raw.githubusercontent.com`
+instead of the LFS-redirected `github.com/.../raw/...` URL).
 
 ## 3. Configure validator.yaml
 

--- a/src/content/docs/network/nodes/validator-node/modify-nodes/update-trusted-setup.mdx
+++ b/src/content/docs/network/nodes/validator-node/modify-nodes/update-trusted-setup.mdx
@@ -13,8 +13,11 @@ repository and are loaded by consensus before the node begins participating in D
 these files.
 
 This page covers the steps an existing validator operator should take to roll a new revision of the blobs onto
-their node. The flow depends on how you deploy: self-managed (source code or Docker) or via the official
-`aptos-node` Helm chart (AWS / GCP / Azure k8s deployments).
+their node. The flow depends on how you deploy:
+
+- **Source code** — you run the validator binary directly.
+- **Docker (compose)** — you run the upstream `aptos-node` docker-compose stack.
+- **Kubernetes (Helm chart)** — you run the official `aptos-node` Helm chart on AWS / GCP / Azure.
 
 <Aside type="caution">
   Every validator in the fleet must load the **same** bytes. Loading a stale or mismatched blob on a subset of
@@ -41,15 +44,15 @@ Testnet checksums correspond to the blobs at
   wrong URL will silently break consensus.
 </Aside>
 
-## Self-managed deployment (source code or Docker)
+## Source code deployment
 
-Use this flow if you run the validator directly from a binary built from source or from a Docker compose file.
-You download the blobs to disk and tell `validator.yaml` where to find them.
+Use this flow if you run the validator directly from a binary built from `aptos-core`. You pick where the blobs
+live on disk and point `validator.yaml` at them.
 
 ### 1. Download the blobs
 
-Pick a directory on the same machine as the validator. The example below uses `/opt/aptos/genesis/` (alongside
-`genesis.blob` and `waypoint.txt`); any path on persistent local storage works.
+Pick a directory on the validator host — anywhere on persistent local storage works. The example below uses
+`/opt/aptos/genesis/` alongside `genesis.blob` and `waypoint.txt`.
 
 #### Testnet
 
@@ -113,6 +116,76 @@ Follow your normal restart procedure (see
 [Upgrade Nodes](/network/nodes/validator-node/modify-nodes/update-validator-node) for deployment-specific steps).
 The node loads the blobs once during startup; subsequent rotations require another restart.
 
+## Docker (compose) deployment
+
+Use this flow if you run the upstream `docker-compose.yaml` from
+[`aptos-core/docker/compose/aptos-node`](https://github.com/aptos-labs/aptos-core/tree/testnet/docker/compose/aptos-node).
+The upstream compose file bind-mounts the trusted-setup files from your working directory into the container at
+`/opt/aptos/genesis/`, and the upstream `validator.yaml` already has the matching `consensus` paths — so you only
+need to drop the files alongside `genesis.blob` / `waypoint.txt`.
+
+### 1. Download the blobs into your working directory
+
+```shellscript filename="Terminal"
+cd ~/$WORKSPACE   # the directory holding genesis.blob and waypoint.txt
+wget -O digest_key.bin https://github.com/aptos-labs/aptos-networks/raw/main/testnet/digest_key.bin
+wget -O pp.bin https://github.com/aptos-labs/aptos-networks/raw/main/testnet/pp.bin
+```
+
+Replace `testnet` with the network you operate on (mainnet blobs are not yet published; see the
+[Published checksums](#published-checksums) note).
+
+### 2. Verify with the Aptos CLI
+
+```shellscript filename="Terminal"
+aptos node validate-digest-key --file digest_key.bin
+aptos node validate-public-parameters --file pp.bin
+```
+
+Compare `size` and `blake3` against the [Published checksums](#published-checksums) table for your network. If
+they don't match, re-download — **do not restart the validator** with a bad file.
+
+### 3. Confirm docker-compose.yaml and validator.yaml are current
+
+The upstream files include both bind mounts and the `consensus` block. If you set up the validator before these
+were added, refresh both files from the `testnet` branch of `aptos-core` (see
+[Testnet Files](/network/nodes/configure/node-files-all-networks/node-files-testnet)) and reconcile any local
+modifications. The relevant pieces to confirm:
+
+`docker-compose.yaml` (validator service):
+
+```yaml
+volumes:
+  # …existing mounts (genesis.blob, waypoint.txt, validator.yaml, identity files)…
+  - type: bind
+    source: ./digest_key.bin
+    target: /opt/aptos/genesis/digest_key.bin
+  - type: bind
+    source: ./pp.bin
+    target: /opt/aptos/genesis/pp.bin
+```
+
+`validator.yaml`:
+
+```yaml
+consensus:
+  digest_key_blob_path: /opt/aptos/genesis/digest_key.bin
+  public_parameters_blob_path: /opt/aptos/genesis/pp.bin
+  # …safety_rules and other consensus settings…
+```
+
+### 4. Restart the validator
+
+```shellscript filename="Terminal"
+docker compose restart validator
+```
+
+Or recreate the stack to pick up any `docker-compose.yaml` changes:
+
+```shellscript filename="Terminal"
+docker compose up -d
+```
+
 ## Kubernetes deployment (Helm chart)
 
 Use this flow if you deploy the validator via the official `aptos-node` Helm chart (the typical setup on AWS,
@@ -144,8 +217,8 @@ trustedSetup:
 ### 2. (Optional) Pre-verify the checksum on a workstation
 
 The chart fetches the bytes inside the cluster, so the in-cluster download never sees the `aptos` CLI. To
-sanity-check the URL before rollout, download a copy locally and run the [self-managed verify
-step](#2-verify-with-the-aptos-cli) on it:
+sanity-check the URL before rollout, download a copy locally and run the
+[source-code verify step](#2-verify-with-the-aptos-cli) on it:
 
 ```shellscript filename="Terminal"
 wget -O /tmp/digest_key.bin \
@@ -180,8 +253,8 @@ trustedSetup:
 
 ## Confirm fleet consistency
 
-After your validators have restarted (either flow), two Prometheus metrics expose the `blake3` of each loaded
-blob as a label:
+After your validators have restarted (any flow), two Prometheus metrics expose the `blake3` of each loaded blob
+as a label:
 
 - `aptos_dkg_digest_key_blake3{blake3="<hex>"} 1`
 - `aptos_dkg_public_params_blake3{blake3="<hex>"} 1`

--- a/src/content/docs/network/nodes/validator-node/modify-nodes/update-trusted-setup.mdx
+++ b/src/content/docs/network/nodes/validator-node/modify-nodes/update-trusted-setup.mdx
@@ -28,13 +28,13 @@ their node. The flow depends on how you deploy:
 ## Published checksums
 
 Testnet checksums correspond to the blobs at
-[`aptos-networks@92b13bf`](https://github.com/aptos-labs/aptos-networks/tree/92b13bf7844a0630cf5688ce8d309c46f712bbf2/testnet)
-(current as of 2026-05-14). This table is updated whenever Aptos Labs publishes a new revision.
+[`aptos-networks@8cfc400`](https://github.com/aptos-labs/aptos-networks/tree/8cfc400bc1e42a232b5b36cde779a5b71d4d275b/testnet)
+(current as of 2026-05-15). This table is updated whenever Aptos Labs publishes a new revision.
 
 | Network | File             | Size (bytes)              | blake3                                                             |
 | ------- | ---------------- | ------------------------- | ------------------------------------------------------------------ |
 | testnet | `digest_key.bin` | `4002048590`              | `ffff6ab738c58c1c7eeb697eecbc369205e111c9ef271ab2cbe524869671b441` |
-| testnet | `pp.bin`         | `201655505`               | `a01c219766c4190f7d1b77836c0efd41b96486f7d46902f93e9b15260ea05cbc` |
+| testnet | `pp.bin`         | `889521361`               | `5094dd22376eefde2febae5f2c9935d7eab0440af93166d246aa5c9f8ecb1b52` |
 | mainnet | `digest_key.bin` | _TBD — not yet published_ | _TBD — not yet published_                                          |
 | mainnet | `pp.bin`         | _TBD — not yet published_ | _TBD — not yet published_                                          |
 
@@ -191,8 +191,8 @@ trustedSetup:
   path: /opt/aptos/data/trusted-setup
   # Bump this integer to force re-download even when URLs are unchanged. Default 0.
   refreshCounter: 0
-  digestKeyUrl: "https://github.com/aptos-labs/aptos-networks/raw/92b13bf7844a0630cf5688ce8d309c46f712bbf2/testnet/digest_key.bin"
-  publicParametersUrl: "https://github.com/aptos-labs/aptos-networks/raw/92b13bf7844a0630cf5688ce8d309c46f712bbf2/testnet/pp.bin"
+  digestKeyUrl: "https://github.com/aptos-labs/aptos-networks/raw/8cfc400bc1e42a232b5b36cde779a5b71d4d275b/testnet/digest_key.bin"
+  publicParametersUrl: "https://github.com/aptos-labs/aptos-networks/raw/8cfc400bc1e42a232b5b36cde779a5b71d4d275b/testnet/pp.bin"
 ```
 
 <Aside type="tip">
@@ -208,7 +208,7 @@ sanity-check the URL before rollout, download a copy locally and run the
 
 ```shellscript filename="Terminal"
 wget -O /tmp/digest_key.bin \
-  https://github.com/aptos-labs/aptos-networks/raw/92b13bf7844a0630cf5688ce8d309c46f712bbf2/testnet/digest_key.bin
+  https://github.com/aptos-labs/aptos-networks/raw/8cfc400bc1e42a232b5b36cde779a5b71d4d275b/testnet/digest_key.bin
 aptos node validate-digest-key --file /tmp/digest_key.bin
 ```
 

--- a/src/content/docs/network/nodes/validator-node/modify-nodes/update-trusted-setup.mdx
+++ b/src/content/docs/network/nodes/validator-node/modify-nodes/update-trusted-setup.mdx
@@ -106,18 +106,18 @@ blobs into `/opt/aptos/genesis/` for you when `digest_key_blob_url` and `public_
 the chart values. In that case the only operator action required is bumping the URLs and triggering a pod
 restart.
 
-## 4. Confirm fleet consistency (optional)
+## 4. Restart the validator
 
-Once the node restarts, two Prometheus metrics expose the `blake3` of each loaded blob as a label:
+Follow your normal restart procedure (see [Upgrade Nodes](/network/nodes/validator-node/modify-nodes/update-validator-node)
+for deployment-specific steps). The node loads the blobs once during startup; subsequent rotations require
+another restart.
+
+## 5. Confirm fleet consistency (optional)
+
+After the restart, two Prometheus metrics expose the `blake3` of each loaded blob as a label:
 
 - `aptos_dkg_digest_key_blake3{blake3="<hex>"} 1`
 - `aptos_dkg_public_params_blake3{blake3="<hex>"} 1`
 
 Group by the `blake3` label in Grafana across your validator fleet. A healthy rollout shows a single label value
 per metric matching the table above. Multiple values indicate at least one validator is running a stale blob.
-
-## 5. Restart the validator
-
-Follow your normal restart procedure (see [Upgrade Nodes](/network/nodes/validator-node/modify-nodes/update-validator-node)
-for deployment-specific steps). The node loads the blobs once during startup; subsequent rotations require
-another restart.

--- a/src/content/docs/network/nodes/validator-node/modify-nodes/update-trusted-setup.mdx
+++ b/src/content/docs/network/nodes/validator-node/modify-nodes/update-trusted-setup.mdx
@@ -12,25 +12,46 @@ The blobs are published by Aptos Labs in the [`aptos-labs/aptos-networks`](https
 repository and are loaded by consensus before the node begins participating in DKG. VFNs and PFNs do **not** need
 these files.
 
-This page covers the steps an existing validator operator should take to download a new revision of the blobs,
-verify their integrity, and roll the change out to their node.
+This page covers the steps an existing validator operator should take to roll a new revision of the blobs onto
+their node. The flow depends on how you deploy: self-managed (source code or Docker) or via the official
+`aptos-node` Helm chart (AWS / GCP / Azure k8s deployments).
 
 <Aside type="caution">
   Every validator in the fleet must load the **same** bytes. Loading a stale or mismatched blob on a subset of
-  validators will prevent the affected nodes from participating in consensus. Always verify the `blake3` checksum
-  against the values published below before restarting your node.
+  validators will prevent the affected nodes from participating in consensus. Always confirm the `blake3` checksum
+  matches the value published below before you start sending traffic to a restarted validator.
 </Aside>
 
-## 1. Download the blobs
+## Published checksums
 
-Both files are stored via Git LFS, so the download URL uses `github.com/.../raw/main/...` (which follows the LFS
-redirect) rather than `raw.githubusercontent.com`.
+Testnet checksums correspond to the blobs at
+[`aptos-networks@92b13bf`](https://github.com/aptos-labs/aptos-networks/tree/92b13bf7844a0630cf5688ce8d309c46f712bbf2/testnet)
+(current as of 2026-05-14). This table is updated whenever Aptos Labs publishes a new revision.
 
-Adjust the destination paths to wherever your deployment stores `genesis.blob` and `waypoint.txt`. The path you
-choose must match the `consensus.digest_key_blob_path` and `consensus.public_parameters_blob_path` entries in
-`validator.yaml` (see step 3).
+| Network | File             | Size (bytes)              | blake3                                                             |
+| ------- | ---------------- | ------------------------- | ------------------------------------------------------------------ |
+| testnet | `digest_key.bin` | `4002048590`              | `ffff6ab738c58c1c7eeb697eecbc369205e111c9ef271ab2cbe524869671b441` |
+| testnet | `pp.bin`         | `201655505`               | `a01c219766c4190f7d1b77836c0efd41b96486f7d46902f93e9b15260ea05cbc` |
+| mainnet | `digest_key.bin` | _TBD — not yet published_ | _TBD — not yet published_                                          |
+| mainnet | `pp.bin`         | _TBD — not yet published_ | _TBD — not yet published_                                          |
 
-### Testnet
+<Aside type="note">
+  Both blobs are stored via Git LFS, so download URLs must use `github.com/.../raw/...` (which follows the LFS
+  redirect) rather than `raw.githubusercontent.com` (which returns the 135-byte LFS pointer text). Using the
+  wrong URL will silently break consensus.
+</Aside>
+
+## Self-managed deployment (source code or Docker)
+
+Use this flow if you run the validator directly from a binary built from source or from a Docker compose file.
+You download the blobs to disk and tell `validator.yaml` where to find them.
+
+### 1. Download the blobs
+
+Pick a directory on the same machine as the validator. The example below uses `/opt/aptos/genesis/` (alongside
+`genesis.blob` and `waypoint.txt`); any path on persistent local storage works.
+
+#### Testnet
 
 ```shellscript filename="Terminal"
 wget -O /opt/aptos/genesis/digest_key.bin \
@@ -39,11 +60,11 @@ wget -O /opt/aptos/genesis/pp.bin \
   https://github.com/aptos-labs/aptos-networks/raw/main/testnet/pp.bin
 ```
 
-### Mainnet
+#### Mainnet
 
 <Aside type="note">
-  Mainnet trusted-setup blobs are not yet published. The commands below are the expected form; this page will
-  be updated with working URLs and checksums once Aptos Labs publishes the files.
+  Mainnet trusted-setup blobs are not yet published. The commands below are the expected form; this page will be
+  updated with working URLs once Aptos Labs publishes the files.
 </Aside>
 
 ```shellscript filename="Terminal"
@@ -53,9 +74,9 @@ wget -O /opt/aptos/genesis/pp.bin \
   https://github.com/aptos-labs/aptos-networks/raw/main/mainnet/pp.bin
 ```
 
-## 2. Verify with the Aptos CLI
+### 2. Verify with the Aptos CLI
 
-Use the `aptos` CLI to confirm each file deserializes correctly and to compute its `blake3` checksum:
+Confirm each file deserializes correctly and compute its `blake3` checksum:
 
 ```shellscript filename="Terminal"
 aptos node validate-digest-key --file /opt/aptos/genesis/digest_key.bin
@@ -71,29 +92,14 @@ Each command prints JSON of the following shape:
 }
 ```
 
-Compare the `size` and `blake3` fields against the values below for the network you are operating on.
+Compare both fields against the [Published checksums](#published-checksums) table for your network. If either
+value differs, **do not restart the validator** — re-download the file (most common cause: truncated transfer or
+fetching the LFS pointer text via `raw.githubusercontent.com`).
 
-### Expected checksums
+### 3. Configure validator.yaml
 
-Testnet checksums correspond to the blobs at
-[`aptos-networks@92b13bf`](https://github.com/aptos-labs/aptos-networks/tree/92b13bf7844a0630cf5688ce8d309c46f712bbf2/testnet)
-(current as of 2026-05-14). This table is updated whenever Aptos Labs publishes a new revision.
-
-| Network | File             | Size (bytes)              | blake3                                                             |
-| ------- | ---------------- | ------------------------- | ------------------------------------------------------------------ |
-| testnet | `digest_key.bin` | `4002048590`              | `ffff6ab738c58c1c7eeb697eecbc369205e111c9ef271ab2cbe524869671b441` |
-| testnet | `pp.bin`         | `201655505`               | `a01c219766c4190f7d1b77836c0efd41b96486f7d46902f93e9b15260ea05cbc` |
-| mainnet | `digest_key.bin` | _TBD — not yet published_ | _TBD — not yet published_                                          |
-| mainnet | `pp.bin`         | _TBD — not yet published_ | _TBD — not yet published_                                          |
-
-If either value differs from the row for your network, **do not restart the validator** — re-download the file
-(the most common cause is a truncated transfer or fetching the LFS pointer text via `raw.githubusercontent.com`
-instead of the LFS-redirected `github.com/.../raw/...` URL).
-
-## 3. Configure validator.yaml
-
-Confirm that the `consensus` block in your `validator.yaml` references both files. The paths must match the
-locations you wrote to in step 1.
+Confirm the `consensus` block in your `validator.yaml` references both files. Paths must match where you wrote
+them in step 1.
 
 ```yaml
 consensus:
@@ -101,23 +107,85 @@ consensus:
   public_parameters_blob_path: /opt/aptos/genesis/pp.bin
 ```
 
-If your deployment is managed by Helm using the official `aptos-node` chart, the init container will curl these
-blobs into `/opt/aptos/genesis/` for you when `digest_key_blob_url` and `public_parameters_blob_url` are set on
-the chart values. In that case the only operator action required is bumping the URLs and triggering a pod
-restart.
+### 4. Restart the validator
 
-## 4. Restart the validator
+Follow your normal restart procedure (see
+[Upgrade Nodes](/network/nodes/validator-node/modify-nodes/update-validator-node) for deployment-specific steps).
+The node loads the blobs once during startup; subsequent rotations require another restart.
 
-Follow your normal restart procedure (see [Upgrade Nodes](/network/nodes/validator-node/modify-nodes/update-validator-node)
-for deployment-specific steps). The node loads the blobs once during startup; subsequent rotations require
-another restart.
+## Kubernetes deployment (Helm chart)
 
-## 5. Confirm fleet consistency (optional)
+Use this flow if you deploy the validator via the official `aptos-node` Helm chart (the typical setup on AWS,
+GCP, and Azure). You do **not** download the blobs manually — the chart's init container fetches them into a
+persistent volume on first restart and skips on subsequent restarts.
 
-After the restart, two Prometheus metrics expose the `blake3` of each loaded blob as a label:
+### 1. Update the `trustedSetup` chart values
+
+Set the URLs (and optionally override the on-disk path) under the chart's `trustedSetup` block. The chart writes
+the blobs to `trustedSetup.path` on the persistent `aptos-data` PVC and configures
+`consensus.digest_key_blob_path` / `public_parameters_blob_path` in `validator.yaml` to match — no further
+validator config is needed.
+
+```yaml
+trustedSetup:
+  # Persistent location on the aptos-data PVC. Default works for most deployments.
+  path: /opt/aptos/data/trusted-setup
+  # Bump this integer to force re-download even when URLs are unchanged. Default 0.
+  refreshCounter: 0
+  digestKeyUrl: "https://github.com/aptos-labs/aptos-networks/raw/92b13bf7844a0630cf5688ce8d309c46f712bbf2/testnet/digest_key.bin"
+  publicParametersUrl: "https://github.com/aptos-labs/aptos-networks/raw/92b13bf7844a0630cf5688ce8d309c46f712bbf2/testnet/pp.bin"
+```
+
+<Aside type="tip">
+  **Pin to an `aptos-networks` commit SHA**, not `main`. Pinning makes rotations explicit and diffable, and
+  prevents a silent `main`-tracking pull from rolling out new bytes on the next pod restart.
+</Aside>
+
+### 2. (Optional) Pre-verify the checksum on a workstation
+
+The chart fetches the bytes inside the cluster, so the in-cluster download never sees the `aptos` CLI. To
+sanity-check the URL before rollout, download a copy locally and run the [self-managed verify
+step](#2-verify-with-the-aptos-cli) on it:
+
+```shellscript filename="Terminal"
+wget -O /tmp/digest_key.bin \
+  https://github.com/aptos-labs/aptos-networks/raw/92b13bf7844a0630cf5688ce8d309c46f712bbf2/testnet/digest_key.bin
+aptos node validate-digest-key --file /tmp/digest_key.bin
+```
+
+Compare the printed `blake3` against the [Published checksums](#published-checksums) table.
+
+### 3. Apply and restart
+
+Run your usual chart-deployment command (`helm upgrade`, `pulumi up`, Terraform apply, etc.). The init container
+detects that the on-disk `.url` marker no longer matches the new URL, downloads the blob into
+`trustedSetup.path`, and writes a new marker. The validator container then loads the freshly fetched files.
+
+<Aside type="note">
+  **First restart pays a one-time download cost.** The blobs total ~4 GiB on testnet, fetched once into the
+  persistent data PVC. Subsequent restarts skip the download via the marker check and start in seconds.
+</Aside>
+
+### Force a re-download without changing URLs
+
+If you suspect on-disk corruption or want to re-fetch from the same URL (for example, to recover from a
+half-written download), bump `trustedSetup.refreshCounter` by one and re-apply. The init container wipes the
+existing markers, which forces every blob to be re-downloaded on the next pod restart.
+
+```yaml
+trustedSetup:
+  refreshCounter: 1 # was 0
+  # urls unchanged
+```
+
+## Confirm fleet consistency
+
+After your validators have restarted (either flow), two Prometheus metrics expose the `blake3` of each loaded
+blob as a label:
 
 - `aptos_dkg_digest_key_blake3{blake3="<hex>"} 1`
 - `aptos_dkg_public_params_blake3{blake3="<hex>"} 1`
 
 Group by the `blake3` label in Grafana across your validator fleet. A healthy rollout shows a single label value
-per metric matching the table above. Multiple values indicate at least one validator is running a stale blob.
+per metric matching the [Published checksums](#published-checksums) table. Multiple values indicate at least one
+validator is running a stale blob.

--- a/src/content/docs/network/nodes/validator-node/modify-nodes/update-trusted-setup.mdx
+++ b/src/content/docs/network/nodes/validator-node/modify-nodes/update-trusted-setup.mdx
@@ -54,28 +54,14 @@ live on disk and point `validator.yaml` at them.
 Pick a directory on the validator host — anywhere on persistent local storage works. The example below uses
 `/opt/aptos/genesis/` alongside `genesis.blob` and `waypoint.txt`.
 
-#### Testnet
-
 ```shellscript filename="Terminal"
 wget -O /opt/aptos/genesis/digest_key.bin \
-  https://github.com/aptos-labs/aptos-networks/raw/main/testnet/digest_key.bin
+  https://github.com/aptos-labs/aptos-networks/raw/main/<network>/digest_key.bin
 wget -O /opt/aptos/genesis/pp.bin \
-  https://github.com/aptos-labs/aptos-networks/raw/main/testnet/pp.bin
+  https://github.com/aptos-labs/aptos-networks/raw/main/<network>/pp.bin
 ```
 
-#### Mainnet
-
-<Aside type="note">
-  Mainnet trusted-setup blobs are not yet published. The commands below are the expected form; this page will be
-  updated with working URLs once Aptos Labs publishes the files.
-</Aside>
-
-```shellscript filename="Terminal"
-wget -O /opt/aptos/genesis/digest_key.bin \
-  https://github.com/aptos-labs/aptos-networks/raw/main/mainnet/digest_key.bin
-wget -O /opt/aptos/genesis/pp.bin \
-  https://github.com/aptos-labs/aptos-networks/raw/main/mainnet/pp.bin
-```
+Replace `<network>` with the appropriate network (`testnet` or `mainnet`).
 
 ### 2. Verify with the Aptos CLI
 

--- a/src/content/docs/zh/network/glossary.mdx
+++ b/src/content/docs/zh/network/glossary.mdx
@@ -483,6 +483,17 @@ sidebar:
 
 - 参见 [Move 脚本](#move-脚本)
 
+### 可信设置
+
+- **可信设置**是 Aptos 验证者共识在参与分布式密钥生成(DKG)之前所消耗的一对二进制 blob
+  (`digest_key.bin` 和 `pp.bin`).
+- Aptos Labs 在 [`aptos-labs/aptos-networks`](https://github.com/aptos-labs/aptos-networks) 仓库中发布
+  这些 blob 并定期轮换它们.网络中的所有验证者必须加载相同的字节.
+- VFN 和 PFN 不需要这些文件.
+
+有关下载,CLI 验证和轮换的运维手册,请参阅
+[更新可信设置](/zh/network/nodes/validator-node/modify-nodes/update-trusted-setup).
+
 ## V
 
 ### 验证者

--- a/src/content/docs/zh/network/nodes/configure/node-files-all-networks/node-files-testnet.mdx
+++ b/src/content/docs/zh/network/nodes/configure/node-files-all-networks/node-files-testnet.mdx
@@ -51,6 +51,42 @@ import { Aside } from '@astrojs/starlight/components';
   wget -O waypoint.txt https://raw.githubusercontent.com/aptos-labs/aptos-networks/main/testnet/waypoint.txt
   ```
 
+### digest\_key.bin
+
+仅验证器需要的可信设置材料,由共识使用.VFN 和 PFN 不需要此文件.
+
+- **Git 仓库:** `aptos-networks`
+- **Git 分支:** `main`,位于 [https://github.com/aptos-labs/aptos-networks](https://github.com/aptos-labs/aptos-networks)
+- **下载命令:**
+  ```shellscript filename="Terminal"
+  wget -O digest_key.bin https://github.com/aptos-labs/aptos-networks/raw/main/testnet/digest_key.bin
+  ```
+
+<Aside type="note">
+  此文件通过 Git LFS 存储,因此下载 URL 使用 `github.com/.../raw/main/...`(它会跟随 LFS 重定向),而非
+  `raw.githubusercontent.com`.将 `validator.yaml` 中的 `consensus.digest_key_blob_path` 指向磁盘上的位置
+  (例如 `/opt/aptos/genesis/digest_key.bin`).有关验证和轮换步骤,请参阅
+  [更新可信设置](/zh/network/nodes/validator-node/modify-nodes/update-trusted-setup).
+</Aside>
+
+### pp.bin
+
+仅验证器需要的公共参数 blob,由共识使用.VFN 和 PFN 不需要此文件.
+
+- **Git 仓库:** `aptos-networks`
+- **Git 分支:** `main`,位于 [https://github.com/aptos-labs/aptos-networks](https://github.com/aptos-labs/aptos-networks)
+- **下载命令:**
+  ```shellscript filename="Terminal"
+  wget -O pp.bin https://github.com/aptos-labs/aptos-networks/raw/main/testnet/pp.bin
+  ```
+
+<Aside type="note">
+  此文件通过 Git LFS 存储,因此下载 URL 使用 `github.com/.../raw/main/...`(它会跟随 LFS 重定向),而非
+  `raw.githubusercontent.com`.将 `validator.yaml` 中的 `consensus.public_parameters_blob_path` 指向磁盘上的
+  位置(例如 `/opt/aptos/genesis/pp.bin`).有关验证和轮换步骤,请参阅
+  [更新可信设置](/zh/network/nodes/validator-node/modify-nodes/update-trusted-setup).
+</Aside>
+
 ### docker-compose-src.yaml
 
 - **Git 仓库:** `aptos-core`

--- a/src/content/docs/zh/network/nodes/configure/node-files-all-networks/node-files-testnet.mdx
+++ b/src/content/docs/zh/network/nodes/configure/node-files-all-networks/node-files-testnet.mdx
@@ -64,8 +64,10 @@ import { Aside } from '@astrojs/starlight/components';
 
 <Aside type="note">
   此文件通过 Git LFS 存储,因此下载 URL 使用 `github.com/.../raw/main/...`(它会跟随 LFS 重定向),而非
-  `raw.githubusercontent.com`.将 `validator.yaml` 中的 `consensus.digest_key_blob_path` 指向磁盘上的位置
-  (例如 `/opt/aptos/genesis/digest_key.bin`).有关验证和轮换步骤,请参阅
+  `raw.githubusercontent.com`.上方的 `wget` 适用于**自托管**部署(源代码或 Docker);将 `validator.yaml`
+  中的 `consensus.digest_key_blob_path` 指向磁盘上的位置(例如 `/opt/aptos/genesis/digest_key.bin`).
+  **Helm/k8s** 部署不需要手动下载 — `aptos-node` chart 会通过其 init 容器获取该 blob.有关完整的按部署
+  流程和验证步骤,请参阅
   [更新可信设置](/zh/network/nodes/validator-node/modify-nodes/update-trusted-setup).
 </Aside>
 
@@ -82,8 +84,10 @@ import { Aside } from '@astrojs/starlight/components';
 
 <Aside type="note">
   此文件通过 Git LFS 存储,因此下载 URL 使用 `github.com/.../raw/main/...`(它会跟随 LFS 重定向),而非
-  `raw.githubusercontent.com`.将 `validator.yaml` 中的 `consensus.public_parameters_blob_path` 指向磁盘上的
-  位置(例如 `/opt/aptos/genesis/pp.bin`).有关验证和轮换步骤,请参阅
+  `raw.githubusercontent.com`.上方的 `wget` 适用于**自托管**部署(源代码或 Docker);将 `validator.yaml`
+  中的 `consensus.public_parameters_blob_path` 指向磁盘上的位置(例如 `/opt/aptos/genesis/pp.bin`).
+  **Helm/k8s** 部署不需要手动下载 — `aptos-node` chart 会通过其 init 容器获取该 blob.有关完整的按部署
+  流程和验证步骤,请参阅
   [更新可信设置](/zh/network/nodes/validator-node/modify-nodes/update-trusted-setup).
 </Aside>
 

--- a/src/content/docs/zh/network/nodes/validator-node/deploy-nodes/using-aws.mdx
+++ b/src/content/docs/zh/network/nodes/validator-node/deploy-nodes/using-aws.mdx
@@ -153,6 +153,8 @@ import { Aside } from '@astrojs/starlight/components';
 
     - `genesis.blob`
     - `waypoint.txt`
+    - `digest_key.bin` 和 `pp.bin`(仅验证器;有关验证步骤,请参阅
+      [更新可信设置](/zh/network/nodes/validator-node/modify-nodes/update-trusted-setup))
 
 13. 总之,在您的工作目录(`~/$WORKSPACE`)中,您应该有以下文件列表:
 

--- a/src/content/docs/zh/network/nodes/validator-node/deploy-nodes/using-aws.mdx
+++ b/src/content/docs/zh/network/nodes/validator-node/deploy-nodes/using-aws.mdx
@@ -153,8 +153,13 @@ import { Aside } from '@astrojs/starlight/components';
 
     - `genesis.blob`
     - `waypoint.txt`
-    - `digest_key.bin` 和 `pp.bin`(仅验证器;有关验证步骤,请参阅
-      [更新可信设置](/zh/network/nodes/validator-node/modify-nodes/update-trusted-setup))
+
+    <Aside type="note">
+      验证器所需的 DKG 可信设置 blob(`digest_key.bin`,`pp.bin`)**不**在此处下载.`aptos-node` Helm
+      chart 通过其 init 容器将其获取到持久卷中 — 请按照
+      [更新可信设置 → Kubernetes 部署](/zh/network/nodes/validator-node/modify-nodes/update-trusted-setup#kubernetes-部署helm-chart)
+      配置 `trustedSetup.*` chart values.
+    </Aside>
 
 13. 总之,在您的工作目录(`~/$WORKSPACE`)中,您应该有以下文件列表:
 

--- a/src/content/docs/zh/network/nodes/validator-node/deploy-nodes/using-azure.mdx
+++ b/src/content/docs/zh/network/nodes/validator-node/deploy-nodes/using-azure.mdx
@@ -151,6 +151,8 @@ import { Aside } from '@astrojs/starlight/components';
 
     - `genesis.blob`
     - `waypoint.txt`
+    - `digest_key.bin` 和 `pp.bin`(仅验证器;有关验证步骤,请参阅
+      [更新可信设置](/zh/network/nodes/validator-node/modify-nodes/update-trusted-setup))
 
 13. 总之,在您的工作目录(`~/$WORKSPACE`)中,您应该有以下文件列表:
 

--- a/src/content/docs/zh/network/nodes/validator-node/deploy-nodes/using-azure.mdx
+++ b/src/content/docs/zh/network/nodes/validator-node/deploy-nodes/using-azure.mdx
@@ -151,8 +151,13 @@ import { Aside } from '@astrojs/starlight/components';
 
     - `genesis.blob`
     - `waypoint.txt`
-    - `digest_key.bin` 和 `pp.bin`(仅验证器;有关验证步骤,请参阅
-      [更新可信设置](/zh/network/nodes/validator-node/modify-nodes/update-trusted-setup))
+
+    <Aside type="note">
+      验证器所需的 DKG 可信设置 blob(`digest_key.bin`,`pp.bin`)**不**在此处下载.`aptos-node` Helm
+      chart 通过其 init 容器将其获取到持久卷中 — 请按照
+      [更新可信设置 → Kubernetes 部署](/zh/network/nodes/validator-node/modify-nodes/update-trusted-setup#kubernetes-部署helm-chart)
+      配置 `trustedSetup.*` chart values.
+    </Aside>
 
 13. 总之,在您的工作目录(`~/$WORKSPACE`)中,您应该有以下文件列表:
 

--- a/src/content/docs/zh/network/nodes/validator-node/deploy-nodes/using-docker.mdx
+++ b/src/content/docs/zh/network/nodes/validator-node/deploy-nodes/using-docker.mdx
@@ -106,8 +106,8 @@ import { Aside } from '@astrojs/starlight/components';
    - `blocked.ips`
    - `genesis.blob`
    - `waypoint.txt`
-   - `digest_key.bin` 和 `pp.bin`(仅验证器;有关验证步骤,请参阅
-     [更新可信设置](/zh/network/nodes/validator-node/modify-nodes/update-trusted-setup))
+   - `digest_key.bin` 和 `pp.bin`(仅验证器;有关验证步骤和这些文件必须匹配的 `validator.yaml` 路径,请参阅
+     [更新可信设置 → 自托管部署](/zh/network/nodes/validator-node/modify-nodes/update-trusted-setup#自托管部署源代码或-docker))
 
 5. 总之,您的工作目录(`~/$WORKSPACE`)中应该有以下文件列表:
 

--- a/src/content/docs/zh/network/nodes/validator-node/deploy-nodes/using-docker.mdx
+++ b/src/content/docs/zh/network/nodes/validator-node/deploy-nodes/using-docker.mdx
@@ -106,6 +106,8 @@ import { Aside } from '@astrojs/starlight/components';
    - `blocked.ips`
    - `genesis.blob`
    - `waypoint.txt`
+   - `digest_key.bin` 和 `pp.bin`(仅验证器;有关验证步骤,请参阅
+     [更新可信设置](/zh/network/nodes/validator-node/modify-nodes/update-trusted-setup))
 
 5. 总之,您的工作目录(`~/$WORKSPACE`)中应该有以下文件列表:
 

--- a/src/content/docs/zh/network/nodes/validator-node/deploy-nodes/using-docker.mdx
+++ b/src/content/docs/zh/network/nodes/validator-node/deploy-nodes/using-docker.mdx
@@ -107,7 +107,7 @@ import { Aside } from '@astrojs/starlight/components';
    - `genesis.blob`
    - `waypoint.txt`
 
-5. \*\*仅验证器:\*\*将可信设置 blob 下载到您的工作目录中,与 `genesis.blob` 和 `waypoint.txt` 放在一起.
+5. **仅验证器:** 将可信设置 blob 下载到您的工作目录中,与 `genesis.blob` 和 `waypoint.txt` 放在一起.
    上游 `docker-compose.yaml` 会从那里将它们绑定挂载到容器中:
 
    ```shellscript filename="Terminal"

--- a/src/content/docs/zh/network/nodes/validator-node/deploy-nodes/using-docker.mdx
+++ b/src/content/docs/zh/network/nodes/validator-node/deploy-nodes/using-docker.mdx
@@ -106,11 +106,21 @@ import { Aside } from '@astrojs/starlight/components';
    - `blocked.ips`
    - `genesis.blob`
    - `waypoint.txt`
-   - `digest_key.bin` 和 `pp.bin`(仅验证器;将其放在工作目录中 `genesis.blob` 和 `waypoint.txt`
-     旁边 — 上游 `docker-compose.yaml` 会从那里绑定挂载它们.有关验证步骤,请参阅
-     [更新可信设置 → Docker(compose)部署](/zh/network/nodes/validator-node/modify-nodes/update-trusted-setup#dockercompose部署))
 
-5. 总之,您的工作目录(`~/$WORKSPACE`)中应该有以下文件列表:
+5. \*\*仅验证器:\*\*将可信设置 blob 下载到您的工作目录中,与 `genesis.blob` 和 `waypoint.txt` 放在一起.
+   上游 `docker-compose.yaml` 会从那里将它们绑定挂载到容器中:
+
+   ```shellscript filename="Terminal"
+   cd ~/$WORKSPACE
+   wget -O digest_key.bin https://github.com/aptos-labs/aptos-networks/raw/main/testnet/digest_key.bin
+   wget -O pp.bin https://github.com/aptos-labs/aptos-networks/raw/main/testnet/pp.bin
+   ```
+
+   将 `testnet` 替换为您所运营的网络.有关验证步骤(`aptos node validate-digest-key` /
+   `validate-public-parameters`),请参阅
+   [更新可信设置 → Docker(compose)部署](/zh/network/nodes/validator-node/modify-nodes/update-trusted-setup#dockercompose部署).
+
+6. 总之,您的工作目录(`~/$WORKSPACE`)中应该有以下文件列表:
 
    - `docker-compose.yaml`:运行验证器的 docker compose 文件.
    - `docker-compose-fullnode.yaml`:运行 VFN 的 docker compose 文件.
@@ -125,7 +135,7 @@ import { Aside } from '@astrojs/starlight/components';
    - `waypoint.txt`:您正在连接的网络上创世交易的路标文件.
    - `genesis.blob`:您正在连接的网络的创世区块(genesis blob).
 
-6. 要启动验证器节点,在您的工作目录中运行以下命令:
+7. 要启动验证器节点,在您的工作目录中运行以下命令:
 
    ```shellscript filename="Terminal"
    docker-compose up （或根据您的版本使用 `docker compose up`）
@@ -133,7 +143,7 @@ import { Aside } from '@astrojs/starlight/components';
 
    这将使用 `docker-compose.yaml` 文件中指定的 docker compose 文件和镜像启动验证器节点.如果您希望更改要连接的网络,您需要修改文件以按网络名称使用正确的 docker 镜像.
 
-7. 在启动 VFN 之前,你需先调整 `fullnode.yaml` 配置文件,以便更新验证器节点的主机地址.比如,如果您使用的是 IP 地址,就需要按照以下方式,修改 vfn 网络的 `full_node_networks` 的地址信息:
+8. 在启动 VFN 之前,你需先调整 `fullnode.yaml` 配置文件,以便更新验证器节点的主机地址.比如,如果您使用的是 IP 地址,就需要按照以下方式,修改 vfn 网络的 `full_node_networks` 的地址信息:
 
    ```yaml filename="fullnode.yaml"
    ---
@@ -149,7 +159,7 @@ import { Aside } from '@astrojs/starlight/components';
      - "/dns/example.com/tcp/6181/noise-ik/..." # 设置验证器的 DNS 地址
    ```
 
-8. 为了启动你的 VFN,请在一台独立的,专为 VFN 设置的计算机上执行以下命令.你需要从验证节点的计算机那里复制密钥,配置文件和 docker compose 文件过来.
+9. 为了启动你的 VFN,请在一台独立的,专为 VFN 设置的计算机上执行以下命令.你需要从验证节点的计算机那里复制密钥,配置文件和 docker compose 文件过来.
 
    <Aside type="caution">
      **VFN 身份**<br />

--- a/src/content/docs/zh/network/nodes/validator-node/deploy-nodes/using-docker.mdx
+++ b/src/content/docs/zh/network/nodes/validator-node/deploy-nodes/using-docker.mdx
@@ -116,9 +116,8 @@ import { Aside } from '@astrojs/starlight/components';
    wget -O pp.bin https://github.com/aptos-labs/aptos-networks/raw/main/<network>/pp.bin
    ```
 
-   将 `<network>` 替换为 `testnet`(主网的可信设置 blob 尚未发布 — 参见
-   [更新可信设置 → 已发布的校验和](/zh/network/nodes/validator-node/modify-nodes/update-trusted-setup#已发布的校验和)).
-   有关验证步骤(`aptos node validate-digest-key` / `validate-public-parameters`),请参阅
+   将 `<network>` 替换为相应的网络(`testnet` 或 `mainnet`).有关验证步骤
+   (`aptos node validate-digest-key` / `validate-public-parameters`),请参阅
    [更新可信设置 → Docker(compose)部署](/zh/network/nodes/validator-node/modify-nodes/update-trusted-setup#dockercompose部署).
 
 6. 总之,您的工作目录(`~/$WORKSPACE`)中应该有以下文件列表:

--- a/src/content/docs/zh/network/nodes/validator-node/deploy-nodes/using-docker.mdx
+++ b/src/content/docs/zh/network/nodes/validator-node/deploy-nodes/using-docker.mdx
@@ -106,8 +106,9 @@ import { Aside } from '@astrojs/starlight/components';
    - `blocked.ips`
    - `genesis.blob`
    - `waypoint.txt`
-   - `digest_key.bin` 和 `pp.bin`(仅验证器;有关验证步骤和这些文件必须匹配的 `validator.yaml` 路径,请参阅
-     [更新可信设置 → 自托管部署](/zh/network/nodes/validator-node/modify-nodes/update-trusted-setup#自托管部署源代码或-docker))
+   - `digest_key.bin` 和 `pp.bin`(仅验证器;将其放在工作目录中 `genesis.blob` 和 `waypoint.txt`
+     旁边 — 上游 `docker-compose.yaml` 会从那里绑定挂载它们.有关验证步骤,请参阅
+     [更新可信设置 → Docker(compose)部署](/zh/network/nodes/validator-node/modify-nodes/update-trusted-setup#dockercompose部署))
 
 5. 总之,您的工作目录(`~/$WORKSPACE`)中应该有以下文件列表:
 

--- a/src/content/docs/zh/network/nodes/validator-node/deploy-nodes/using-docker.mdx
+++ b/src/content/docs/zh/network/nodes/validator-node/deploy-nodes/using-docker.mdx
@@ -112,12 +112,13 @@ import { Aside } from '@astrojs/starlight/components';
 
    ```shellscript filename="Terminal"
    cd ~/$WORKSPACE
-   wget -O digest_key.bin https://github.com/aptos-labs/aptos-networks/raw/main/testnet/digest_key.bin
-   wget -O pp.bin https://github.com/aptos-labs/aptos-networks/raw/main/testnet/pp.bin
+   wget -O digest_key.bin https://github.com/aptos-labs/aptos-networks/raw/main/<network>/digest_key.bin
+   wget -O pp.bin https://github.com/aptos-labs/aptos-networks/raw/main/<network>/pp.bin
    ```
 
-   将 `testnet` 替换为您所运营的网络.有关验证步骤(`aptos node validate-digest-key` /
-   `validate-public-parameters`),请参阅
+   将 `<network>` 替换为 `testnet`(主网的可信设置 blob 尚未发布 — 参见
+   [更新可信设置 → 已发布的校验和](/zh/network/nodes/validator-node/modify-nodes/update-trusted-setup#已发布的校验和)).
+   有关验证步骤(`aptos node validate-digest-key` / `validate-public-parameters`),请参阅
    [更新可信设置 → Docker(compose)部署](/zh/network/nodes/validator-node/modify-nodes/update-trusted-setup#dockercompose部署).
 
 6. 总之,您的工作目录(`~/$WORKSPACE`)中应该有以下文件列表:

--- a/src/content/docs/zh/network/nodes/validator-node/deploy-nodes/using-docker.mdx
+++ b/src/content/docs/zh/network/nodes/validator-node/deploy-nodes/using-docker.mdx
@@ -134,6 +134,8 @@ import { Aside } from '@astrojs/starlight/components';
      - `operator.yaml`:验证器和 VFN 运营者信息.
    - `waypoint.txt`:您正在连接的网络上创世交易的路标文件.
    - `genesis.blob`:您正在连接的网络的创世区块(genesis blob).
+   - `digest_key.bin`:仅验证器.由共识加载的 DKG digest-key blob.
+   - `pp.bin`:仅验证器.由共识加载的 DKG 公共参数 blob.
 
 7. 要启动验证器节点,在您的工作目录中运行以下命令:
 

--- a/src/content/docs/zh/network/nodes/validator-node/deploy-nodes/using-gcp.mdx
+++ b/src/content/docs/zh/network/nodes/validator-node/deploy-nodes/using-gcp.mdx
@@ -153,6 +153,8 @@ import { Aside } from '@astrojs/starlight/components';
 
     - `genesis.blob`
     - `waypoint.txt`
+    - `digest_key.bin` 和 `pp.bin`(仅验证器;有关验证步骤,请参阅
+      [更新可信设置](/zh/network/nodes/validator-node/modify-nodes/update-trusted-setup))
 
 13. 总之,您的工作目录(`~/$WORKSPACE`)中应该有以下文件列表:
 

--- a/src/content/docs/zh/network/nodes/validator-node/deploy-nodes/using-gcp.mdx
+++ b/src/content/docs/zh/network/nodes/validator-node/deploy-nodes/using-gcp.mdx
@@ -153,8 +153,13 @@ import { Aside } from '@astrojs/starlight/components';
 
     - `genesis.blob`
     - `waypoint.txt`
-    - `digest_key.bin` 和 `pp.bin`(仅验证器;有关验证步骤,请参阅
-      [更新可信设置](/zh/network/nodes/validator-node/modify-nodes/update-trusted-setup))
+
+    <Aside type="note">
+      验证器所需的 DKG 可信设置 blob(`digest_key.bin`,`pp.bin`)**不**在此处下载.`aptos-node` Helm
+      chart 通过其 init 容器将其获取到持久卷中 — 请按照
+      [更新可信设置 → Kubernetes 部署](/zh/network/nodes/validator-node/modify-nodes/update-trusted-setup#kubernetes-部署helm-chart)
+      配置 `trustedSetup.*` chart values.
+    </Aside>
 
 13. 总之,您的工作目录(`~/$WORKSPACE`)中应该有以下文件列表:
 

--- a/src/content/docs/zh/network/nodes/validator-node/deploy-nodes/using-source-code.mdx
+++ b/src/content/docs/zh/network/nodes/validator-node/deploy-nodes/using-source-code.mdx
@@ -114,9 +114,8 @@ import { Aside } from '@astrojs/starlight/components';
      https://github.com/aptos-labs/aptos-networks/raw/main/<network>/pp.bin
    ```
 
-   将 `<network>` 替换为 `testnet`(主网的可信设置 blob 尚未发布 — 参见
-   [更新可信设置 → 已发布的校验和](/zh/network/nodes/validator-node/modify-nodes/update-trusted-setup#已发布的校验和)).
-   有关验证步骤(`aptos node validate-digest-key` / `validate-public-parameters`),请参阅
+   将 `<network>` 替换为相应的网络(`testnet` 或 `mainnet`).有关验证步骤
+   (`aptos node validate-digest-key` / `validate-public-parameters`),请参阅
    [更新可信设置 → 源代码部署](/zh/network/nodes/validator-node/modify-nodes/update-trusted-setup#源代码部署).
 
 8. 接下来,将刚刚下载的 `validator.yaml` 和 `fullnode.yaml` 模板文件复制到

--- a/src/content/docs/zh/network/nodes/validator-node/deploy-nodes/using-source-code.mdx
+++ b/src/content/docs/zh/network/nodes/validator-node/deploy-nodes/using-source-code.mdx
@@ -109,13 +109,14 @@ import { Aside } from '@astrojs/starlight/components';
 
    ```shellscript filename="Terminal"
    wget -O /opt/aptos/genesis/digest_key.bin \
-     https://github.com/aptos-labs/aptos-networks/raw/main/testnet/digest_key.bin
+     https://github.com/aptos-labs/aptos-networks/raw/main/<network>/digest_key.bin
    wget -O /opt/aptos/genesis/pp.bin \
-     https://github.com/aptos-labs/aptos-networks/raw/main/testnet/pp.bin
+     https://github.com/aptos-labs/aptos-networks/raw/main/<network>/pp.bin
    ```
 
-   将 `testnet` 替换为您所运营的网络.有关验证步骤(`aptos node validate-digest-key` /
-   `validate-public-parameters`),请参阅
+   将 `<network>` 替换为 `testnet`(主网的可信设置 blob 尚未发布 — 参见
+   [更新可信设置 → 已发布的校验和](/zh/network/nodes/validator-node/modify-nodes/update-trusted-setup#已发布的校验和)).
+   有关验证步骤(`aptos node validate-digest-key` / `validate-public-parameters`),请参阅
    [更新可信设置 → 源代码部署](/zh/network/nodes/validator-node/modify-nodes/update-trusted-setup#源代码部署).
 
 8. 接下来,将刚刚下载的 `validator.yaml` 和 `fullnode.yaml` 模板文件复制到

--- a/src/content/docs/zh/network/nodes/validator-node/deploy-nodes/using-source-code.mdx
+++ b/src/content/docs/zh/network/nodes/validator-node/deploy-nodes/using-source-code.mdx
@@ -103,7 +103,7 @@ import { Aside } from '@astrojs/starlight/components';
    - `genesis.blob`
    - `waypoint.txt`
    - `digest_key.bin` 和 `pp.bin`(仅验证器;有关验证步骤和这些文件必须匹配的 `validator.yaml` 路径,请参阅
-     [更新可信设置 → 自托管部署](/zh/network/nodes/validator-node/modify-nodes/update-trusted-setup#自托管部署源代码或-docker))
+     [更新可信设置 → 源代码部署](/zh/network/nodes/validator-node/modify-nodes/update-trusted-setup#源代码部署))
 
 7. 接下来,将刚刚下载的 `validator.yaml` 和 `fullnode.yaml` 模板文件复制到
    `~/$WORKSPACE/config/` 目录中.这可以通过运行以下命令完成:

--- a/src/content/docs/zh/network/nodes/validator-node/deploy-nodes/using-source-code.mdx
+++ b/src/content/docs/zh/network/nodes/validator-node/deploy-nodes/using-source-code.mdx
@@ -103,7 +103,7 @@ import { Aside } from '@astrojs/starlight/components';
    - `genesis.blob`
    - `waypoint.txt`
 
-7. \*\*仅验证器:\*\*将可信设置 blob 下载到本地持久存储上的某个路径.下面的示例使用 `/opt/aptos/genesis/`,
+7. **仅验证器:** 将可信设置 blob 下载到本地持久存储上的某个路径.下面的示例使用 `/opt/aptos/genesis/`,
    与 `genesis.blob` 和 `waypoint.txt` 放在一起.在步骤 9 中设置 `validator.yaml` 的
    `consensus.digest_key_blob_path` 和 `consensus.public_parameters_blob_path` 时,请使用相同的路径.
 
@@ -162,20 +162,20 @@ import { Aside } from '@astrojs/starlight/components';
 
 10. 总之,在您的工作目录(`~/$WORKSPACE`)中,您应该有以下文件列表:
 
-- `config` 文件夹包含:
-  - `validator.yaml`:验证器配置文件.
-  - `fullnode.yaml`:VFN 配置文件.
-- `keys` 文件夹包含:
-  - `public-keys.yaml`:两个节点的公钥.
-  - `private-keys.yaml`:两个节点的私钥.
-  - `validator-identity.yaml`:验证器的密钥和账户信息.
-  - `validator-full-node-identity.yaml`:VFN 的密钥和账户信息.
-- `$username` 文件夹包含:
-  - `owner.yaml`:所有者,运营者和投票者映射关系.
-  - `operator.yaml`:验证器和 VFN 运营者信息.
-- `waypoint.txt`:您连接的网络上创世交易的路标文件.
-- `genesis.blob`:您连接的网络的创世区块(genesis blob).
-- `digest_key.bin` 和 `pp.bin`(仅验证器):位于您在步骤 7 中选择的路径(可能在工作目录之外)的 DKG 可信设置 blob.
+    - `config` 文件夹包含:
+      - `validator.yaml`:验证器配置文件.
+      - `fullnode.yaml`:VFN 配置文件.
+    - `keys` 文件夹包含:
+      - `public-keys.yaml`:两个节点的公钥.
+      - `private-keys.yaml`:两个节点的私钥.
+      - `validator-identity.yaml`:验证器的密钥和账户信息.
+      - `validator-full-node-identity.yaml`:VFN 的密钥和账户信息.
+    - `$username` 文件夹包含:
+      - `owner.yaml`:所有者,运营者和投票者映射关系.
+      - `operator.yaml`:验证器和 VFN 运营者信息.
+    - `waypoint.txt`:您连接的网络上创世交易的路标文件.
+    - `genesis.blob`:您连接的网络的创世区块(genesis blob).
+    - `digest_key.bin` 和 `pp.bin`(仅验证器):位于您在步骤 7 中选择的路径(可能在工作目录之外)的 DKG 可信设置 blob.
 
 11. 现在您已经设置好了配置文件,可以启动您的验证器和 VFN 了.要启动您的验证器,请在 `aptos-core` 目录根目录下运行以下命令:
 

--- a/src/content/docs/zh/network/nodes/validator-node/deploy-nodes/using-source-code.mdx
+++ b/src/content/docs/zh/network/nodes/validator-node/deploy-nodes/using-source-code.mdx
@@ -175,6 +175,7 @@ import { Aside } from '@astrojs/starlight/components';
   - `operator.yaml`:验证器和 VFN 运营者信息.
 - `waypoint.txt`:您连接的网络上创世交易的路标文件.
 - `genesis.blob`:您连接的网络的创世区块(genesis blob).
+- `digest_key.bin` 和 `pp.bin`(仅验证器):位于您在步骤 7 中选择的路径(可能在工作目录之外)的 DKG 可信设置 blob.
 
 11. 现在您已经设置好了配置文件,可以启动您的验证器和 VFN 了.要启动您的验证器,请在 `aptos-core` 目录根目录下运行以下命令:
 

--- a/src/content/docs/zh/network/nodes/validator-node/deploy-nodes/using-source-code.mdx
+++ b/src/content/docs/zh/network/nodes/validator-node/deploy-nodes/using-source-code.mdx
@@ -102,10 +102,23 @@ import { Aside } from '@astrojs/starlight/components';
    - `fullnode.yaml`
    - `genesis.blob`
    - `waypoint.txt`
-   - `digest_key.bin` 和 `pp.bin`(仅验证器;有关验证步骤和这些文件必须匹配的 `validator.yaml` 路径,请参阅
-     [更新可信设置 → 源代码部署](/zh/network/nodes/validator-node/modify-nodes/update-trusted-setup#源代码部署))
 
-7. 接下来,将刚刚下载的 `validator.yaml` 和 `fullnode.yaml` 模板文件复制到
+7. \*\*仅验证器:\*\*将可信设置 blob 下载到本地持久存储上的某个路径.下面的示例使用 `/opt/aptos/genesis/`,
+   与 `genesis.blob` 和 `waypoint.txt` 放在一起.在步骤 9 中设置 `validator.yaml` 的
+   `consensus.digest_key_blob_path` 和 `consensus.public_parameters_blob_path` 时,请使用相同的路径.
+
+   ```shellscript filename="Terminal"
+   wget -O /opt/aptos/genesis/digest_key.bin \
+     https://github.com/aptos-labs/aptos-networks/raw/main/testnet/digest_key.bin
+   wget -O /opt/aptos/genesis/pp.bin \
+     https://github.com/aptos-labs/aptos-networks/raw/main/testnet/pp.bin
+   ```
+
+   将 `testnet` 替换为您所运营的网络.有关验证步骤(`aptos node validate-digest-key` /
+   `validate-public-parameters`),请参阅
+   [更新可信设置 → 源代码部署](/zh/network/nodes/validator-node/modify-nodes/update-trusted-setup#源代码部署).
+
+8. 接下来,将刚刚下载的 `validator.yaml` 和 `fullnode.yaml` 模板文件复制到
    `~/$WORKSPACE/config/` 目录中.这可以通过运行以下命令完成:
 
    ```shellscript filename="Terminal"
@@ -116,7 +129,7 @@ import { Aside } from '@astrojs/starlight/components';
 
    这些将分别是您的验证器和 VFN 的主要配置文件.
 
-8. 现在,修改 `validator.yaml` 和 `fullnode.yaml` 模板文件以包含适用于您的验证器和 VFN 的信息和工作目录.
+9. 现在,修改 `validator.yaml` 和 `fullnode.yaml` 模板文件以包含适用于您的验证器和 VFN 的信息和工作目录.
 
    对于 `validator.yaml` 文件,您需要修改以下字段:
 
@@ -147,23 +160,23 @@ import { Aside } from '@astrojs/starlight/components';
        - "/dns/example.com/tcp/6181/noise-ik/..." # 设置验证器的 DNS 地址
      ```
 
-9. 总之,在您的工作目录(`~/$WORKSPACE`)中,您应该有以下文件列表:
+10. 总之,在您的工作目录(`~/$WORKSPACE`)中,您应该有以下文件列表:
 
-   - `config` 文件夹包含:
-     - `validator.yaml`:验证器配置文件.
-     - `fullnode.yaml`:VFN 配置文件.
-   - `keys` 文件夹包含:
-     - `public-keys.yaml`:两个节点的公钥.
-     - `private-keys.yaml`:两个节点的私钥.
-     - `validator-identity.yaml`:验证器的密钥和账户信息.
-     - `validator-full-node-identity.yaml`:VFN 的密钥和账户信息.
-   - `$username` 文件夹包含:
-     - `owner.yaml`:所有者,运营者和投票者映射关系.
-     - `operator.yaml`:验证器和 VFN 运营者信息.
-   - `waypoint.txt`:您连接的网络上创世交易的路标文件.
-   - `genesis.blob`:您连接的网络的创世区块(genesis blob).
+- `config` 文件夹包含:
+  - `validator.yaml`:验证器配置文件.
+  - `fullnode.yaml`:VFN 配置文件.
+- `keys` 文件夹包含:
+  - `public-keys.yaml`:两个节点的公钥.
+  - `private-keys.yaml`:两个节点的私钥.
+  - `validator-identity.yaml`:验证器的密钥和账户信息.
+  - `validator-full-node-identity.yaml`:VFN 的密钥和账户信息.
+- `$username` 文件夹包含:
+  - `owner.yaml`:所有者,运营者和投票者映射关系.
+  - `operator.yaml`:验证器和 VFN 运营者信息.
+- `waypoint.txt`:您连接的网络上创世交易的路标文件.
+- `genesis.blob`:您连接的网络的创世区块(genesis blob).
 
-10. 现在您已经设置好了配置文件,可以启动您的验证器和 VFN 了.要启动您的验证器,请在 `aptos-core` 目录根目录下运行以下命令:
+11. 现在您已经设置好了配置文件,可以启动您的验证器和 VFN 了.要启动您的验证器,请在 `aptos-core` 目录根目录下运行以下命令:
 
     ```shellscript filename="Terminal"
     cargo clean

--- a/src/content/docs/zh/network/nodes/validator-node/deploy-nodes/using-source-code.mdx
+++ b/src/content/docs/zh/network/nodes/validator-node/deploy-nodes/using-source-code.mdx
@@ -102,8 +102,8 @@ import { Aside } from '@astrojs/starlight/components';
    - `fullnode.yaml`
    - `genesis.blob`
    - `waypoint.txt`
-   - `digest_key.bin` 和 `pp.bin`(仅验证器;有关验证步骤,请参阅
-     [更新可信设置](/zh/network/nodes/validator-node/modify-nodes/update-trusted-setup))
+   - `digest_key.bin` 和 `pp.bin`(仅验证器;有关验证步骤和这些文件必须匹配的 `validator.yaml` 路径,请参阅
+     [更新可信设置 → 自托管部署](/zh/network/nodes/validator-node/modify-nodes/update-trusted-setup#自托管部署源代码或-docker))
 
 7. 接下来,将刚刚下载的 `validator.yaml` 和 `fullnode.yaml` 模板文件复制到
    `~/$WORKSPACE/config/` 目录中.这可以通过运行以下命令完成:

--- a/src/content/docs/zh/network/nodes/validator-node/deploy-nodes/using-source-code.mdx
+++ b/src/content/docs/zh/network/nodes/validator-node/deploy-nodes/using-source-code.mdx
@@ -102,6 +102,8 @@ import { Aside } from '@astrojs/starlight/components';
    - `fullnode.yaml`
    - `genesis.blob`
    - `waypoint.txt`
+   - `digest_key.bin` 和 `pp.bin`(仅验证器;有关验证步骤,请参阅
+     [更新可信设置](/zh/network/nodes/validator-node/modify-nodes/update-trusted-setup))
 
 7. 接下来,将刚刚下载的 `validator.yaml` 和 `fullnode.yaml` 模板文件复制到
    `~/$WORKSPACE/config/` 目录中.这可以通过运行以下命令完成:

--- a/src/content/docs/zh/network/nodes/validator-node/modify-nodes/update-trusted-setup.mdx
+++ b/src/content/docs/zh/network/nodes/validator-node/modify-nodes/update-trusted-setup.mdx
@@ -48,28 +48,14 @@ Aptos Labs 在 [`aptos-labs/aptos-networks`](https://github.com/aptos-labs/aptos
 在验证器所在主机上选择一个目录 — 本地持久存储上的任何位置都可以.下面的示例使用 `/opt/aptos/genesis/`,
 与 `genesis.blob` 和 `waypoint.txt` 放在一起.
 
-#### 测试网
-
 ```shellscript filename="Terminal"
 wget -O /opt/aptos/genesis/digest_key.bin \
-  https://github.com/aptos-labs/aptos-networks/raw/main/testnet/digest_key.bin
+  https://github.com/aptos-labs/aptos-networks/raw/main/<network>/digest_key.bin
 wget -O /opt/aptos/genesis/pp.bin \
-  https://github.com/aptos-labs/aptos-networks/raw/main/testnet/pp.bin
+  https://github.com/aptos-labs/aptos-networks/raw/main/<network>/pp.bin
 ```
 
-#### 主网
-
-<Aside type="note">
-  主网的可信设置 blob 尚未发布.以下命令为预期形式;一旦 Aptos Labs 发布这些文件,本页将使用可用的 URL
-  进行更新.
-</Aside>
-
-```shellscript filename="Terminal"
-wget -O /opt/aptos/genesis/digest_key.bin \
-  https://github.com/aptos-labs/aptos-networks/raw/main/mainnet/digest_key.bin
-wget -O /opt/aptos/genesis/pp.bin \
-  https://github.com/aptos-labs/aptos-networks/raw/main/mainnet/pp.bin
-```
+将 `<network>` 替换为相应的网络(`testnet` 或 `mainnet`).
 
 ### 2. 使用 Aptos CLI 验证
 

--- a/src/content/docs/zh/network/nodes/validator-node/modify-nodes/update-trusted-setup.mdx
+++ b/src/content/docs/zh/network/nodes/validator-node/modify-nodes/update-trusted-setup.mdx
@@ -1,5 +1,9 @@
 ---
 title: "更新可信设置"
+sidebar:
+  badge:
+    text: New
+    variant: tip
 ---
 
 import { Aside } from '@astrojs/starlight/components';

--- a/src/content/docs/zh/network/nodes/validator-node/modify-nodes/update-trusted-setup.mdx
+++ b/src/content/docs/zh/network/nodes/validator-node/modify-nodes/update-trusted-setup.mdx
@@ -96,17 +96,17 @@ consensus:
 `public_parameters_blob_url` 时,init 容器会为您将这些 blob 下载到 `/opt/aptos/genesis/` 中.在这种情况下,
 运维人员唯一需要做的就是更新 URL 并触发 pod 重启.
 
-## 4. 确认集群一致性(可选)
+## 4. 重启验证器
 
-节点重启后,有两个 Prometheus 指标将每个已加载 blob 的 `blake3` 作为标签暴露出来:
+按照您正常的重启流程操作(请参阅 [升级节点](/zh/network/nodes/validator-node/modify-nodes/update-validator-node)
+了解特定部署的步骤).节点在启动时只加载一次 blob;后续的轮换需要再次重启.
+
+## 5. 确认集群一致性(可选)
+
+重启后,有两个 Prometheus 指标将每个已加载 blob 的 `blake3` 作为标签暴露出来:
 
 - `aptos_dkg_digest_key_blake3{blake3="<hex>"} 1`
 - `aptos_dkg_public_params_blake3{blake3="<hex>"} 1`
 
 在 Grafana 中跨整个验证器集群按 `blake3` 标签分组.健康的发布显示每个指标只有一个标签值,且与上表匹配.
 多个值表示至少有一个验证器正在运行过时的 blob.
-
-## 5. 重启验证器
-
-按照您正常的重启流程操作(请参阅 [升级节点](/zh/network/nodes/validator-node/modify-nodes/update-validator-node)
-了解特定部署的步骤).节点在启动时只加载一次 blob;后续的轮换需要再次重启.

--- a/src/content/docs/zh/network/nodes/validator-node/modify-nodes/update-trusted-setup.mdx
+++ b/src/content/docs/zh/network/nodes/validator-node/modify-nodes/update-trusted-setup.mdx
@@ -8,8 +8,11 @@ Aptos 验证器在启动时会加载两个可信设置 blob:`digest_key.bin` 和
 Aptos Labs 在 [`aptos-labs/aptos-networks`](https://github.com/aptos-labs/aptos-networks) 仓库中发布,
 并在节点参与 DKG 之前由共识加载.VFN 和 PFN **不需要** 这些文件.
 
-本页面介绍现有验证器运维人员将新版本 blob 部署到节点的步骤.具体流程取决于您的部署方式:自托管(源代码或
-Docker),或通过官方 `aptos-node` Helm chart 部署(AWS / GCP / Azure k8s 部署).
+本页面介绍现有验证器运维人员将新版本 blob 部署到节点的步骤.具体流程取决于您的部署方式:
+
+- **源代码** — 您直接运行验证器二进制文件.
+- **Docker(compose)** — 您运行上游的 `aptos-node` docker-compose 堆栈.
+- **Kubernetes(Helm chart)** — 您在 AWS / GCP / Azure 上运行官方 `aptos-node` Helm chart.
 
 <Aside type="caution">
   验证器集群中的每个节点都必须加载**相同**的字节.在部分验证器上加载过时或不匹配的 blob 将阻止受影响的节点参与
@@ -35,15 +38,15 @@ Docker),或通过官方 `aptos-node` Helm chart 部署(AWS / GCP / Azure k8s 部
   破坏共识.
 </Aside>
 
-## 自托管部署(源代码或 Docker)
+## 源代码部署
 
-如果您直接从源代码构建的二进制文件或 Docker compose 文件运行验证器,请使用此流程.您将 blob 下载到磁盘,并在
-`validator.yaml` 中告诉验证器在哪里找到它们.
+如果您直接从 `aptos-core` 构建的二进制文件运行验证器,请使用此流程.您选择 blob 在磁盘上的位置,并让
+`validator.yaml` 指向它们.
 
 ### 1. 下载 blob
 
-在验证器所在机器上选择一个目录.下面的示例使用 `/opt/aptos/genesis/`(与 `genesis.blob` 和 `waypoint.txt`
-放在一起);本地持久存储上的任何路径都可以.
+在验证器所在主机上选择一个目录 — 本地持久存储上的任何位置都可以.下面的示例使用 `/opt/aptos/genesis/`,
+与 `genesis.blob` 和 `waypoint.txt` 放在一起.
 
 #### 测试网
 
@@ -106,6 +109,75 @@ consensus:
 [升级节点](/zh/network/nodes/validator-node/modify-nodes/update-validator-node)了解特定部署的步骤).
 节点在启动时只加载一次 blob;后续的轮换需要再次重启.
 
+## Docker(compose)部署
+
+如果您运行
+[`aptos-core/docker/compose/aptos-node`](https://github.com/aptos-labs/aptos-core/tree/testnet/docker/compose/aptos-node)
+中的上游 `docker-compose.yaml`,请使用此流程.上游 compose 文件会将可信设置文件从您的工作目录绑定挂载到容器
+内的 `/opt/aptos/genesis/`,并且上游 `validator.yaml` 已经设置了相应的 `consensus` 路径 — 因此您只需将
+文件放在 `genesis.blob` / `waypoint.txt` 旁边即可.
+
+### 1. 将 blob 下载到您的工作目录
+
+```shellscript filename="Terminal"
+cd ~/$WORKSPACE   # 存放 genesis.blob 和 waypoint.txt 的目录
+wget -O digest_key.bin https://github.com/aptos-labs/aptos-networks/raw/main/testnet/digest_key.bin
+wget -O pp.bin https://github.com/aptos-labs/aptos-networks/raw/main/testnet/pp.bin
+```
+
+将 `testnet` 替换为您所运营的网络(主网 blob 尚未发布;参见 [已发布的校验和](#已发布的校验和) 备注).
+
+### 2. 使用 Aptos CLI 验证
+
+```shellscript filename="Terminal"
+aptos node validate-digest-key --file digest_key.bin
+aptos node validate-public-parameters --file pp.bin
+```
+
+将 `size` 和 `blake3` 与 [已发布的校验和](#已发布的校验和) 表中您所在网络的值进行比较.如果不匹配,
+请重新下载 — **请不要**用错误的文件重启验证器.
+
+### 3. 确认 docker-compose.yaml 和 validator.yaml 是最新的
+
+上游文件既包含绑定挂载,也包含 `consensus` 块.如果您是在添加这些之前设置的验证器,请从 `aptos-core` 的
+`testnet` 分支刷新这两个文件(参见
+[测试网文件](/zh/network/nodes/configure/node-files-all-networks/node-files-testnet)),并调和任何本地修改.
+需要确认的相关部分:
+
+`docker-compose.yaml`(validator 服务):
+
+```yaml
+volumes:
+  # …已有的挂载(genesis.blob、waypoint.txt、validator.yaml、身份文件)…
+  - type: bind
+    source: ./digest_key.bin
+    target: /opt/aptos/genesis/digest_key.bin
+  - type: bind
+    source: ./pp.bin
+    target: /opt/aptos/genesis/pp.bin
+```
+
+`validator.yaml`:
+
+```yaml
+consensus:
+  digest_key_blob_path: /opt/aptos/genesis/digest_key.bin
+  public_parameters_blob_path: /opt/aptos/genesis/pp.bin
+  # …safety_rules 等其他共识设置…
+```
+
+### 4. 重启验证器
+
+```shellscript filename="Terminal"
+docker compose restart validator
+```
+
+或重新创建堆栈以拾取 `docker-compose.yaml` 的任何更改:
+
+```shellscript filename="Terminal"
+docker compose up -d
+```
+
 ## Kubernetes 部署(Helm chart)
 
 如果您通过官方 `aptos-node` Helm chart 部署验证器(AWS,GCP 和 Azure 上的典型设置),请使用此流程.您**不需要**
@@ -135,7 +207,7 @@ trustedSetup:
 ### 2.(可选)在工作站上预先验证校验和
 
 chart 在集群内部获取字节,因此集群内的下载过程不会经过 `aptos` CLI.在部署前对 URL 进行健全性检查:在本地下载
-一份副本,并对其运行 [自托管验证步骤](#2-使用-aptos-cli-验证):
+一份副本,并对其运行 [源代码验证步骤](#2-使用-aptos-cli-验证):
 
 ```shellscript filename="Terminal"
 wget -O /tmp/digest_key.bin \
@@ -152,7 +224,7 @@ aptos node validate-digest-key --file /tmp/digest_key.bin
 新获取的文件.
 
 <Aside type="note">
-  \*\*首次重启需要支付一次性下载成本.\*\*在测试网上,这两个 blob 总计约 4 GiB,一次性获取到持久数据 PVC.
+  **首次重启需要支付一次性下载成本.** 在测试网上,这两个 blob 总计约 4 GiB,一次性获取到持久数据 PVC.
   后续重启通过标记检查跳过下载,并在几秒钟内启动.
 </Aside>
 

--- a/src/content/docs/zh/network/nodes/validator-node/modify-nodes/update-trusted-setup.mdx
+++ b/src/content/docs/zh/network/nodes/validator-node/modify-nodes/update-trusted-setup.mdx
@@ -1,0 +1,98 @@
+---
+title: "更新可信设置"
+---
+
+import { Aside } from '@astrojs/starlight/components';
+
+Aptos 验证器在启动时会加载两个可信设置 blob:`digest_key.bin` 和 `pp.bin`(公共参数).这两个 blob 由
+Aptos Labs 在 [`aptos-labs/aptos-networks`](https://github.com/aptos-labs/aptos-networks) 仓库中发布,
+并在节点参与 DKG 之前由共识加载.VFN 和 PFN **不需要** 这些文件.
+
+本页面介绍现有验证器运维人员下载新版本 blob,验证其完整性,并将更改部署到节点的步骤.
+
+<Aside type="caution">
+  验证器集群中的每个节点都必须加载**相同**的字节.在部分验证器上加载过时或不匹配的 blob 将阻止受影响的节点参与
+  共识.在重启节点之前,请始终对照下方发布的值验证 `blake3` 校验和.
+</Aside>
+
+<Aside type="note">
+  这些文件目前仅在**测试网**上发布.主网说明将在上游发布 blob 后添加.
+</Aside>
+
+## 1. 下载 blob
+
+这两个文件通过 Git LFS 存储,因此下载 URL 使用 `github.com/.../raw/main/...`(它会跟随 LFS 重定向),
+而非 `raw.githubusercontent.com`.
+
+```shellscript filename="Terminal"
+wget -O /opt/aptos/genesis/digest_key.bin \
+  https://github.com/aptos-labs/aptos-networks/raw/main/testnet/digest_key.bin
+wget -O /opt/aptos/genesis/pp.bin \
+  https://github.com/aptos-labs/aptos-networks/raw/main/testnet/pp.bin
+```
+
+将目标路径调整为您的部署存储 `genesis.blob` 和 `waypoint.txt` 的位置.您选择的路径必须与 `validator.yaml`
+中的 `consensus.digest_key_blob_path` 和 `consensus.public_parameters_blob_path` 条目匹配(参见步骤 3).
+
+## 2. 使用 Aptos CLI 验证
+
+使用 `aptos` CLI 确认每个文件能够正确反序列化,并计算其 `blake3` 校验和:
+
+```shellscript filename="Terminal"
+aptos node validate-digest-key --file /opt/aptos/genesis/digest_key.bin
+aptos node validate-public-parameters --file /opt/aptos/genesis/pp.bin
+```
+
+每个命令都会输出以下形状的 JSON:
+
+```json
+{
+  "size": 4002048590,
+  "blake3": "ffff6ab738c58c1c7eeb697eecbc369205e111c9ef271ab2cbe524869671b441"
+}
+```
+
+将 `size` 和 `blake3` 字段与下面的值进行比较.
+
+### 预期的测试网校验和
+
+以下校验和对应于
+[`aptos-networks@92b13bf`](https://github.com/aptos-labs/aptos-networks/tree/92b13bf7844a0630cf5688ce8d309c46f712bbf2/testnet)
+中的 blob(截至 2026-05-14).每当 Aptos Labs 发布新版本时,本页面都会更新.
+
+| 文件               | 大小(字节)       | blake3                                                             |
+| ---------------- | ------------ | ------------------------------------------------------------------ |
+| `digest_key.bin` | `4002048590` | `ffff6ab738c58c1c7eeb697eecbc369205e111c9ef271ab2cbe524869671b441` |
+| `pp.bin`         | `201655505`  | `a01c219766c4190f7d1b77836c0efd41b96486f7d46902f93e9b15260ea05cbc` |
+
+如果任一值不同,**请不要重启验证器** — 重新下载文件(最常见的原因是传输被截断,或者通过
+`raw.githubusercontent.com` 获取 LFS 指针文本,而不是通过 LFS 重定向的 `github.com/.../raw/...` URL).
+
+## 3. 配置 validator.yaml
+
+确认您的 `validator.yaml` 中的 `consensus` 块引用了这两个文件.路径必须与您在步骤 1 中写入的位置匹配.
+
+```yaml
+consensus:
+  digest_key_blob_path: /opt/aptos/genesis/digest_key.bin
+  public_parameters_blob_path: /opt/aptos/genesis/pp.bin
+```
+
+如果您的部署由 Helm 使用官方 `aptos-node` chart 管理,当在 chart values 中设置了 `digest_key_blob_url` 和
+`public_parameters_blob_url` 时,init 容器会为您将这些 blob 下载到 `/opt/aptos/genesis/` 中.在这种情况下,
+运维人员唯一需要做的就是更新 URL 并触发 pod 重启.
+
+## 4. 确认集群一致性(可选)
+
+节点重启后,有两个 Prometheus 指标将每个已加载 blob 的 `blake3` 作为标签暴露出来:
+
+- `aptos_dkg_digest_key_blake3{blake3="<hex>"} 1`
+- `aptos_dkg_public_params_blake3{blake3="<hex>"} 1`
+
+在 Grafana 中跨整个验证器集群按 `blake3` 标签分组.健康的发布显示每个指标只有一个标签值,且与上表匹配.
+多个值表示至少有一个验证器正在运行过时的 blob.
+
+## 5. 重启验证器
+
+按照您正常的重启流程操作(请参阅 [升级节点](/zh/network/nodes/validator-node/modify-nodes/update-validator-node)
+了解特定部署的步骤).节点在启动时只加载一次 blob;后续的轮换需要再次重启.

--- a/src/content/docs/zh/network/nodes/validator-node/modify-nodes/update-trusted-setup.mdx
+++ b/src/content/docs/zh/network/nodes/validator-node/modify-nodes/update-trusted-setup.mdx
@@ -8,22 +8,44 @@ Aptos 验证器在启动时会加载两个可信设置 blob:`digest_key.bin` 和
 Aptos Labs 在 [`aptos-labs/aptos-networks`](https://github.com/aptos-labs/aptos-networks) 仓库中发布,
 并在节点参与 DKG 之前由共识加载.VFN 和 PFN **不需要** 这些文件.
 
-本页面介绍现有验证器运维人员下载新版本 blob,验证其完整性,并将更改部署到节点的步骤.
+本页面介绍现有验证器运维人员将新版本 blob 部署到节点的步骤.具体流程取决于您的部署方式:自托管(源代码或
+Docker),或通过官方 `aptos-node` Helm chart 部署(AWS / GCP / Azure k8s 部署).
 
 <Aside type="caution">
   验证器集群中的每个节点都必须加载**相同**的字节.在部分验证器上加载过时或不匹配的 blob 将阻止受影响的节点参与
-  共识.在重启节点之前,请始终对照下方发布的值验证 `blake3` 校验和.
+  共识.在向重启后的验证器发送流量之前,请始终确认 `blake3` 校验和与下方发布的值匹配.
 </Aside>
 
-## 1. 下载 blob
+## 已发布的校验和
 
-这两个文件通过 Git LFS 存储,因此下载 URL 使用 `github.com/.../raw/main/...`(它会跟随 LFS 重定向),
-而非 `raw.githubusercontent.com`.
+测试网校验和对应于
+[`aptos-networks@92b13bf`](https://github.com/aptos-labs/aptos-networks/tree/92b13bf7844a0630cf5688ce8d309c46f712bbf2/testnet)
+中的 blob(截至 2026-05-14).每当 Aptos Labs 发布新版本时,本表都会更新.
 
-将目标路径调整为您的部署存储 `genesis.blob` 和 `waypoint.txt` 的位置.您选择的路径必须与 `validator.yaml`
-中的 `consensus.digest_key_blob_path` 和 `consensus.public_parameters_blob_path` 条目匹配(参见步骤 3).
+| 网络      | 文件               | 大小(字节)       | blake3                                                             |
+| ------- | ---------------- | ------------ | ------------------------------------------------------------------ |
+| testnet | `digest_key.bin` | `4002048590` | `ffff6ab738c58c1c7eeb697eecbc369205e111c9ef271ab2cbe524869671b441` |
+| testnet | `pp.bin`         | `201655505`  | `a01c219766c4190f7d1b77836c0efd41b96486f7d46902f93e9b15260ea05cbc` |
+| mainnet | `digest_key.bin` | _待定 — 尚未发布_  | _待定 — 尚未发布_                                                        |
+| mainnet | `pp.bin`         | _待定 — 尚未发布_  | _待定 — 尚未发布_                                                        |
 
-### 测试网
+<Aside type="note">
+  这两个 blob 都通过 Git LFS 存储,因此下载 URL 必须使用 `github.com/.../raw/...`(它会跟随 LFS 重定向),
+  而非 `raw.githubusercontent.com`(后者会返回 135 字节的 LFS 指针文本).使用错误的 URL 会悄无声息地
+  破坏共识.
+</Aside>
+
+## 自托管部署(源代码或 Docker)
+
+如果您直接从源代码构建的二进制文件或 Docker compose 文件运行验证器,请使用此流程.您将 blob 下载到磁盘,并在
+`validator.yaml` 中告诉验证器在哪里找到它们.
+
+### 1. 下载 blob
+
+在验证器所在机器上选择一个目录.下面的示例使用 `/opt/aptos/genesis/`(与 `genesis.blob` 和 `waypoint.txt`
+放在一起);本地持久存储上的任何路径都可以.
+
+#### 测试网
 
 ```shellscript filename="Terminal"
 wget -O /opt/aptos/genesis/digest_key.bin \
@@ -32,11 +54,11 @@ wget -O /opt/aptos/genesis/pp.bin \
   https://github.com/aptos-labs/aptos-networks/raw/main/testnet/pp.bin
 ```
 
-### 主网
+#### 主网
 
 <Aside type="note">
-  主网的可信设置 blob 尚未发布.以下命令为预期形式;一旦 Aptos Labs 发布这些文件,本页将使用可用的 URL 和
-  校验和进行更新.
+  主网的可信设置 blob 尚未发布.以下命令为预期形式;一旦 Aptos Labs 发布这些文件,本页将使用可用的 URL
+  进行更新.
 </Aside>
 
 ```shellscript filename="Terminal"
@@ -46,9 +68,9 @@ wget -O /opt/aptos/genesis/pp.bin \
   https://github.com/aptos-labs/aptos-networks/raw/main/mainnet/pp.bin
 ```
 
-## 2. 使用 Aptos CLI 验证
+### 2. 使用 Aptos CLI 验证
 
-使用 `aptos` CLI 确认每个文件能够正确反序列化,并计算其 `blake3` 校验和:
+确认每个文件能够正确反序列化,并计算其 `blake3` 校验和:
 
 ```shellscript filename="Terminal"
 aptos node validate-digest-key --file /opt/aptos/genesis/digest_key.bin
@@ -64,25 +86,11 @@ aptos node validate-public-parameters --file /opt/aptos/genesis/pp.bin
 }
 ```
 
-根据您所运营的网络,将 `size` 和 `blake3` 字段与下表中的值进行比较.
+根据您所运营的网络,将这两个字段与 [已发布的校验和](#已发布的校验和) 表进行比较.如果任一值不同,
+**请不要重启验证器** — 重新下载文件(最常见的原因是传输被截断,或者通过 `raw.githubusercontent.com`
+获取 LFS 指针文本).
 
-### 预期校验和
-
-测试网校验和对应于
-[`aptos-networks@92b13bf`](https://github.com/aptos-labs/aptos-networks/tree/92b13bf7844a0630cf5688ce8d309c46f712bbf2/testnet)
-中的 blob(截至 2026-05-14).每当 Aptos Labs 发布新版本时,本表都会更新.
-
-| 网络      | 文件               | 大小(字节)       | blake3                                                             |
-| ------- | ---------------- | ------------ | ------------------------------------------------------------------ |
-| testnet | `digest_key.bin` | `4002048590` | `ffff6ab738c58c1c7eeb697eecbc369205e111c9ef271ab2cbe524869671b441` |
-| testnet | `pp.bin`         | `201655505`  | `a01c219766c4190f7d1b77836c0efd41b96486f7d46902f93e9b15260ea05cbc` |
-| mainnet | `digest_key.bin` | _待定 — 尚未发布_  | _待定 — 尚未发布_                                                        |
-| mainnet | `pp.bin`         | _待定 — 尚未发布_  | _待定 — 尚未发布_                                                        |
-
-如果任一值与您所在网络的行不同,**请不要重启验证器** — 重新下载文件(最常见的原因是传输被截断,或者通过
-`raw.githubusercontent.com` 获取 LFS 指针文本,而不是通过 LFS 重定向的 `github.com/.../raw/...` URL).
-
-## 3. 配置 validator.yaml
+### 3. 配置 validator.yaml
 
 确认您的 `validator.yaml` 中的 `consensus` 块引用了这两个文件.路径必须与您在步骤 1 中写入的位置匹配.
 
@@ -92,21 +100,79 @@ consensus:
   public_parameters_blob_path: /opt/aptos/genesis/pp.bin
 ```
 
-如果您的部署由 Helm 使用官方 `aptos-node` chart 管理,当在 chart values 中设置了 `digest_key_blob_url` 和
-`public_parameters_blob_url` 时,init 容器会为您将这些 blob 下载到 `/opt/aptos/genesis/` 中.在这种情况下,
-运维人员唯一需要做的就是更新 URL 并触发 pod 重启.
+### 4. 重启验证器
 
-## 4. 重启验证器
+按照您正常的重启流程操作(请参阅
+[升级节点](/zh/network/nodes/validator-node/modify-nodes/update-validator-node)了解特定部署的步骤).
+节点在启动时只加载一次 blob;后续的轮换需要再次重启.
 
-按照您正常的重启流程操作(请参阅 [升级节点](/zh/network/nodes/validator-node/modify-nodes/update-validator-node)
-了解特定部署的步骤).节点在启动时只加载一次 blob;后续的轮换需要再次重启.
+## Kubernetes 部署(Helm chart)
 
-## 5. 确认集群一致性(可选)
+如果您通过官方 `aptos-node` Helm chart 部署验证器(AWS,GCP 和 Azure 上的典型设置),请使用此流程.您**不需要**
+手动下载 blob — chart 的 init 容器会在首次重启时将其下载到持久卷,并在后续重启时跳过.
 
-重启后,有两个 Prometheus 指标将每个已加载 blob 的 `blake3` 作为标签暴露出来:
+### 1. 更新 `trustedSetup` chart values
+
+在 chart 的 `trustedSetup` 块中设置 URL(可选地覆盖磁盘路径).chart 将 blob 写入持久 `aptos-data` PVC 上的
+`trustedSetup.path`,并在 `validator.yaml` 中配置 `consensus.digest_key_blob_path` /
+`public_parameters_blob_path` 进行匹配 — 无需进一步的 validator 配置.
+
+```yaml
+trustedSetup:
+  # 持久 aptos-data PVC 上的位置.默认值适用于大多数部署.
+  path: /opt/aptos/data/trusted-setup
+  # 即使 URL 未变,也通过递增此整数来强制重新下载.默认为 0.
+  refreshCounter: 0
+  digestKeyUrl: "https://github.com/aptos-labs/aptos-networks/raw/92b13bf7844a0630cf5688ce8d309c46f712bbf2/testnet/digest_key.bin"
+  publicParametersUrl: "https://github.com/aptos-labs/aptos-networks/raw/92b13bf7844a0630cf5688ce8d309c46f712bbf2/testnet/pp.bin"
+```
+
+<Aside type="tip">
+  **将 URL 锁定到 `aptos-networks` 的某个提交 SHA**,而非 `main`.锁定能使轮换变得显式和可比对,并防止
+  `main` 在下一次 pod 重启时悄无声息地推出新的字节.
+</Aside>
+
+### 2.(可选)在工作站上预先验证校验和
+
+chart 在集群内部获取字节,因此集群内的下载过程不会经过 `aptos` CLI.在部署前对 URL 进行健全性检查:在本地下载
+一份副本,并对其运行 [自托管验证步骤](#2-使用-aptos-cli-验证):
+
+```shellscript filename="Terminal"
+wget -O /tmp/digest_key.bin \
+  https://github.com/aptos-labs/aptos-networks/raw/92b13bf7844a0630cf5688ce8d309c46f712bbf2/testnet/digest_key.bin
+aptos node validate-digest-key --file /tmp/digest_key.bin
+```
+
+将打印的 `blake3` 与 [已发布的校验和](#已发布的校验和) 表进行比较.
+
+### 3. 应用并重启
+
+运行您通常的 chart 部署命令(`helm upgrade`,`pulumi up`,Terraform apply 等).init 容器检测到磁盘上的
+`.url` 标记不再匹配新的 URL,将 blob 下载到 `trustedSetup.path`,并写入新的标记.随后 validator 容器加载
+新获取的文件.
+
+<Aside type="note">
+  \*\*首次重启需要支付一次性下载成本.\*\*在测试网上,这两个 blob 总计约 4 GiB,一次性获取到持久数据 PVC.
+  后续重启通过标记检查跳过下载,并在几秒钟内启动.
+</Aside>
+
+### 在不更改 URL 的情况下强制重新下载
+
+如果您怀疑磁盘损坏,或希望从相同的 URL 重新获取(例如,从写入一半的下载中恢复),将 `trustedSetup.refreshCounter`
+加一并重新应用.init 容器会清除现有标记,从而强制在下一次 pod 重启时重新下载每个 blob.
+
+```yaml
+trustedSetup:
+  refreshCounter: 1 # 原为 0
+  # URL 不变
+```
+
+## 确认集群一致性
+
+在您的验证器重启后(任一流程),有两个 Prometheus 指标将每个已加载 blob 的 `blake3` 作为标签暴露出来:
 
 - `aptos_dkg_digest_key_blake3{blake3="<hex>"} 1`
 - `aptos_dkg_public_params_blake3{blake3="<hex>"} 1`
 
-在 Grafana 中跨整个验证器集群按 `blake3` 标签分组.健康的发布显示每个指标只有一个标签值,且与上表匹配.
-多个值表示至少有一个验证器正在运行过时的 blob.
+在 Grafana 中跨整个验证器集群按 `blake3` 标签分组.健康的发布显示每个指标只有一个标签值,且与
+[已发布的校验和](#已发布的校验和) 表匹配.多个值表示至少有一个验证器正在运行过时的 blob.

--- a/src/content/docs/zh/network/nodes/validator-node/modify-nodes/update-trusted-setup.mdx
+++ b/src/content/docs/zh/network/nodes/validator-node/modify-nodes/update-trusted-setup.mdx
@@ -15,14 +15,15 @@ Aptos Labs 在 [`aptos-labs/aptos-networks`](https://github.com/aptos-labs/aptos
   共识.在重启节点之前,请始终对照下方发布的值验证 `blake3` 校验和.
 </Aside>
 
-<Aside type="note">
-  这些文件目前仅在**测试网**上发布.主网说明将在上游发布 blob 后添加.
-</Aside>
-
 ## 1. 下载 blob
 
 这两个文件通过 Git LFS 存储,因此下载 URL 使用 `github.com/.../raw/main/...`(它会跟随 LFS 重定向),
 而非 `raw.githubusercontent.com`.
+
+将目标路径调整为您的部署存储 `genesis.blob` 和 `waypoint.txt` 的位置.您选择的路径必须与 `validator.yaml`
+中的 `consensus.digest_key_blob_path` 和 `consensus.public_parameters_blob_path` 条目匹配(参见步骤 3).
+
+### 测试网
 
 ```shellscript filename="Terminal"
 wget -O /opt/aptos/genesis/digest_key.bin \
@@ -31,8 +32,19 @@ wget -O /opt/aptos/genesis/pp.bin \
   https://github.com/aptos-labs/aptos-networks/raw/main/testnet/pp.bin
 ```
 
-将目标路径调整为您的部署存储 `genesis.blob` 和 `waypoint.txt` 的位置.您选择的路径必须与 `validator.yaml`
-中的 `consensus.digest_key_blob_path` 和 `consensus.public_parameters_blob_path` 条目匹配(参见步骤 3).
+### 主网
+
+<Aside type="note">
+  主网的可信设置 blob 尚未发布.以下命令为预期形式;一旦 Aptos Labs 发布这些文件,本页将使用可用的 URL 和
+  校验和进行更新.
+</Aside>
+
+```shellscript filename="Terminal"
+wget -O /opt/aptos/genesis/digest_key.bin \
+  https://github.com/aptos-labs/aptos-networks/raw/main/mainnet/digest_key.bin
+wget -O /opt/aptos/genesis/pp.bin \
+  https://github.com/aptos-labs/aptos-networks/raw/main/mainnet/pp.bin
+```
 
 ## 2. 使用 Aptos CLI 验证
 
@@ -52,20 +64,22 @@ aptos node validate-public-parameters --file /opt/aptos/genesis/pp.bin
 }
 ```
 
-将 `size` 和 `blake3` 字段与下面的值进行比较.
+根据您所运营的网络,将 `size` 和 `blake3` 字段与下表中的值进行比较.
 
-### 预期的测试网校验和
+### 预期校验和
 
-以下校验和对应于
+测试网校验和对应于
 [`aptos-networks@92b13bf`](https://github.com/aptos-labs/aptos-networks/tree/92b13bf7844a0630cf5688ce8d309c46f712bbf2/testnet)
-中的 blob(截至 2026-05-14).每当 Aptos Labs 发布新版本时,本页面都会更新.
+中的 blob(截至 2026-05-14).每当 Aptos Labs 发布新版本时,本表都会更新.
 
-| 文件               | 大小(字节)       | blake3                                                             |
-| ---------------- | ------------ | ------------------------------------------------------------------ |
-| `digest_key.bin` | `4002048590` | `ffff6ab738c58c1c7eeb697eecbc369205e111c9ef271ab2cbe524869671b441` |
-| `pp.bin`         | `201655505`  | `a01c219766c4190f7d1b77836c0efd41b96486f7d46902f93e9b15260ea05cbc` |
+| 网络      | 文件               | 大小(字节)       | blake3                                                             |
+| ------- | ---------------- | ------------ | ------------------------------------------------------------------ |
+| testnet | `digest_key.bin` | `4002048590` | `ffff6ab738c58c1c7eeb697eecbc369205e111c9ef271ab2cbe524869671b441` |
+| testnet | `pp.bin`         | `201655505`  | `a01c219766c4190f7d1b77836c0efd41b96486f7d46902f93e9b15260ea05cbc` |
+| mainnet | `digest_key.bin` | _待定 — 尚未发布_  | _待定 — 尚未发布_                                                        |
+| mainnet | `pp.bin`         | _待定 — 尚未发布_  | _待定 — 尚未发布_                                                        |
 
-如果任一值不同,**请不要重启验证器** — 重新下载文件(最常见的原因是传输被截断,或者通过
+如果任一值与您所在网络的行不同,**请不要重启验证器** — 重新下载文件(最常见的原因是传输被截断,或者通过
 `raw.githubusercontent.com` 获取 LFS 指针文本,而不是通过 LFS 重定向的 `github.com/.../raw/...` URL).
 
 ## 3. 配置 validator.yaml

--- a/src/content/docs/zh/network/nodes/validator-node/modify-nodes/update-trusted-setup.mdx
+++ b/src/content/docs/zh/network/nodes/validator-node/modify-nodes/update-trusted-setup.mdx
@@ -22,13 +22,13 @@ Aptos Labs 在 [`aptos-labs/aptos-networks`](https://github.com/aptos-labs/aptos
 ## 已发布的校验和
 
 测试网校验和对应于
-[`aptos-networks@92b13bf`](https://github.com/aptos-labs/aptos-networks/tree/92b13bf7844a0630cf5688ce8d309c46f712bbf2/testnet)
-中的 blob(截至 2026-05-14).每当 Aptos Labs 发布新版本时,本表都会更新.
+[`aptos-networks@8cfc400`](https://github.com/aptos-labs/aptos-networks/tree/8cfc400bc1e42a232b5b36cde779a5b71d4d275b/testnet)
+中的 blob(截至 2026-05-15).每当 Aptos Labs 发布新版本时,本表都会更新.
 
 | 网络      | 文件               | 大小(字节)       | blake3                                                             |
 | ------- | ---------------- | ------------ | ------------------------------------------------------------------ |
 | testnet | `digest_key.bin` | `4002048590` | `ffff6ab738c58c1c7eeb697eecbc369205e111c9ef271ab2cbe524869671b441` |
-| testnet | `pp.bin`         | `201655505`  | `a01c219766c4190f7d1b77836c0efd41b96486f7d46902f93e9b15260ea05cbc` |
+| testnet | `pp.bin`         | `889521361`  | `5094dd22376eefde2febae5f2c9935d7eab0440af93166d246aa5c9f8ecb1b52` |
 | mainnet | `digest_key.bin` | _待定 — 尚未发布_  | _待定 — 尚未发布_                                                        |
 | mainnet | `pp.bin`         | _待定 — 尚未发布_  | _待定 — 尚未发布_                                                        |
 
@@ -181,8 +181,8 @@ trustedSetup:
   path: /opt/aptos/data/trusted-setup
   # 即使 URL 未变,也通过递增此整数来强制重新下载.默认为 0.
   refreshCounter: 0
-  digestKeyUrl: "https://github.com/aptos-labs/aptos-networks/raw/92b13bf7844a0630cf5688ce8d309c46f712bbf2/testnet/digest_key.bin"
-  publicParametersUrl: "https://github.com/aptos-labs/aptos-networks/raw/92b13bf7844a0630cf5688ce8d309c46f712bbf2/testnet/pp.bin"
+  digestKeyUrl: "https://github.com/aptos-labs/aptos-networks/raw/8cfc400bc1e42a232b5b36cde779a5b71d4d275b/testnet/digest_key.bin"
+  publicParametersUrl: "https://github.com/aptos-labs/aptos-networks/raw/8cfc400bc1e42a232b5b36cde779a5b71d4d275b/testnet/pp.bin"
 ```
 
 <Aside type="tip">
@@ -197,7 +197,7 @@ chart 在集群内部获取字节,因此集群内的下载过程不会经过 `ap
 
 ```shellscript filename="Terminal"
 wget -O /tmp/digest_key.bin \
-  https://github.com/aptos-labs/aptos-networks/raw/92b13bf7844a0630cf5688ce8d309c46f712bbf2/testnet/digest_key.bin
+  https://github.com/aptos-labs/aptos-networks/raw/8cfc400bc1e42a232b5b36cde779a5b71d4d275b/testnet/digest_key.bin
 aptos node validate-digest-key --file /tmp/digest_key.bin
 ```
 


### PR DESCRIPTION
## Summary

Adds a new operator runbook (EN + zh) for downloading, verifying, and rotating the DKG trusted-setup blobs (`digest_key.bin`, `pp.bin`) consumed by Aptos validator consensus, plus matching updates across the validator deploy guides, the testnet node-files reference, the glossary, and the sidebar. Companion to:

- **[internal-ops#8144](https://github.com/aptos-labs/internal-ops/pull/8144)** — Helm `aptos-node` chart refactor that introduces a `trustedSetup.*` values block (`path`, `refreshCounter`, `digestKeyUrl`, `publicParametersUrl`) and persists the blobs to the `aptos-data` PVC at `/opt/aptos/data/trusted-setup/` with `.url`-marker idempotency.
- **[aptos-core#19760](https://github.com/aptos-labs/aptos-core/pull/19760)** — new CLI commands `aptos node validate-digest-key` / `validate-public-parameters` and the `aptos_dkg_digest_key_blake3` / `aptos_dkg_public_params_blake3` Prometheus metrics.
- **Aptos-core docker/compose** — bind-mounts `digest_key.bin` / `pp.bin` from the working directory into `/opt/aptos/genesis/` and adds the matching `consensus.{digest_key,public_parameters}_blob_path` entries to the upstream `validator.yaml` (changes you're landing alongside this doc PR).

## Runbook structure

`network/nodes/validator-node/modify-nodes/update-trusted-setup` is split into three deployment-family flows so each operator reads top-to-bottom for their setup:

1. **Source code** — manual `wget`, verify with CLI, set `consensus.{digest_key,public_parameters}_blob_path` in `validator.yaml`, restart.
2. **Docker (compose)** — `wget` into the working directory; the upstream `docker-compose.yaml` bind-mounts the files and `validator.yaml` already has the consensus paths.
3. **Kubernetes (Helm chart)** — no manual download; set `trustedSetup.*` chart values, optional pre-deploy CLI verify on a workstation copy, apply, and the init container fetches once into the PVC. `refreshCounter` bump is the force-refresh path.

Shared sections at top + bottom: **Published checksums** (pinned `aptos-networks` SHA + blake3 table) and **Confirm fleet consistency** (Prometheus `blake3` label group-by in Grafana).

## Published checksums

Pinned to [`aptos-networks@8cfc400`](https://github.com/aptos-labs/aptos-networks/tree/8cfc400bc1e42a232b5b36cde779a5b71d4d275b/testnet) (the recent ceremony fix in [aptos-networks#194](https://github.com/aptos-labs/aptos-networks/pull/194)):

| File | Size (bytes) | blake3 |
|---|---|---|
| `digest_key.bin` | 4,002,048,590 | `ffff6ab738c58c1c7eeb697eecbc369205e111c9ef271ab2cbe524869671b441` |
| `pp.bin` | 889,521,361 | `5094dd22376eefde2febae5f2c9935d7eab0440af93166d246aa5c9f8ecb1b52` |

## Other surface changes

- `node-files-testnet.mdx` (EN + zh): `digest_key.bin` / `pp.bin` sections with the Git-LFS URL caveat.
- Five deploy guides (EN + zh): `using-source-code` and `using-docker` gain a dedicated `wget` step using a `<network>` placeholder; `using-aws` / `gcp` / `azure` get an `<Aside>` pointing at the Helm flow (chart fetches the blobs, no manual download).
- Glossary: **Trusted Setup** entry.
- Sidebar: new runbook entry under **Configure Validators**.

## Key safety callouts in the docs

1. **Git LFS**: download URLs must use \`github.com/.../raw/...\` (LFS-redirected) — \`raw.githubusercontent.com\` returns the 135-byte pointer text and silently breaks consensus.
2. **Fleet must load the same bytes**: every validator's blake3 must match the published value; mismatches across the fleet stop consensus.
3. **Pin Helm URLs to a SHA, not \`main\`**: avoids a silent \`main\`-tracking pull rolling out new bytes on the next pod restart.

## Follow-ups (non-blocking)

- When mainnet trusted-setup blobs are published in `aptos-networks/mainnet/`, fill in the mainnet rows in the **Published checksums** table.
- If/when an `aptos` CLI version is cut that includes the `validate-digest-key` / `validate-public-parameters` commands, consider adding a `requires aptos CLI ≥ vX.Y.Z` note (no point pinning a version that doesn't exist yet).

## Test plan

- [x] `pnpm format` / `pnpm lint` clean
- [x] `pnpm check` — 0 errors / 0 warnings / 0 hints across 205 files
- [x] `pnpm test tests/agent-discovery.test.ts tests/markdown-negotiation.test.ts` — 42/42 pass (no agent-discovery surface changes; ran as sanity)
- [x] Re-downloaded `testnet/digest_key.bin` and `pp.bin` at `aptos-networks@8cfc400` and recomputed blake3 — matches the published table
- [ ] Visual review of the new page in `pnpm dev`

🤖 Generated with [Claude Code](https://claude.com/claude-code)