### PR TITLE
docs: repoint the table info backup bucket to the v2 bucket

### DIFF
--- a/src/content/docs/build/indexer/txn-stream/self-hosted.mdx
+++ b/src/content/docs/build/indexer/txn-stream/self-hosted.mdx
@@ -98,7 +98,7 @@ Call DataService.GetTransactions directly. In this case you might want to run bo
 - Do not keep full history
   If your stream never needs to serve old data and you don't want to keep the full history, for example you want to start a stream now and only care about data in the future, you can choose to not sync from genesis.
 
-In order to do that, first you can start your FN and do a fast sync. Then download the most recent table info database from [https://console.cloud.google.com/storage/browser/aptos-indexer-grpc-mainnet-table-info-backup](https://console.cloud.google.com/storage/browser/aptos-indexer-grpc-mainnet-table-info-backup) (for testnet, replace `mainnet` with `testnet`), unzip to the db folder in your FN.
+In order to do that, first you can start your FN and do a fast sync. Then download the most recent table info database from [https://console.cloud.google.com/storage/browser/aptos-indexer-grpc-v2-mainnet-table-info-backup](https://console.cloud.google.com/storage/browser/aptos-indexer-grpc-v2-mainnet-table-info-backup) (for testnet, replace `mainnet` with `testnet`), unzip to the db folder in your FN.
 
 Then start your GrpcManager, it will generate the `metadata.json` in your file store (it could be your local file stream or GCS based on your config). Manually update the version to the next version you want to start processing. (the version must be a multiple of 100000 plus 1, e.g. 1000000001, and your FN must have data at this version).
 

--- a/src/content/docs/zh/build/indexer/txn-stream/self-hosted.mdx
+++ b/src/content/docs/zh/build/indexer/txn-stream/self-hosted.mdx
@@ -98,7 +98,7 @@ server_config:
 - 不保留完整历史
   如果流永远不需要提供旧数据，也不想保留完整历史，例如只想现在开始流式处理并只关心未来数据，可以选择不从创世同步。
 
-为此，先启动 FN 并进行快速同步。然后从 [https://console.cloud.google.com/storage/browser/aptos-indexer-grpc-mainnet-table-info-backup](https://console.cloud.google.com/storage/browser/aptos-indexer-grpc-mainnet-table-info-backup) 下载最新 table info 数据库（对于 Testnet，将 mainnet 替换为 testnet），解压到 FN 中的 db 文件夹。
+为此，先启动 FN 并进行快速同步。然后从 [https://console.cloud.google.com/storage/browser/aptos-indexer-grpc-v2-mainnet-table-info-backup](https://console.cloud.google.com/storage/browser/aptos-indexer-grpc-v2-mainnet-table-info-backup) 下载最新 table info 数据库（对于 Testnet，将 mainnet 替换为 testnet），解压到 FN 中的 db 文件夹。
 
 随后启动 GrpcManager；它会在文件存储中生成 metadata.json（根据配置，它可以是本地文件流或 GCS）。手动将版本更新为希望开始处理的下一个版本。（该版本必须是 100000 的倍数加 1，例如 1000000001，并且 FN 必须拥有该版本的数据。）
 


### PR DESCRIPTION
## Summary

The self-hosted txn-stream page links to `aptos-indexer-grpc-mainnet-table-info-backup`, which no longer grants public read — that bucket belonged to the now-decommissioned `v2-mainnet-prod` / `v2-testnet-staging` stacks, and it stopped being written to when table-info publishing moved. Anyone following the "do not keep full history" instructions gets a 403.

The current public buckets are `aptos-indexer-grpc-v2-{mainnet,testnet}-table-info-backup`. Both are world-readable and actively written — mainnet is at epoch 17039 and testnet at epoch 35237 as of today, updated hourly.

Applied to the English and Chinese copies of the page. The "for testnet, replace `mainnet` with `testnet`" instruction still resolves correctly against the new name.

Reported in https://github.com/aptos-labs/aptos-core/issues/20362.

## Test plan

- [ ] The linked bucket browser loads without a permissions error
- [ ] `curl -o /dev/null -w '%{http_code}' https://storage.googleapis.com/storage/v1/b/aptos-indexer-grpc-v2-mainnet-table-info-backup/o?maxResults=1` returns 200 unauthenticated (same for `-v2-testnet-`)