### PR TITLE
fix(docs): TypeScript SDK reference links 404 (ts-sdk-1.35.0)

### DIFF
--- a/src/content/docs/build/guides/aptos-keyless/federated-keyless/other.mdx
+++ b/src/content/docs/build/guides/aptos-keyless/federated-keyless/other.mdx
@@ -11,7 +11,7 @@ sidebar:
 
 - An account address depends on values of several variables that are specific to an IAM service, including `aud` (client ID) and `iss` (issuer).  If these values are changed, then a different address will be derived.
 - If you want to switch IAM providers, you will need to develop an account migration flow, resulting in a key rotation from the account derived from the prior IAM provider to the account derived from the new IAM provider.
-- We recommend allowing your users to add a secondary authentication method to their accounts (e.g., back-up private key) so that they can maintain access should the authentication path into their account via Federated Keyless be disrupted via a service provider change. In order to implement this, you need to do a key rotation to a multikey account. For relevant documentation see [key rotation](/build/guides/key-rotation) and [multikey SDK](https://aptos-labs.github.io/aptos-ts-sdk/@aptos-labs/ts-sdk-1.35.0/classes/MultiKeyAccount.html).
+- We recommend allowing your users to add a secondary authentication method to their accounts (e.g., back-up private key) so that they can maintain access should the authentication path into their account via Federated Keyless be disrupted via a service provider change. In order to implement this, you need to do a key rotation to a multikey account. For relevant documentation see [key rotation](/build/guides/key-rotation) and [multikey SDK](https://aptos-labs.github.io/aptos-ts-sdk/@aptos-labs/ts-sdk-7.2.0/classes/MultiKeyAccount.html).
 
 **Does using an IAM cost money?**
 

--- a/src/content/docs/build/sdks/ts-sdk/building-transactions.mdx
+++ b/src/content/docs/build/sdks/ts-sdk/building-transactions.mdx
@@ -10,7 +10,7 @@ import { Aside, Steps } from '@astrojs/starlight/components';
 Transactions allow you to change on-chain data or trigger events. Generally, transactions follow 5 steps from building to executing on chain: building, simulating, signing, submitting, and waiting.
 
 <Aside type="note">
-  For these examples, `aptos` is an instance of the [`Aptos`](https://aptos-labs.github.io/aptos-ts-sdk/@aptos-labs/ts-sdk-1.35.0/classes/Aptos.html) client object.
+  For these examples, `aptos` is an instance of the [`Aptos`](https://aptos-labs.github.io/aptos-ts-sdk/@aptos-labs/ts-sdk-7.2.0/classes/Aptos.html) client object.
 </Aside>
 
 <Steps>
@@ -93,7 +93,7 @@ Transactions allow you to change on-chain data or trigger events. Generally, tra
 
   5. Wait
 
-     Finally, you can wait for the result of the transaction by using [`aptos.waitForTransaction`](https://aptos-labs.github.io/aptos-ts-sdk/@aptos-labs/ts-sdk-1.35.0/classes/Aptos.html#waitForTransaction) and specifying the hash of the transaction you just submitted like so:
+     Finally, you can wait for the result of the transaction by using [`aptos.waitForTransaction`](https://aptos-labs.github.io/aptos-ts-sdk/@aptos-labs/ts-sdk-7.2.0/classes/Aptos.html#waitfortransaction) and specifying the hash of the transaction you just submitted like so:
 
      ```typescript filename="build-a-transaction.ts"
      // 5. Wait

--- a/src/content/docs/build/sdks/ts-sdk/fetch-data-via-sdk.mdx
+++ b/src/content/docs/build/sdks/ts-sdk/fetch-data-via-sdk.mdx
@@ -7,7 +7,7 @@ sidebar:
 
 import { Aside } from '@astrojs/starlight/components';
 
-You can use the `Aptos` client to get on-chain data using a variety of helper functions. Specifically, many of the functions listed in the reference docs [here](https://aptos-labs.github.io/aptos-ts-sdk/@aptos-labs/ts-sdk-1.35.0/classes/Aptos.html) that start with `get...` will retrieve data from on-chain.
+You can use the `Aptos` client to get on-chain data using a variety of helper functions. Specifically, many of the functions listed in the reference docs [here](https://aptos-labs.github.io/aptos-ts-sdk/@aptos-labs/ts-sdk-7.2.0/classes/Aptos.html) that start with `get...` will retrieve data from on-chain.
 
 Here’s an example showing how to fetch common data you may need in your application:
 

--- a/src/content/docs/build/sdks/ts-sdk/quickstart.mdx
+++ b/src/content/docs/build/sdks/ts-sdk/quickstart.mdx
@@ -332,7 +332,7 @@ All told, you just learned how to transfer APT via a transaction by:
 
 1. Connecting to the network using the `Aptos` client.
 2. Creating an account.
-3. Looking up data from on-chain using client helper functions like [`aptos.getAccountModules`](https://aptos-labs.github.io/aptos-ts-sdk/@aptos-labs/ts-sdk-1.35.0/classes/Aptos.html#getAccountModules).
+3. Looking up data from on-chain using client helper functions like [`aptos.getAccountModules`](https://aptos-labs.github.io/aptos-ts-sdk/@aptos-labs/ts-sdk-7.2.0/classes/Aptos.html#getaccountmodules).
 4. Signing and submitting a transaction to the network.
 5. Waiting for Aptos to execute the transaction.
 
@@ -341,5 +341,5 @@ To see all this in action, you can copy and run the full working code snippet fo
 <Aside type="note">
   For future development, make sure to bookmark the [reference docs](https://aptos-labs.github.io/aptos-ts-sdk/) to look up specific function signatures.
 
-  Note that most helper functions are listed on the [`Aptos` client object](https://aptos-labs.github.io/aptos-ts-sdk/@aptos-labs/ts-sdk-1.35.0/classes/Aptos.html).
+  Note that most helper functions are listed on the [`Aptos` client object](https://aptos-labs.github.io/aptos-ts-sdk/@aptos-labs/ts-sdk-7.2.0/classes/Aptos.html).
 </Aside>

--- a/src/content/docs/zh/build/sdks/ts-sdk/building-transactions.mdx
+++ b/src/content/docs/zh/build/sdks/ts-sdk/building-transactions.mdx
@@ -10,7 +10,7 @@ import { Aside, Steps } from '@astrojs/starlight/components';
 交易允许你更改链上数据或触发事件.通常,交易从构建到链上执行会经历5个步骤:构建,模拟,签名,提交和等待.
 
 <Aside type="note">
-  在这些示例中,`aptos` 是 [`Aptos`](https://aptos-labs.github.io/aptos-ts-sdk/@aptos-labs/ts-sdk-1.35.0/classes/Aptos.html) 客户端对象的实例.
+  在这些示例中,`aptos` 是 [`Aptos`](https://aptos-labs.github.io/aptos-ts-sdk/@aptos-labs/ts-sdk-7.2.0/classes/Aptos.html) 客户端对象的实例.
 </Aside>
 
 <Steps>
@@ -91,7 +91,7 @@ import { Aside, Steps } from '@astrojs/starlight/components';
 
   4. 等待
 
-     最后,可以通过 [`aptos.waitForTransaction`](https://aptos-labs.github.io/aptos-ts-sdk/@aptos-labs/ts-sdk-1.35.0/classes/Aptos.html#waitForTransaction) 等待交易结果,指定刚提交的交易哈希:
+     最后,可以通过 [`aptos.waitForTransaction`](https://aptos-labs.github.io/aptos-ts-sdk/@aptos-labs/ts-sdk-7.2.0/classes/Aptos.html#waitfortransaction) 等待交易结果,指定刚提交的交易哈希:
 
      ```typescript filename="build-a-transaction.ts"
      // 5. 等待

--- a/src/content/docs/zh/build/sdks/ts-sdk/fetch-data-via-sdk.mdx
+++ b/src/content/docs/zh/build/sdks/ts-sdk/fetch-data-via-sdk.mdx
@@ -7,7 +7,7 @@ sidebar:
 
 import { Aside } from '@astrojs/starlight/components';
 
-你可以使用 `Aptos` 客户端通过多种辅助函数获取链上数据.具体来说,参考文档[此处](https://aptos-labs.github.io/aptos-ts-sdk/@aptos-labs/ts-sdk-1.35.0/classes/Aptos.html)列出的许多以 `get...` 开头的函数都可以从链上检索数据.
+你可以使用 `Aptos` 客户端通过多种辅助函数获取链上数据.具体来说,参考文档[此处](https://aptos-labs.github.io/aptos-ts-sdk/@aptos-labs/ts-sdk-7.2.0/classes/Aptos.html)列出的许多以 `get...` 开头的函数都可以从链上检索数据.
 
 以下示例展示了如何获取应用程序中可能需要的常见数据:
 

--- a/src/content/docs/zh/build/sdks/ts-sdk/quickstart.mdx
+++ b/src/content/docs/zh/build/sdks/ts-sdk/quickstart.mdx
@@ -326,7 +326,7 @@ example();
 
 1. 使用 `Aptos` 客户端连接网络
 2. 创建账户
-3. 使用客户端辅助函数如 [`aptos.getAccountModules`](https://aptos-labs.github.io/aptos-ts-sdk/@aptos-labs/ts-sdk-1.35.0/classes/Aptos.html#getAccountModules) 查询链上数据
+3. 使用客户端辅助函数如 [`aptos.getAccountModules`](https://aptos-labs.github.io/aptos-ts-sdk/@aptos-labs/ts-sdk-7.2.0/classes/Aptos.html#getaccountmodules) 查询链上数据
 4. 签名并向网络提交交易
 5. 等待 Aptos 执行交易
 
@@ -335,5 +335,5 @@ example();
 <Aside type="note">
   为了后续开发,请务必收藏 [参考文档](https://aptos-labs.github.io/aptos-ts-sdk/) 以便查阅具体函数签名.
 
-  请注意,大多数辅助函数都列在 [`Aptos` 客户端对象](https://aptos-labs.github.io/aptos-ts-sdk/@aptos-labs/ts-sdk-1.35.0/classes/Aptos.html)上.
+  请注意,大多数辅助函数都列在 [`Aptos` 客户端对象](https://aptos-labs.github.io/aptos-ts-sdk/@aptos-labs/ts-sdk-7.2.0/classes/Aptos.html)上.
 </Aside>


### PR DESCRIPTION
## Problem

Every TypeScript SDK reference link in the docs points into `@aptos-labs/ts-sdk-1.35.0`, a version tree that is no longer published:

```
$ curl -o /dev/null -w '%{http_code}' -L \
    https://aptos-labs.github.io/aptos-ts-sdk/@aptos-labs/ts-sdk-1.35.0/classes/Aptos.html
404
```

The published version index (https://aptos-labs.github.io/aptos-ts-sdk/) currently lists `5.2.1`, `6.3.1`, `7.1.0`–`7.1.3` and `7.2.0` — `1.35.0` is gone. So a reader who follows the `Aptos` client link from the TS SDK quickstart, `building-transactions`, or `fetch-data-via-sdk` lands on a 404, in both the English and Chinese docs.

A second, smaller breakage rides along on the same URLs: two links use camelCase fragments (`#waitForTransaction`, `#getAccountModules`), but TypeDoc emits lowercase ids (`id="waitfortransaction"`, `id="getaccountmodules"`), so even once the page resolves the anchor does not jump.

## Fix

- `ts-sdk-1.35.0` → `ts-sdk-7.2.0` (11 links across 7 files)
- lowercase the two TypeDoc fragments on those same links

## Why pin 7.2.0 rather than a floating alias

`@aptos-labs/ts-sdk-latest` is a single redirect page, not a version directory — it resolves at the root but 404s on any deep path:

| URL | Status |
|---|---|
| `.../@aptos-labs/ts-sdk-latest` | 200 (meta-refresh to `ts-sdk-7.2.0`) |
| `.../@aptos-labs/ts-sdk-latest/classes/Aptos.html` | 404 |
| `.../@aptos-labs/ts-sdk-7.2.0/classes/Aptos.html` | 200 |

So an explicit version is the only form that works for reference deep links today. If you would rather these links track the SDK automatically, the underlying fix belongs in the docs-publishing setup (a `latest/` directory alias); happy to close this in favour of that.

## Verification

Every resulting URL was checked twice:

| URL | Status |
|---|---|
| `.../ts-sdk-7.2.0/classes/Aptos.html` | 200 |
| `.../ts-sdk-7.2.0/classes/MultiKeyAccount.html` | 200 |

Both replacement anchors were confirmed present in the fetched HTML (`id="waitfortransaction"`, `id="getaccountmodules"`).

Docs-only change: no code, config, or dependency is touched.