### PR TITLE
fix: restore GFM table rendering for all MDX content

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -385,6 +385,7 @@ export default defineConfig({
     },
   },
   markdown: {
+    gfm: true,
     remarkPlugins: [
       remarkMath,
       [


### PR DESCRIPTION
## Summary

Adds `gfm: true` to the `markdown` config in `astro.config.mjs`.

`@astrojs/mdx@5.0.3` no longer inherits `gfm: true` by default. Without this flag, `remark-gfm` is never loaded and all MDX files with GFM tables render raw pipe-delimited text instead of HTML `<table>` elements.

**Affected page (broken on production):** https://aptos.dev/build/smart-contracts/why-move

Tables currently render as raw text like:
```
| **Principle** | **Description** | | --- | --- | | **Safe by default** | Financial systems are designed...
```
instead of proper HTML tables.

## Root cause

`markdownConfigToMdxOptions` in `@astrojs/mdx@5.0.3` spreads `markdownConfig` but its `defaultMdxOptions` doesn't include `gfm`. When `astro.config.mjs` doesn't explicitly set `gfm`, the value is `undefined` and the `if (mdxOptions.gfm)` guard in `plugins.js` skips loading `remark-gfm` entirely.

## Test plan

- [x] Tables render as proper `<table>` HTML after fix
- [x] `pnpm check` passes (0 errors)
- [x] `pnpm build` + link checker passes — no broken links

🤖 Generated with [Claude Code](https://claude.com/claude-code)