### PR TITLE
chore: split Codecov bundle analysis into client and server bundles

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -337,11 +337,16 @@ export default defineConfig({
   vite: {
     plugins: [
       tailwindcss(),
-      codecovVitePlugin({
+      ...codecovVitePlugin({
         enableBundleAnalysis: Boolean(process.env.CODECOV_TOKEN),
-        bundleName: "aptos-docs",
+        bundleName: "aptos-docs-client",
         uploadToken: process.env.CODECOV_TOKEN || undefined,
-      }),
+      }).map((p) => ({ ...p, apply: (config) => !config.build?.ssr })),
+      ...codecovVitePlugin({
+        enableBundleAnalysis: Boolean(process.env.CODECOV_TOKEN),
+        bundleName: "aptos-docs-server",
+        uploadToken: process.env.CODECOV_TOKEN || undefined,
+      }).map((p) => ({ ...p, apply: (config) => Boolean(config.build?.ssr) })),
     ],
     optimizeDeps: {
       exclude: ["@rollup/browser"],

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -86,6 +86,11 @@ const ALGOLIA_INDEX_NAME = ENV.ALGOLIA_INDEX_NAME;
 const hasAlgoliaConfig = ALGOLIA_APP_ID && ALGOLIA_SEARCH_API_KEY && ALGOLIA_INDEX_NAME;
 const enableApiReference = true;
 
+/** @type {(config: import("vite").UserConfig) => boolean} */
+const isClientViteBuild = (config) => !config.build?.ssr;
+/** @type {(config: import("vite").UserConfig) => boolean} */
+const isServerViteBuild = (config) => Boolean(config.build?.ssr);
+
 // https://astro.build/config
 export default defineConfig({
   build: {
@@ -341,12 +346,12 @@ export default defineConfig({
         enableBundleAnalysis: Boolean(process.env.CODECOV_TOKEN),
         bundleName: "aptos-docs-client",
         uploadToken: process.env.CODECOV_TOKEN || undefined,
-      }).map((p) => ({ ...p, apply: (config) => !config.build?.ssr })),
+      }).map((p) => ({ ...p, apply: isClientViteBuild })),
       ...codecovVitePlugin({
         enableBundleAnalysis: Boolean(process.env.CODECOV_TOKEN),
         bundleName: "aptos-docs-server",
         uploadToken: process.env.CODECOV_TOKEN || undefined,
-      }).map((p) => ({ ...p, apply: (config) => Boolean(config.build?.ssr) })),
+      }).map((p) => ({ ...p, apply: isServerViteBuild })),
     ],
     optimizeDeps: {
       exclude: ["@rollup/browser"],


### PR DESCRIPTION
## Summary

- Replaces the single `"aptos-docs"` Codecov bundle with two separate bundles: `"aptos-docs-client"` and `"aptos-docs-server"`
- Uses Vite's `apply` callback (branching on `config.build?.ssr`) to route each plugin instance to exactly one of Astro's two SSR build passes — previously both passes uploaded stats under the same name, so whichever finished last silently overwrote the other
- JSDoc `@type` helpers at module scope provide the `UserConfig` parameter type without TypeScript syntax (the config file is `.mjs` with `// @ts-check`)

## Test plan

- [ ] Confirm CI passes (lint, type check, link check)
- [ ] After merge, verify two separate bundle entries appear in Codecov: `aptos-docs-client` and `aptos-docs-server`