### PR TITLE
chore: pin GitHub Actions to SHA hashes and bump versions

### DIFF
--- a/.github/actions/prepare-runner/action.yml
+++ b/.github/actions/prepare-runner/action.yml
@@ -4,10 +4,10 @@ runs:
   using: composite
   steps:
     - name: Install Node.js
-      uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+      uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
       with:
         node-version: 22.23.0
-    - uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4.1.0
+    - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
       name: Install pnpm
       id: pnpm-install
     - name: Get pnpm store directory
@@ -16,7 +16,7 @@ runs:
       run: |
         echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_OUTPUT
 
-    - uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
+    - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
       name: Setup pnpm cache
       with:
         path: ${{ steps.pnpm-cache.outputs.STORE_PATH }}

--- a/.github/workflows/cli-install-scripts.yml
+++ b/.github/workflows/cli-install-scripts.yml
@@ -57,7 +57,7 @@ jobs:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Test install_cli.sh
         if: runner.os != 'Windows'


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Ensures all third-party GitHub Actions are pinned to full commit SHAs (supply-chain hardening) and updates them to the latest releases published more than 3 days ago (as of 2026-07-02).

## Changes

| Action | Previous | Updated |
|--------|----------|---------|
| `actions/checkout` | `@v7` (tag only, in `cli-install-scripts.yml`) | `@9c091bb…` (v7.0.0) |
| `actions/setup-node` | v4.4.0 | v6.4.0 |
| `pnpm/action-setup` | v4.1.0 | v6.0.9 |
| `actions/cache` | v4.2.4 | v6.1.0 |

`actions/checkout` in `check.yml`, `lint.yml`, and `test.yml` was already pinned to v7.0.0 and remains current.

## Verification

- All `uses:` references under `.github/` now resolve to 40-character commit SHAs with version comments.
- No tag-only (`@v*`) or branch references remain for third-party actions.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f229f-e383-7b66-9d90-91d3a8438177"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f229f-e383-7b66-9d90-91d3a8438177"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

