### PR TITLE
docs: drop dead status.devnet.aptos.dev refs (aptos.dev DNS audit)

### DIFF
--- a/src/content/docs/network/nodes/full-node/modify/update-fullnode-with-new-releases.mdx
+++ b/src/content/docs/network/nodes/full-node/modify/update-fullnode-with-new-releases.mdx
@@ -135,5 +135,3 @@ terraform apply -var force_helm_update=true
 [devnet_waypoint]: https://devnet.aptoslabs.com/waypoint.txt
 
 [aptos-labs/aptos-core]: https://github.com/aptos-labs/aptos-core.git
-
-[status dashboard]: https://status.devnet.aptos.dev

--- a/src/content/docs/network/nodes/full-node/verify-pfn.mdx
+++ b/src/content/docs/network/nodes/full-node/verify-pfn.mdx
@@ -101,5 +101,3 @@ du -cs -BM /opt/aptos/data
 [devnet_waypoint]: https://devnet.aptoslabs.com/waypoint.txt
 
 [aptos-labs/aptos-core]: https://github.com/aptos-labs/aptos-core.git
-
-[status dashboard]: https://status.devnet.aptos.dev

--- a/src/content/docs/zh/network/nodes/full-node/modify/update-fullnode-with-new-releases.mdx
+++ b/src/content/docs/zh/network/nodes/full-node/modify/update-fullnode-with-new-releases.mdx
@@ -129,5 +129,3 @@ terraform apply -var force_helm_update=true
 [devnet_waypoint]: https://devnet.aptoslabs.com/waypoint.txt
 
 [aptos-labs/aptos-core]: https://github.com/aptos-labs/aptos-core.git
-
-[status dashboard]: https://status.devnet.aptos.dev

--- a/src/content/docs/zh/network/nodes/full-node/verify-pfn.mdx
+++ b/src/content/docs/zh/network/nodes/full-node/verify-pfn.mdx
@@ -85,5 +85,3 @@ du -cs -BM /opt/aptos/data
 [devnet_waypoint]: https://devnet.aptoslabs.com/waypoint.txt
 
 [aptos-labs/aptos-core]: https://github.com/aptos-labs/aptos-core.git
-
-[status dashboard]: https://status.devnet.aptos.dev


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What this PR does

