### PR TITLE
Add OpenChainBench to external tools

### DIFF
--- a/src/content/docs/build/external-resources.mdx
+++ b/src/content/docs/build/external-resources.mdx
@@ -58,3 +58,5 @@ Network explorers and hosted developer services:
 ## Data and analytics
 
 SQL datasets, dashboards, and RPC vendors are listed on [Data Providers](/build/apis/data-providers).
+
+- [OpenChainBench](https://openchainbench.com/benchmarks/aptos-rpc) — Live RPC latency benchmark for Aptos public REST nodes: p50/p90/p99 measured every 60 seconds from US-East, EU-West and Singapore.


### PR DESCRIPTION
OpenChainBench (https://openchainbench.com) actively benchmarks Aptos:

- **Move FA token deployment cost** — tracked every 5 minutes (sui_aptos.go harness), comparing Aptos with Solana, Sui, and other non-EVM chains
- **Wormhole VAA latency** — Aptos chain ID 22 tracked
- **RPC latency** — p50/p90/p99 for Aptos RPC providers

The tool is open-source (CC BY 4.0), no token, no commercial lock-in. Source: https://github.com/ChainBench/OpenChainBench