### PR TITLE
docs: add Codex to data providers

### DIFF
--- a/src/content/docs/build/apis/data-providers.mdx
+++ b/src/content/docs/build/apis/data-providers.mdx
@@ -103,6 +103,7 @@ We also have some partners who target more enterprise use cases
 - [NODEREAL](https://nodereal.io/aptos) for REST API endpoint
 - [SHINAMI](https://docs.shinami.com/reference/api-references-overview) for REST API and GraphQL endpoints
 - [QuickNode](https://www.quicknode.com/chains/apt) for REST API endpoint
+- [Codex](https://docs.codex.io/networks/aptos) for a GraphQL API with token prices, trading pairs, holders, and wallet balances, plus WebSocket subscriptions for real-time updates
 
 Additional RPC vendors can be found [here](https://aptosnetwork.com/ecosystem/directory/category/rpc)
 

--- a/src/content/docs/zh/build/apis/data-providers.mdx
+++ b/src/content/docs/zh/build/apis/data-providers.mdx
@@ -78,6 +78,10 @@ sidebar:
 他们在这里提供了指南:[https://docs.sentio.xyz/docs/aptos](https://docs.sentio.xyz/docs/aptos)  数据可以在 data source -> external project -> sentio/aptos-overview 路径下找到\
 他们还提供交易的堆栈追踪功能
 
+## 实时数据供应商
+
+- [Codex](https://docs.codex.io/networks/aptos) 提供 GraphQL API,涵盖代币价格,交易对,持有者和钱包余额,并支持通过 WebSocket 订阅获取实时更新
+
 ## 其他供应商
 
 我们还有一些面向更企业级使用场景的合作伙伴- [Token Terminal](https://tokenterminal.com/resources/articles/aptos-data-partnership)


### PR DESCRIPTION
## Description

Adds [Codex](https://docs.codex.io/networks/aptos) to the "Vendors for real-time data" list on the Data Providers page.

Codex indexes Aptos (network ID `49705`) and provides a GraphQL API covering token prices, trading pairs, holders, and wallet balances, plus WebSocket subscriptions for real-time updates. See their [Aptos network docs](https://docs.codex.io/networks/aptos) for the full endpoint list.

## Changes

- `src/content/docs/build/apis/data-providers.mdx`: added Codex to the real-time data vendors list
- `src/content/docs/zh/build/apis/data-providers.mdx`: added the corresponding Chinese entry. Note: the zh page predates the English page's "Vendors for real-time data" section, so this adds a new `实时数据供应商` section with the Codex entry.

## Checks

- `pnpm lint` / Prettier pass on the edited files
- `astro check` and starlight-links-validator pass (via pre-push hook)