Removes unused markdown reference definitions that pointed at `https://status.devnet.aptos.dev`. That hostname no longer resolves (`NXDOMAIN`). The English and Chinese PFN pages already send operators to [Aptos Explorer](https://explorer.aptoslabs.com/?network=mainnet) for version checks, so the leftover labels were dead.

The rest of this description is a **live DNS audit of `aptos.dev`** (queried 2026-08-13 against Google Cloud DNS `ns-cloud-c1.googledomains.com`). DNS itself lives in Google Cloud DNS, not this repo — the items below need a Cloud DNS / Vercel / Netlify change, not a docs deploy.

## Current zone (keep)

Nameservers: `ns-cloud-c{1,2,3,4}.googledomains.com` (Google Cloud DNS). Apex is **not** on Vercel DNS.

| Name | Type | Target | Notes |
| --- | --- | --- | --- |
| `aptos.dev` | A | `76.76.21.21` | Vercel anycast. Serves production docs. |
| `www.aptos.dev` | CNAME | `cname.vercel-dns.com` | 307 → `https://aptos.dev/` |
| `js-pro.aptos.dev` | CNAME | `cname.vercel-dns.com` | Live (Aptos JS-Pro). Linked from the sidebar. |
| `siwa.aptos.dev` | CNAME | `cname.vercel-dns.com` | Live (Sign in with Aptos). Linked from the sidebar. |
| `aptos.dev` | TXT | `google-site-verification=3b5igLUo51tyTlj…` | Search Console. Keep unless ownership moved. |

`www` → apex redirect, HTTP → HTTPS, and Vercel TLS all look correct. No wildcard `*.aptos.dev`. `.dev` is on the HSTS preload list with `includeSubDomains`, so **every** hostname under `aptos.dev` must have a valid certificate or browsers fail closed.

## Cleanup: delete or repair these records

### 1. `legacy.aptos.dev` — delete

- CNAME → `aptos-developer-docs.netlify.app` (old Nextra docs, archived `aptos-labs/developer-docs`).
- HTTPS presents Netlify’s `*.netlify.app` cert, **not** `legacy.aptos.dev`. Browsers get a certificate error.
- HTTP/HTTPS both return Netlify **404**. Custom domain was removed from the Netlify site; the DNS CNAME was left behind.

**Action:** delete the CNAME in Cloud DNS. Optionally delete/archive the Netlify project `aptos-developer-docs` if nothing else uses it.

### 2. `fullnode.devnet.aptos.dev` — delete (or add it to the API cert)

- CNAME → `fullnode.devnet.aptoslabs.com` → `api.devnet.aptoslabs.com`.
- The cert on that endpoint only covers `api.devnet.aptoslabs.com`, `fullnode.devnet.aptoslabs.com`, and `grpc.devnet.aptoslabs.com` — **not** `*.aptos.dev`.
- Because `.dev` is HSTS-preloaded, this alias is unusable in browsers.

**Action:** remove the CNAME. Callers should use `fullnode.devnet.aptoslabs.com` / `api.devnet.aptoslabs.com`. Docs already use the `aptoslabs.com` names.

### 3. `status.devnet.aptos.dev` — already gone (docs cleaned here)

`NXDOMAIN`. Unused `[status dashboard]` footnotes removed in this PR (EN + ZH).

## Review with owners (do not delete blindly)

### `explorer.devnet.aptos.dev` — working legacy redirect

- CNAME → `aptos-explorer.netlify.app`.
- Cert SAN includes both `explorer.aptoslabs.com` and `explorer.devnet.aptos.dev`.
- 301 → `https://explorer.aptoslabs.com/?network=devnet`.

This is the old explorer hostname still doing a compatibility redirect. Keep until traffic is gone, then drop the CNAME and the Netlify custom domain.

### `preview.aptos.dev` — production alias, not a preview

- CNAME → `cname.vercel-dns.com`.
- Every path 307s to the same path on `https://aptos.dev/`.
- Also listed in `astro.config.mjs` `image.domains`.

If this was meant to be a Vercel preview domain, it is attached to production instead. Either wire it up as a real preview host or remove the DNS + Vercel domain + `image.domains` entry. Harmless as a duplicate production alias, but extra attack/config surface.

### `encrypted-mempool.setup-ceremony.aptos.dev` — confirm with research

- A → `136.119.166.176` (`*.bc.googleusercontent.com`, GCP).
- No HTTP/TLS service responded on 80/443.
- Related to the encrypted-mempool trusted setup (`aptos-labs/aptos-setup-ceremony`, AIP-144). Repo is recent (2026-03).

**Action:** ask the ceremony owners whether this VM is still needed. Do not delete until they confirm the ceremony is finished.

## Missing records (add, not delete)

The zone has **no MX**, which is correct if `aptos.dev` does not receive mail. It also has **no SPF, DMARC, or CAA**, which is the more interesting gap:

| Record | Suggested value | Why |
| --- | --- | --- |
| TXT `aptos.dev` | `v=spf1 -all` | Publish that this domain sends no mail. Without SPF, anyone can spoof `@aptos.dev`. |
| TXT `_dmarc.aptos.dev` | `v=DMARC1; p=reject; sp=reject; adkim=s; aspf=s;` | Reject spoofed mail at receivers that honor DMARC. |
| CAA `aptos.dev` | `0 issue "letsencrypt.org"` and `0 issue "pki.goog"` (confirm against Vercel’s current issuers before adding) | Stop unexpected CAs from issuing certs for the zone. Do not add CAA until the issuer list is verified — a wrong CAA record breaks TLS issuance. |

Optional / not urgent:

- **DNSSEC:** zone is unsigned (no DS at the `.dev` parent).
- **AAAA at apex:** none. Vercel’s `76.76.21.21` A record is IPv4-only; this matches current Vercel guidance.
- **`_vercel` TXT:** not present; apex A to `76.76.21.21` is enough for Vercel verification.
- **SOA serial is `1`:** unusual for a zone that has accumulated several CNAMEs. Worth a glance in the Cloud DNS console that this is the intended production zone, not a freshly recreated one.

## Out of scope / not found

Enumerated common names (`api`, `docs`, `staging`, `faucet`, `cdn`, `_acme-challenge`, `_dmarc`, DKIM selectors, `*.testnet.aptos.dev`, `*.mainnet.aptos.dev`, etc.) — no extra records. No zone transfer. Public CT (Cert Spotter) names: `aptos.dev`, `www`, `preview`, `js-pro`, `siwa`, `explorer.devnet.aptos.dev`.

## How to apply the DNS cleanup

In Google Cloud DNS for `aptos.dev`:

1. Delete `legacy.aptos.dev` CNAME.
2. Delete `fullnode.devnet.aptos.dev` CNAME.
3. Confirm ceremony A record with research; delete only if retired.
4. Decide on `preview.aptos.dev` and `explorer.devnet.aptos.dev` as above.
5. Add SPF + DMARC (and CAA only after issuer confirmation).

This PR does not change DNS. It only removes the unused docs footnotes for the hostname that is already gone.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-76eedbeb-f355-4c78-ad70-14dfd90a4d48?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-76eedbeb-f355-4c78-ad70-14dfd90a4d48&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

