### PR TITLE
docs: align official SDK docs with tested examples

### DIFF
--- a/astro.sidebar.ts
+++ b/astro.sidebar.ts
@@ -209,6 +209,7 @@ export const sidebar = [
             collapsed: true,
             items: [
               "build/sdks/go-sdk",
+              "build/sdks/go-sdk/quickstart",
               "build/sdks/go-sdk/account",
               "build/sdks/go-sdk/fetch-data-via-sdk",
               "build/sdks/go-sdk/go-examples",
@@ -220,6 +221,7 @@ export const sidebar = [
                   "build/sdks/go-sdk/building-transactions/simulating-transactions",
                   "build/sdks/go-sdk/building-transactions/bcs-format",
                   "build/sdks/go-sdk/building-transactions/multi-agent-transactions",
+                  "build/sdks/go-sdk/building-transactions/orderless-transactions",
                   "build/sdks/go-sdk/building-transactions/sponsoring-transactions",
                 ],
               }),
@@ -259,6 +261,7 @@ export const sidebar = [
             collapsed: true,
             items: [
               "build/sdks/python-sdk",
+              "build/sdks/python-sdk/quickstart",
               "build/sdks/python-sdk/account",
               "build/sdks/python-sdk/fetch-data-via-sdk",
               "build/sdks/python-sdk/python-examples",
@@ -270,6 +273,7 @@ export const sidebar = [
                   "build/sdks/python-sdk/building-transactions/simulating-transactions",
                   "build/sdks/python-sdk/building-transactions/bcs-format",
                   "build/sdks/python-sdk/building-transactions/multi-agent-transactions",
+                  "build/sdks/python-sdk/building-transactions/orderless-transactions",
                   "build/sdks/python-sdk/building-transactions/sponsoring-transactions",
                 ],
               }),
@@ -291,6 +295,7 @@ export const sidebar = [
             collapsed: true,
             items: [
               "build/sdks/rust-sdk",
+              "build/sdks/rust-sdk/quickstart",
               "build/sdks/rust-sdk/account",
               "build/sdks/rust-sdk/fetch-data-via-sdk",
               "build/sdks/rust-sdk/rust-examples",
@@ -302,6 +307,7 @@ export const sidebar = [
                   "build/sdks/rust-sdk/building-transactions/simulating-transactions",
                   "build/sdks/rust-sdk/building-transactions/bcs-format",
                   "build/sdks/rust-sdk/building-transactions/multi-agent-transactions",
+                  "build/sdks/rust-sdk/building-transactions/orderless-transactions",
                   "build/sdks/rust-sdk/building-transactions/sponsoring-transactions",
                 ],
               }),

--- a/src/content/docs/build/get-started.mdx
+++ b/src/content/docs/build/get-started.mdx
@@ -22,7 +22,7 @@ import { GraphQLEditor } from '~/components/react/GraphQLEditor';
 ## What developer tools should I use?
 
 <CardGrid>
-  <LinkCard href="/build/sdks" title="SDKs" description="Use our TypeScript, Python, Rust, and other SDKs to submit transactions and read on-chain data." />
+  <LinkCard href="/build/sdks" title="SDKs" description="Use the TypeScript, Python, Go, and Rust SDKs to submit transactions and read on-chain data." />
 
   <LinkCard href="/build/indexer" title="Indexer" description="Query for on-chain data like account balances, historical transactions, NFTs by account, and more." />
 

--- a/src/content/docs/build/guides/first-coin.mdx
+++ b/src/content/docs/build/guides/first-coin.mdx
@@ -398,4 +398,6 @@ Aptos provides several building blocks to support coin transfers:
 - [Aptos CLI](/build/cli)
 - [TypeScript SDK](/build/sdks/ts-sdk)
 - [Python SDK](/build/sdks/python-sdk)
+- [Go SDK](/build/sdks/go-sdk)
+- [Rust SDK](/build/sdks/rust-sdk)
 - [REST API specification](/rest-api)

--- a/src/content/docs/build/guides/first-move-module.mdx
+++ b/src/content/docs/build/guides/first-move-module.mdx
@@ -533,4 +533,6 @@ Here are some **suggested next steps to get a deeper understanding of Move modul
 - [Account basics](/network/blockchain/accounts)
 - [TypeScript SDK](/build/sdks/ts-sdk)
 - [Python SDK](/build/sdks/python-sdk)
+- [Go SDK](/build/sdks/go-sdk)
+- [Rust SDK](/build/sdks/rust-sdk)
 - [REST API specification](/rest-api)

--- a/src/content/docs/build/guides/first-transaction.mdx
+++ b/src/content/docs/build/guides/first-transaction.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Your First Transaction"
-description: "Create and submit your first transaction on Aptos blockchain - transfer coins between accounts with TypeScript and Python examples."
+description: "Create and submit your first transaction on Aptos blockchain - transfer coins between accounts with TypeScript, Python, Go, and Rust examples."
 sidebar:
   label: "Your First Transaction"
 ---
@@ -22,6 +22,13 @@ This tutorial will guide you through creating and submitting your first transact
   This tutorial builds on concepts from the Aptos blockchain. If you're new to blockchain development, don't worry - we'll explain key concepts along the way.
 
   You can jump to the full code sample [here](#full-code-sample) or continue reading for a step-by-step walkthrough.
+
+  Official SDK walkthroughs with the same transfer flow:
+
+  - [TypeScript quickstart](/build/sdks/ts-sdk/quickstart)
+  - [Python quickstart (v2 API)](/build/sdks/python-sdk/quickstart)
+  - [Go quickstart](/build/sdks/go-sdk/quickstart)
+  - [Rust quickstart](/build/sdks/rust-sdk/quickstart)
 </Aside>
 
 ## 1. Setting Up Your Environment
@@ -915,12 +922,15 @@ Congratulations! You've successfully created and executed your first transaction
 
 **Learn about more complex transactions**:
 
-- [Multi-Agent Signatures](/build/sdks/ts-sdk/building-transactions/multi-agent-transactions) - Transactions requiring multiple signers
-- [Sponsoring Transactions](/build/sdks/ts-sdk/building-transactions/sponsoring-transactions) - Having another account pay gas fees
-- [Batching Transactions](/build/sdks/ts-sdk/building-transactions/batching-transactions) - Sending multiple transactions efficiently
+- [TypeScript SDK](/build/sdks/ts-sdk/building-transactions) — [multi-agent](/build/sdks/ts-sdk/building-transactions/multi-agent-transactions), [sponsored](/build/sdks/ts-sdk/building-transactions/sponsoring-transactions), [batching](/build/sdks/ts-sdk/building-transactions/batching-transactions)
+- [Python SDK](/build/sdks/python-sdk/building-transactions) — [multi-agent](/build/sdks/python-sdk/building-transactions/multi-agent-transactions), [sponsored](/build/sdks/python-sdk/building-transactions/sponsoring-transactions), [batching](/build/sdks/python-sdk/building-transactions/batching-transactions)
+- [Go SDK](/build/sdks/go-sdk/building-transactions) — [multi-agent](/build/sdks/go-sdk/building-transactions/multi-agent-transactions), [sponsored](/build/sdks/go-sdk/building-transactions/sponsoring-transactions), [batching](/build/sdks/go-sdk/building-transactions/batching-transactions)
+- [Rust SDK](/build/sdks/rust-sdk/building-transactions) — [multi-agent](/build/sdks/rust-sdk/building-transactions/multi-agent-transactions), [sponsored](/build/sdks/rust-sdk/building-transactions/sponsoring-transactions), [batching](/build/sdks/rust-sdk/building-transactions/batching-transactions)
 
 <Aside type="note">
-  The above links are for the Typescript SDK but the principles are the same if you are using Python or Rust.
+  The step-by-step Python samples on this page use the v1 API. New Python
+  projects should follow the [Python SDK quickstart](/build/sdks/python-sdk/quickstart)
+  (`aptos_sdk.v2`).
 </Aside>
 
 **Explore smart contracts or account basics**:

--- a/src/content/docs/build/guides/orderless-transactions.mdx
+++ b/src/content/docs/build/guides/orderless-transactions.mdx
@@ -35,7 +35,9 @@ with the same nonce.
 
 ## SDK Support
 
-These are demonstrations of sponsored transactions:
+Each official SDK documents orderless transactions and ships a tested example:
 
-- The [TypeScript SDK](/build/sdks/ts-sdk/building-transactions/orderless-transactions) has documentation
-- The [Go SDK](https://github.com/aptos-labs/aptos-go-sdk/tree/main/examples/orderless_transaction) has an example
+- [TypeScript SDK](/build/sdks/ts-sdk/building-transactions/orderless-transactions) — [`simple_orderless_transfer.ts`](https://github.com/aptos-labs/aptos-ts-sdk/blob/main/examples/typescript/simple_orderless_transfer.ts)
+- [Python SDK](/build/sdks/python-sdk/building-transactions/orderless-transactions) — [`orderless_transfer.py`](https://github.com/aptos-labs/aptos-python-sdk/blob/main/v2/examples/orderless_transfer.py)
+- [Go SDK](/build/sdks/go-sdk/building-transactions/orderless-transactions) — [`examples/orderless_transaction`](https://github.com/aptos-labs/aptos-go-sdk/tree/main/examples/orderless_transaction)
+- [Rust SDK](/build/sdks/rust-sdk/building-transactions/orderless-transactions) — [`orderless_transaction.rs`](https://github.com/aptos-labs/aptos-rust-sdk/blob/main/crates/aptos-sdk/examples/orderless_transaction.rs)

--- a/src/content/docs/build/guides/sponsored-transactions.mdx
+++ b/src/content/docs/build/guides/sponsored-transactions.mdx
@@ -108,11 +108,9 @@ address set.
 
 ## SDK Support
 
-These are demonstrations of sponsored transactions:
+Each official SDK documents sponsored transactions and ships a tested example:
 
-- The TypeScript SDK
-  has [several examples](https://github.com/aptos-labs/aptos-ts-sdk/tree/main/examples/typescript-esm/sponsored_transactions)
-- The Python SDK has an example
-  in [fee\_payer\_transfer\_coin.py](https://github.com/aptos-labs/aptos-python-sdk/blob/main/examples/fee_payer_transfer_coin.py).
-- The Rust SDK has a test case
-  in [the API tests](https://github.com/aptos-labs/aptos-core/blob/0a62e54e13bc5da604ceaf39efed5c012a292078/api/src/tests/transactions_test.rs#L255).
+- [TypeScript SDK](/build/sdks/ts-sdk/building-transactions/sponsoring-transactions) — [`simple_sponsored_transaction.ts`](https://github.com/aptos-labs/aptos-ts-sdk/blob/main/examples/typescript/simple_sponsored_transaction.ts)
+- [Python SDK](/build/sdks/python-sdk/building-transactions/sponsoring-transactions) — [`sponsored_transaction.py`](https://github.com/aptos-labs/aptos-python-sdk/blob/main/v2/examples/sponsored_transaction.py)
+- [Go SDK](/build/sdks/go-sdk/building-transactions/sponsoring-transactions) — [`examples/sponsored_transaction`](https://github.com/aptos-labs/aptos-go-sdk/tree/main/examples/sponsored_transaction)
+- [Rust SDK](/build/sdks/rust-sdk/building-transactions/sponsoring-transactions) — [`sponsored_transaction.rs`](https://github.com/aptos-labs/aptos-rust-sdk/blob/main/crates/aptos-sdk/examples/sponsored_transaction.rs)

--- a/src/content/docs/build/sdks/go-sdk.mdx
+++ b/src/content/docs/build/sdks/go-sdk.mdx
@@ -7,22 +7,50 @@ sidebar:
 
 import { CardGrid, LinkCard } from '@astrojs/starlight/components';
 
+import { RemoteCodeblock } from '~/components/RemoteCodeblock';
+
+<div className="flex gap-2 mt-6 flex-wrap">
+  <a target="_blank" href="https://github.com/aptos-labs/aptos-go-sdk">
+    ![Github Repo Stars](https://img.shields.io/github/stars/aptos-labs/aptos-go-sdk)
+  </a>
+
+  <a target="_blank" href="https://pkg.go.dev/github.com/aptos-labs/aptos-go-sdk">
+    ![Go Reference](https://pkg.go.dev/badge/github.com/aptos-labs/aptos-go-sdk.svg)
+  </a>
+</div>
+
+The Go SDK lets you connect, explore, and interact with the Aptos blockchain. You can use it to request data, send transactions, set up test environments, and more.
+
 ## Installing the Go SDK
 
-Aptos provides an official Go SDK in
-the [aptos-go-sdk GitHub](https://github.com/aptos-labs/aptos-go-sdk) repository.
-To use the Go SDK, get the main package here:
+Aptos publishes the official Go SDK in the
+[aptos-go-sdk GitHub](https://github.com/aptos-labs/aptos-go-sdk) repository.
+The SDK requires **Go 1.25+**.
 
-```shellscript
+```shellscript filename="Terminal"
 go get github.com/aptos-labs/aptos-go-sdk
 ```
 
-## Usage
+## Examples
 
 <CardGrid>
-  <LinkCard href="/build/sdks/go-sdk/fetch-data-via-sdk" title="Fetching Data" description="Learn how to fetch data with the Go SDK" />
+  <LinkCard href="/build/sdks/go-sdk/quickstart" title="Quickstart" description="Get a working transfer on devnet in a few minutes" />
 
-  <LinkCard href="/build/sdks/go-sdk/building-transactions" title="Submitting Transactions" description="Learn how to submit transactions with the Go SDK" />
+  <LinkCard href="/build/sdks/go-sdk/account" title="Accounts" description="Generate, restore, and fund accounts" />
 
-  <LinkCard href="/build/sdks/go-sdk/go-examples" title="Examples" description="Explore Go examples provided in the SDK" />
+  <LinkCard href="/build/sdks/go-sdk/fetch-data-via-sdk" title="Fetching Data" description="Read ledger, account, and view-function data" />
+
+  <LinkCard href="/build/sdks/go-sdk/building-transactions" title="Submitting Transactions" description="Build, simulate, sign, and submit transactions" />
+
+  <LinkCard href="/build/sdks/go-sdk/go-examples" title="Examples" description="Catalog of runnable examples in the SDK repository" />
+
+  <LinkCard href="https://github.com/aptos-labs/aptos-go-sdk/tree/main/integration_test" title="Tests" description="Integration tests and package tests that exercise the SDK" target="_blank" />
 </CardGrid>
+
+### Transfer APT from the tested example suite
+
+The snippet below is pulled from
+[`examples/transfer_coin`](https://github.com/aptos-labs/aptos-go-sdk/tree/main/examples/transfer_coin)
+in the SDK repository.
+
+<RemoteCodeblock permalink="https://github.com/aptos-labs/aptos-go-sdk/blob/8b983c5acabd61b0f2c0ab725500cacccdf77301/examples/transfer_coin/main.go#L132-L153" />

--- a/src/content/docs/build/sdks/go-sdk/account.mdx
+++ b/src/content/docs/build/sdks/go-sdk/account.mdx
@@ -12,17 +12,25 @@ use:
 - `aptos.NewSecp256k1Account()`
 - `aptos.NewEd25519SingleSenderAccount()`
 - `aptos.NewAccountFromSigner()`
+- `aptos.NewEd25519AccountFromMnemonic()`
+- `aptos.NewEd25519AccountFromDerivationPath()`
 
-`Account.NewEd25519Account()` is the most commonly used method to create keys
+`NewEd25519Account()` is the most commonly used method to create keys
 for a new account. It defaults to `ED25519` key types, but you can also specify
 which signing scheme you would prefer like so:
 
 ```go
 // To derive an ed25519 account
-account1 := aptos.NewEd25519Account()
+account1, err := aptos.NewEd25519Account()
+if err != nil {
+  panic("Failed to create account:" + err.Error())
+}
 
 // To derive a secp256k1 account
-account2 := aptos.NewSecp256k1Account()
+account2, err := aptos.NewSecp256k1Account()
+if err != nil {
+  panic("Failed to create account:" + err.Error())
+}
 ```
 
 Once you have generated credentials, you **must** fund it for the network to know it exists.
@@ -30,13 +38,16 @@ Once you have generated credentials, you **must** fund it for the network to kno
 In devnet environments this can be done with a faucet by running the following command:
 
 ```go filename="fund.go"
-client, err = aptos.NewClient(aptos.DevnetConfig)
+client, err := aptos.NewClient(aptos.DevnetConfig)
 if err != nil {
   panic("Failed to create client:" + err.Error())
 }
 
 // Fund an account with 1 Devnet APT
-client.Fund(account1.Address, 100_000_000)
+err = client.Fund(account1.Address, 100_000_000)
+if err != nil {
+  panic("Failed to fund account:" + err.Error())
+}
 ```
 
 On testnet you can mint at the [mint page](/network/faucet).
@@ -61,7 +72,10 @@ err := privateKey.FromHex(privateKeyHex)
 if err != nil {
   panic("Failed to parse private key:" + err.Error())
 }
-account := aptos.NewAccountFromSigner(privateKey)
+account, err := aptos.NewAccountFromSigner(privateKey)
+if err != nil {
+  panic("Failed to derive account:" + err.Error())
+}
 
 // to derive an account with a Single Sender Ed25519 key scheme
 privateKey := &aptos.Ed25519PrivateKey{}
@@ -70,7 +84,10 @@ if err != nil {
   panic("Failed to parse private key:" + err.Error())
 }
 singleSigner := &crypto.SingleSigner{Signer: privateKey}
-account := aptos.NewAccountFromSigner(singleSigner)
+account, err = aptos.NewAccountFromSigner(singleSigner)
+if err != nil {
+  panic("Failed to derive account:" + err.Error())
+}
 
 // to derive an account with a Single Sender Secp256k1 key scheme
 privateKey := &aptos.Secp256k1PrivateKey{}
@@ -79,20 +96,38 @@ if err != nil {
   panic("Failed to parse private key:" + err.Error())
 }
 singleSigner := &crypto.SingleSigner{Signer: privateKey}
-account := aptos.NewAccountFromSigner(singleSigner)
+account, err = aptos.NewAccountFromSigner(singleSigner)
+if err != nil {
+  panic("Failed to derive account:" + err.Error())
+}
 
 // to derive an account with a private key and account address
-address := &aptos.AccountAddress{}
-err := address.ParseStringRelaxed(addressHex)
+var address aptos.AccountAddress
+err = address.ParseStringRelaxed(addressHex)
 if err != nil {
   panic("Failed to parse address:" + err.Error())
 }
 privateKey := &aptos.Ed25519PrivateKey{}
-err := privateKey.FromHex(privateKeyHex)
+err = privateKey.FromHex(privateKeyHex)
 if err != nil {
   panic("Failed to parse private key:" + err.Error())
 }
-account := aptos.NewAccountFromSigner(privateKey, address.AuthKey())
+account, err = aptos.NewAccountFromSigner(privateKey, address)
+if err != nil {
+  panic("Failed to derive account:" + err.Error())
+}
 ```
 
-{/* TODO: Once derivation path is supported ### Derive an account from derivation path */}
+### Derive an account from a mnemonic
+
+```go
+account, err := aptos.NewEd25519AccountFromMnemonic(mnemonic)
+if err != nil {
+  panic("Failed to derive account:" + err.Error())
+}
+
+account, err = aptos.NewEd25519AccountFromDerivationPath(mnemonic, "m/44'/637'/0'/0'/0'")
+if err != nil {
+  panic("Failed to derive account:" + err.Error())
+}
+```

--- a/src/content/docs/build/sdks/go-sdk/building-transactions.mdx
+++ b/src/content/docs/build/sdks/go-sdk/building-transactions.mdx
@@ -327,6 +327,7 @@ Building and sending transactions on-chain involves the following 5 steps:
 Transactions have a couple of additional features which let them adapt to your needs which you can learn about here:
 
 1. [Multi-Agent Signatures](/build/sdks/go-sdk/building-transactions/multi-agent-transactions) - Allowing multiple accounts to be used for a single contract.
-2. [Sponsoring Transactions](/build/sdks/go-sdk/building-transactions/sponsoring-transactions) - Have another account pay gas fees for this transaction.
-3. [Batch Submit Transactions](/build/sdks/go-sdk/building-transactions/batching-transactions) - How to send multiple transactions quickly from a single account.
-4. [Binary Canonical Serialization (BCS)](/build/sdks/go-sdk/building-transactions/bcs-format) - The format used to serialize data for Aptos transactions.
+2. [Orderless Transactions](/build/sdks/go-sdk/building-transactions/orderless-transactions) - Allowing for transactions to be executed out of order for easier management.
+3. [Sponsoring Transactions](/build/sdks/go-sdk/building-transactions/sponsoring-transactions) - Have another account pay gas fees for this transaction.
+4. [Batch Submit Transactions](/build/sdks/go-sdk/building-transactions/batching-transactions) - How to send multiple transactions quickly from a single account.
+5. [Binary Canonical Serialization (BCS)](/build/sdks/go-sdk/building-transactions/bcs-format) - The format used to serialize data for Aptos transactions.

--- a/src/content/docs/build/sdks/go-sdk/building-transactions/batching-transactions.mdx
+++ b/src/content/docs/build/sdks/go-sdk/building-transactions/batching-transactions.mdx
@@ -145,3 +145,8 @@ func main() {
 	example(aptos.DevnetConfig, 100)
 }
 ```
+
+## Tested example
+
+See [`examples/sending_concurrent_transactions`](https://github.com/aptos-labs/aptos-go-sdk/tree/main/examples/sending_concurrent_transactions)
+in the SDK repository.

--- a/src/content/docs/build/sdks/go-sdk/building-transactions/multi-agent-transactions.mdx
+++ b/src/content/docs/build/sdks/go-sdk/building-transactions/multi-agent-transactions.mdx
@@ -89,6 +89,11 @@ notable differences.
 
 {/* TODO: Add full code snippet for Go */}
 
+## Tested example
+
+See [`examples/multi_agent`](https://github.com/aptos-labs/aptos-go-sdk/tree/main/examples/multi_agent)
+in the SDK repository. Run it with `go run examples/multi_agent/main.go`.
+
 ## Common Errors
 
 `NUMBER_OF_SIGNER_ARGUMENTS_MISMATCH` - This happens when you are attempting to

--- a/src/content/docs/build/sdks/go-sdk/building-transactions/orderless-transactions.mdx
+++ b/src/content/docs/build/sdks/go-sdk/building-transactions/orderless-transactions.mdx
@@ -1,0 +1,91 @@
+---
+title: "Go SDK - Orderless Transactions"
+description: "Create transactions that can be executed in any order using replay-protection nonces with the Go SDK"
+sidebar:
+  label: "Orderless Transactions"
+---
+
+import { Aside } from '@astrojs/starlight/components';
+
+Orderless transactions allow you to create transactions that do not specify an
+order of execution between them. This is useful when multiple machines need to
+sign or submit for the same sending account, but the order does not affect the
+outcome.
+
+See [Orderless Transactions](/build/guides/orderless-transactions) for the
+protocol overview ([AIP-123](https://github.com/aptos-foundation/AIPs/blob/main/aips/aip-123.md)
+and [AIP-129](https://github.com/aptos-foundation/AIPs/blob/main/aips/aip-129.md)).
+
+## Building Orderless Transactions
+
+Wrap the entry function in a `TransactionInnerPayload` and set
+`ReplayProtectionNonce` on `TransactionExtraConfigV1`. Cap expiration at 60
+seconds with `aptos.ExpirationSeconds(60)`.
+
+<Aside type="note">
+  The nonce must be unique for each transaction. Orderless transactions expire
+  at most 60 seconds after submission. If the transaction is not executed in
+  that window, it expires and will not execute.
+</Aside>
+
+```go filename="orderless.go"
+replayNonce := uint64(100)
+accountBytes, err := bcs.Serialize(&bob.Address)
+if err != nil {
+    panic("Failed to serialize bob's address:" + err.Error())
+}
+amountBytes, err := bcs.SerializeU64(TransferAmount)
+if err != nil {
+    panic("Failed to serialize transfer amount:" + err.Error())
+}
+
+rawTxn, err := client.BuildTransaction(
+    alice.AccountAddress(),
+    aptos.TransactionPayload{
+        Payload: &aptos.TransactionInnerPayload{
+            Payload: &aptos.TransactionInnerPayloadV1{
+                Executable: aptos.TransactionExecutable{
+                    Inner: &aptos.EntryFunction{
+                        Module: aptos.ModuleId{
+                            Address: aptos.AccountOne,
+                            Name:    "aptos_account",
+                        },
+                        Function: "transfer",
+                        ArgTypes: []aptos.TypeTag{},
+                        Args:     [][]byte{accountBytes, amountBytes},
+                    },
+                },
+                ExtraConfig: aptos.TransactionExtraConfig{
+                    Inner: &aptos.TransactionExtraConfigV1{
+                        MultisigAddress:       nil,
+                        ReplayProtectionNonce: &replayNonce,
+                    },
+                },
+            },
+        },
+    },
+    aptos.ExpirationSeconds(60),
+)
+```
+
+After that, follow the same steps as a simple transaction:
+
+1. [**Simulate** the transaction (optional)](/build/sdks/go-sdk/building-transactions/simulating-transactions).
+2. **Sign** the transaction.
+3. **Submit** the transaction to the network.
+4. **Wait** for the transaction to be executed.
+
+`BuildSignAndSubmitTransaction` accepts the same inner payload if you want to
+skip the manual sign and submit steps.
+
+## Tested example
+
+The SDK repository includes a runnable example that follows this API:
+
+- [`examples/orderless_transaction`](https://github.com/aptos-labs/aptos-go-sdk/tree/main/examples/orderless_transaction)
+
+Run it with:
+
+```shellscript filename="Terminal"
+go run examples/orderless_transaction/main.go
+```

--- a/src/content/docs/build/sdks/go-sdk/building-transactions/simulating-transactions.mdx
+++ b/src/content/docs/build/sdks/go-sdk/building-transactions/simulating-transactions.mdx
@@ -123,3 +123,8 @@ You can also learn how to simulate more advanced transactions by looking at the 
 
 - [Sponsored Transactions](/build/sdks/go-sdk/building-transactions/sponsoring-transactions)
 - [Multi-Agent Transactions](/build/sdks/go-sdk/building-transactions/multi-agent-transactions)
+
+## Tested example
+
+See [`examples/transfer_coin`](https://github.com/aptos-labs/aptos-go-sdk/tree/main/examples/transfer_coin)
+in the SDK repository, which includes a simulation step.

--- a/src/content/docs/build/sdks/go-sdk/building-transactions/sponsoring-transactions.mdx
+++ b/src/content/docs/build/sdks/go-sdk/building-transactions/sponsoring-transactions.mdx
@@ -306,3 +306,8 @@ func main() {
 	example(aptos.DevnetConfig)
 }
 ```
+
+## Tested example
+
+See [`examples/sponsored_transaction`](https://github.com/aptos-labs/aptos-go-sdk/tree/main/examples/sponsored_transaction)
+in the SDK repository.

--- a/src/content/docs/build/sdks/go-sdk/fetch-data-via-sdk.mdx
+++ b/src/content/docs/build/sdks/go-sdk/fetch-data-via-sdk.mdx
@@ -20,14 +20,24 @@ if err != nil {
 }
 
 address := aptos.AccountAddress{}
-err := address.ParseStringRelaxed("0x123")
+err = address.ParseStringRelaxed("0x123")
 if err != nil {
   panic("Failed to parse address:" + err.Error())
 }
 
 accountInfo, err := client.Account(address)
+if err != nil {
+  panic("Failed to get account:" + err.Error())
+}
 resources, err := client.AccountResources(address)
+if err != nil {
+  panic("Failed to get resources:" + err.Error())
+}
 transactions, err := client.Transactions()
+if err != nil {
+  panic("Failed to get transactions:" + err.Error())
+}
+fmt.Println(accountInfo, resources, len(transactions))
 ```
 
 <Aside type="note">
@@ -54,10 +64,9 @@ query for Indexer API data, you can use `client.QueryIndexer()` like so:
 	variables := map[string]any{
 		"address": address.StringLong(),
 	}
-	err := ic.Query(&q, variables)
-
+	err = client.QueryIndexer(&q, variables)
 	if err != nil {
-		return nil, err
+		panic("Failed to query indexer:" + err.Error())
 	}
 
 	for _, coin := range q.Current_coin_balances {
@@ -80,12 +89,15 @@ You can call view functions which return custom data from on-chain by using `cli
 For example, you can look up the network you are using with the `chain_id` view function:
 
 ```go filename="fetch_data.go"
-viewResponse, err := client.View(&aptos.ViewPayload {
-  Module: aptos.ModuleId{Address: aptos.AccountAddress{}, Name: "chain_id"},
+viewResponse, err := client.View(&aptos.ViewPayload{
+  Module:   aptos.ModuleId{Address: aptos.AccountOne, Name: "chain_id"},
   Function: "get",
   ArgTypes: []aptos.TypeTag{},
-  Args: [][]byte{},
-)
+  Args:     [][]byte{},
+})
+if err != nil {
+  panic("Failed to call view:" + err.Error())
+}
 
 chainId := viewResponse[0]
 ```

--- a/src/content/docs/build/sdks/go-sdk/go-examples.mdx
+++ b/src/content/docs/build/sdks/go-sdk/go-examples.mdx
@@ -5,10 +5,11 @@ sidebar:
   label: "Examples"
 ---
 
-import { Steps } from '@astrojs/starlight/components';
+import { Aside, Steps } from '@astrojs/starlight/components';
 
 For sample code which explains the core concepts of how to use the SDK, see:
 
+- [Quickstart](/build/sdks/go-sdk/quickstart)
 - [Fetching Data](/build/sdks/go-sdk/fetch-data-via-sdk)
 - [Building, Simulating, and Submitting Transactions](/build/sdks/go-sdk/building-transactions)
 
@@ -17,39 +18,54 @@ Below are additional resources which may be more suited for your individual use 
 ## Code Snippets
 
 The [`examples` folder](https://github.com/aptos-labs/aptos-go-sdk/tree/main/examples)
-in the SDK repo has many code snippets you can customize to your needs.
+in the SDK repository has many code snippets you can customize. These examples
+are part of the SDK's CI surface.
+
+| Example                           | Description                                       |
+| --------------------------------- | ------------------------------------------------- |
+| `transfer_coin`                   | Basic APT transfer between two accounts           |
+| `orderless_transaction`           | Orderless transfer with a replay-protection nonce |
+| `sponsored_transaction`           | Fee-payer sponsored transaction                   |
+| `multi_agent`                     | Multi-agent transaction with two signers          |
+| `sending_concurrent_transactions` | Concurrent submissions from one account           |
+| `fungible_asset`                  | Fungible asset transfer                           |
+| `onchain_multisig`                | On-chain multisig account flow                    |
+| `offchain_multisig`               | Off-chain multisig signing                        |
+| `script_transaction`              | Script payload construction                       |
+| `alternative_signing`             | Custom / alternative signer                       |
+| `external_signing`                | Sign with an external signer                      |
+
+<Aside type="note">
+  Prefer these repository examples over copying snippets from older blog posts.
+  The Go SDK tracks the current on-chain transaction payload formats, including
+  orderless inner payloads.
+</Aside>
 
 ### How to run examples
 
 To run one of the example scripts:
 
 <Steps>
-  1. Clone the
+  1. Clone the repository.
 
      ```shellscript filename="Terminal"
      git clone https://github.com/aptos-labs/aptos-go-sdk.git
+     cd aptos-go-sdk
      ```
 
-  2. From the top-level of the package, install all dependencies.
-
-     ```shellscript filename="Terminal"
-     go install
-     ```
-
-  3. Build the package.
-
-     ```shellscript filename="Terminal"
-     go build ./...
-     ```
-
-  4. Run an example
+  2. Run an example from the repository root. Go downloads module dependencies
+     automatically.
 
      ```shellscript filename="Terminal"
      go run examples/transfer_coin/main.go
      ```
 </Steps>
 
+The SDK requires **Go 1.25+**.
+
 ## Helpful Reference Code
 
+- [Integration tests](https://github.com/aptos-labs/aptos-go-sdk/tree/main/integration_test) - Broader flows that use the SDK against a live network.
+- [Package tests](https://github.com/aptos-labs/aptos-go-sdk) - `*_test.go` files next to the implementation.
 - [SDK source code](https://github.com/aptos-labs/aptos-go-sdk/tree/main) - This has in-line comments explaining what each function does.
 - [SDK reference docs](https://pkg.go.dev/github.com/aptos-labs/aptos-go-sdk) - These are another way to view the in-line documentation with built-in search.

--- a/src/content/docs/build/sdks/go-sdk/quickstart.mdx
+++ b/src/content/docs/build/sdks/go-sdk/quickstart.mdx
@@ -1,0 +1,211 @@
+---
+title: "Go SDK Quickstart"
+description: "Get started with the Aptos Go SDK by creating accounts, funding them, and transferring APT"
+sidebar:
+  label: "Go SDK Quickstart"
+---
+
+import { Aside, Steps } from '@astrojs/starlight/components';
+
+<Aside type="note">
+  The complete example is at [Full Quickstart Code](#full-quickstart-code) at
+  the bottom of this page. It follows the same flow as
+  [`examples/transfer_coin`](https://github.com/aptos-labs/aptos-go-sdk/tree/main/examples/transfer_coin)
+  in the SDK repository.
+</Aside>
+
+<Steps>
+  1. Install the Go SDK
+
+     The SDK requires **Go 1.25+**.
+
+     ```shellscript filename="Terminal"
+     mkdir aptos-go-quickstart
+     cd aptos-go-quickstart
+     go mod init example/aptos-go-quickstart
+     go get github.com/aptos-labs/aptos-go-sdk
+     ```
+
+  2. Set up the Aptos client
+
+     ```go filename="quickstart.go"
+     client, err := aptos.NewClient(aptos.DevnetConfig)
+     if err != nil {
+         panic("Failed to create client:" + err.Error())
+     }
+     ```
+
+     <Aside type="note">
+       (Advanced) To connect to a specific node, construct an `aptos.NetworkConfig`
+       with a custom `NodeUrl`.
+     </Aside>
+
+  3. Create and fund accounts
+
+     `NewEd25519Account` returns both the account and an error.
+
+     ```go filename="quickstart.go"
+     alice, err := aptos.NewEd25519Account()
+     if err != nil {
+         panic("Failed to create alice:" + err.Error())
+     }
+     bob, err := aptos.NewEd25519Account()
+     if err != nil {
+         panic("Failed to create bob:" + err.Error())
+     }
+
+     err = client.Fund(alice.Address, 1_000_000_000)
+     if err != nil {
+         panic("Failed to fund alice:" + err.Error())
+     }
+     ```
+
+     On testnet, mint from the [faucet page](/network/faucet).
+
+  4. Transfer APT
+
+     Build an `aptos_account::transfer` payload, then sign, submit, and wait.
+     `BuildSignAndSubmitTransaction` combines those steps.
+
+     ```go filename="quickstart.go"
+     accountBytes, err := bcs.Serialize(&bob.Address)
+     amountBytes, err := bcs.SerializeU64(1_000)
+     resp, err := client.BuildSignAndSubmitTransaction(alice, aptos.TransactionPayload{
+         Payload: &aptos.EntryFunction{
+             Module: aptos.ModuleId{
+                 Address: aptos.AccountOne,
+                 Name:    "aptos_account",
+             },
+             Function: "transfer",
+             ArgTypes: []aptos.TypeTag{},
+             Args:     [][]byte{accountBytes, amountBytes},
+         },
+     })
+     _, err = client.WaitForTransaction(resp.Hash)
+     ```
+
+     For the lower-level build → simulate → sign → submit → wait flow, see
+     [Building Transactions](/build/sdks/go-sdk/building-transactions).
+</Steps>
+
+## Full Quickstart Code
+
+```go filename="quickstart.go"
+package main
+
+import (
+	"fmt"
+
+	"github.com/aptos-labs/aptos-go-sdk"
+	"github.com/aptos-labs/aptos-go-sdk/bcs"
+)
+
+const (
+	FundAmount     = 1_000_000_000
+	TransferAmount = 1_000
+)
+
+func main() {
+	client, err := aptos.NewClient(aptos.DevnetConfig)
+	if err != nil {
+		panic("Failed to create client:" + err.Error())
+	}
+
+	alice, err := aptos.NewEd25519Account()
+	if err != nil {
+		panic("Failed to create alice:" + err.Error())
+	}
+	bob, err := aptos.NewEd25519Account()
+	if err != nil {
+		panic("Failed to create bob:" + err.Error())
+	}
+
+	fmt.Printf("=== Addresses ===\n")
+	fmt.Printf("Alice: %s\n", alice.Address.String())
+	fmt.Printf("Bob:   %s\n", bob.Address.String())
+
+	err = client.Fund(alice.Address, FundAmount)
+	if err != nil {
+		panic("Failed to fund alice:" + err.Error())
+	}
+
+	aliceBalance, err := client.AccountAPTBalance(alice.Address)
+	if err != nil {
+		panic("Failed to retrieve alice balance:" + err.Error())
+	}
+	bobBalance, err := client.AccountAPTBalance(bob.Address)
+	if err != nil {
+		panic("Failed to retrieve bob balance:" + err.Error())
+	}
+	fmt.Printf("=== Initial Balances ===\n")
+	fmt.Printf("Alice: %d\n", aliceBalance)
+	fmt.Printf("Bob:   %d\n", bobBalance)
+
+	accountBytes, err := bcs.Serialize(&bob.Address)
+	if err != nil {
+		panic("Failed to serialize bob's address:" + err.Error())
+	}
+	amountBytes, err := bcs.SerializeU64(TransferAmount)
+	if err != nil {
+		panic("Failed to serialize transfer amount:" + err.Error())
+	}
+
+	resp, err := client.BuildSignAndSubmitTransaction(alice, aptos.TransactionPayload{
+		Payload: &aptos.EntryFunction{
+			Module: aptos.ModuleId{
+				Address: aptos.AccountOne,
+				Name:    "aptos_account",
+			},
+			Function: "transfer",
+			ArgTypes: []aptos.TypeTag{},
+			Args: [][]byte{
+				accountBytes,
+				amountBytes,
+			},
+		},
+	})
+	if err != nil {
+		panic("Failed to submit transaction:" + err.Error())
+	}
+
+	_, err = client.WaitForTransaction(resp.Hash)
+	if err != nil {
+		panic("Failed to wait for transaction:" + err.Error())
+	}
+
+	aliceBalance, err = client.AccountAPTBalance(alice.Address)
+	if err != nil {
+		panic("Failed to retrieve alice balance:" + err.Error())
+	}
+	bobBalance, err = client.AccountAPTBalance(bob.Address)
+	if err != nil {
+		panic("Failed to retrieve bob balance:" + err.Error())
+	}
+	fmt.Printf("=== Final Balances ===\n")
+	fmt.Printf("Alice: %d\n", aliceBalance)
+	fmt.Printf("Bob:   %d\n", bobBalance)
+	fmt.Printf("See txn: https://explorer.aptoslabs.com/txn/%s?network=devnet\n", resp.Hash)
+}
+```
+
+Run it with:
+
+```shellscript filename="Terminal"
+go run quickstart.go
+```
+
+## Summary
+
+You just learned how to transfer APT by:
+
+1. Connecting to the network with `aptos.NewClient`.
+2. Creating and funding accounts.
+3. Submitting a transfer and waiting for execution.
+
+<Aside type="note">
+  Bookmark the [examples](https://github.com/aptos-labs/aptos-go-sdk/tree/main/examples)
+  and [integration tests](https://github.com/aptos-labs/aptos-go-sdk/tree/main/integration_test)
+  in the SDK repository. Those suites are the source of truth for APIs shown in
+  these docs. Generated API docs live on
+  [pkg.go.dev](https://pkg.go.dev/github.com/aptos-labs/aptos-go-sdk).
+</Aside>

--- a/src/content/docs/build/sdks/python-sdk.mdx
+++ b/src/content/docs/build/sdks/python-sdk.mdx
@@ -7,9 +7,27 @@ sidebar:
 
 import { Aside, CardGrid, LinkCard } from '@astrojs/starlight/components';
 
+import { RemoteCodeblock } from '~/components/RemoteCodeblock';
+
+<div className="flex gap-2 mt-6 flex-wrap">
+  <a target="_blank" href="https://github.com/aptos-labs/aptos-python-sdk">
+    ![Github Repo Stars](https://img.shields.io/github/stars/aptos-labs/aptos-python-sdk)
+  </a>
+
+  <a target="_blank" href="https://pypi.org/project/aptos-sdk/">
+    ![PyPI Version](https://img.shields.io/pypi/v/aptos-sdk)
+  </a>
+
+  <a target="_blank" href="https://pypi.org/project/aptos-sdk/">
+    ![Python Version](https://img.shields.io/pypi/pyversions/aptos-sdk)
+  </a>
+</div>
+
+The Python SDK lets you connect, explore, and interact with the Aptos blockchain. You can use it to request data, send transactions, set up test environments, and more.
+
 ## Installing the Python SDK
 
-Aptos provides an official Python SDK on
+Aptos publishes the official Python SDK on
 [PyPI](https://pypi.org/project/aptos-sdk/) with source code in the
 [aptos-python-sdk GitHub repository](https://github.com/aptos-labs/aptos-python-sdk).
 The SDK requires **Python 3.12+**.
@@ -36,12 +54,27 @@ pip install .
   in the SDK repository.
 </Aside>
 
-## Usage
+## Examples
 
 <CardGrid>
-  <LinkCard href="/build/sdks/python-sdk/fetch-data-via-sdk" title="Fetching Data" description="Learn how to fetch data with the Python SDK" />
+  <LinkCard href="/build/sdks/python-sdk/quickstart" title="Quickstart" description="Get a working transfer on devnet in a few minutes" />
 
-  <LinkCard href="/build/sdks/python-sdk/building-transactions" title="Submitting Transactions" description="Learn how to submit transactions with the Python SDK" />
+  <LinkCard href="/build/sdks/python-sdk/account" title="Accounts" description="Generate, restore, and fund accounts" />
 
-  <LinkCard href="/build/sdks/python-sdk/python-examples" title="Examples" description="Explore Python examples provided in the SDK" />
+  <LinkCard href="/build/sdks/python-sdk/fetch-data-via-sdk" title="Fetching Data" description="Read ledger, account, and view-function data" />
+
+  <LinkCard href="/build/sdks/python-sdk/building-transactions" title="Submitting Transactions" description="Build, simulate, sign, and submit transactions" />
+
+  <LinkCard href="/build/sdks/python-sdk/python-examples" title="Examples" description="Catalog of runnable examples in the SDK repository" />
+
+  <LinkCard href="https://github.com/aptos-labs/aptos-python-sdk/tree/main/v2/tests" title="Tests" description="Unit and integration tests that exercise the v2 API" target="_blank" />
 </CardGrid>
+
+### Transfer APT from the tested example suite
+
+The snippet below is pulled from
+[`v2/examples/transfer_apt.py`](https://github.com/aptos-labs/aptos-python-sdk/blob/main/v2/examples/transfer_apt.py)
+in the SDK repository. When you install from PyPI, import the same APIs from
+`aptos_sdk.v2` instead of `aptos_sdk_v2`.
+
+<RemoteCodeblock permalink="https://github.com/aptos-labs/aptos-python-sdk/blob/8480dca2804fb042ef8392f2ad5950a771ca9b8f/v2/examples/transfer_apt.py#L31-L36" />

--- a/src/content/docs/build/sdks/python-sdk/building-transactions.mdx
+++ b/src/content/docs/build/sdks/python-sdk/building-transactions.mdx
@@ -209,6 +209,7 @@ Building and sending transactions on-chain involves the following 5 steps:
 Transactions have a couple of additional features which let them adapt to your needs which you can learn about here:
 
 1. [Multi-Agent Signatures](/build/sdks/python-sdk/building-transactions/multi-agent-transactions) - Allowing multiple accounts to be used for a single contract.
-2. [Sponsoring Transactions](/build/sdks/python-sdk/building-transactions/sponsoring-transactions) - Have another account pay gas fees for this transaction.
-3. [Batch Submit Transactions](/build/sdks/python-sdk/building-transactions/batching-transactions) - How to send multiple transactions quickly from a single account.
-4. [Binary Canonical Serialization (BCS)](/build/sdks/python-sdk/building-transactions/bcs-format) - The format used to serialize data for Aptos transactions.
+2. [Orderless Transactions](/build/sdks/python-sdk/building-transactions/orderless-transactions) - Allowing for transactions to be executed out of order for easier management.
+3. [Sponsoring Transactions](/build/sdks/python-sdk/building-transactions/sponsoring-transactions) - Have another account pay gas fees for this transaction.
+4. [Batch Submit Transactions](/build/sdks/python-sdk/building-transactions/batching-transactions) - How to send multiple transactions quickly from a single account.
+5. [Binary Canonical Serialization (BCS)](/build/sdks/python-sdk/building-transactions/bcs-format) - The format used to serialize data for Aptos transactions.

--- a/src/content/docs/build/sdks/python-sdk/building-transactions/batching-transactions.mdx
+++ b/src/content/docs/build/sdks/python-sdk/building-transactions/batching-transactions.mdx
@@ -6,7 +6,7 @@ sidebar:
 ---
 
 The Python SDK can submit many transactions concurrently from the same account
-by using [orderless transactions](/build/guides/orderless-transactions). Each
+by using [orderless transactions](/build/sdks/python-sdk/building-transactions/orderless-transactions). Each
 transaction carries a unique replay-protection nonce instead of a sequence
 number, so you do not need to coordinate sequence numbers locally.
 
@@ -77,3 +77,8 @@ asyncio.run(main())
 
 The v1 API also includes `TransactionWorker` for sequence-number batching. New
 projects should use the v2 orderless flow above.
+
+## Tested example
+
+See [`batch_orderless_transfers.py`](https://github.com/aptos-labs/aptos-python-sdk/blob/main/v2/examples/batch_orderless_transfers.py)
+in the SDK repository.

--- a/src/content/docs/build/sdks/python-sdk/building-transactions/multi-agent-transactions.mdx
+++ b/src/content/docs/build/sdks/python-sdk/building-transactions/multi-agent-transactions.mdx
@@ -138,3 +138,8 @@ do multi-agent signing for a function which does not require that number of
 accounts. For example, if you try using multiple signatures for a
 `0x1::aptos_account::transfer` function - it only expects one address, and so
 produces an error when more than one is provided.
+
+## Tested example
+
+See [`multi_agent_transfer.py`](https://github.com/aptos-labs/aptos-python-sdk/blob/main/v2/examples/multi_agent_transfer.py)
+in the SDK repository.

--- a/src/content/docs/build/sdks/python-sdk/building-transactions/orderless-transactions.mdx
+++ b/src/content/docs/build/sdks/python-sdk/building-transactions/orderless-transactions.mdx
@@ -1,0 +1,76 @@
+---
+title: "Python SDK - Orderless Transactions"
+description: "Create transactions that can be executed in any order using replay-protection nonces with the Python SDK"
+sidebar:
+  label: "Orderless Transactions"
+---
+
+import { Aside } from '@astrojs/starlight/components';
+
+Orderless transactions allow you to create transactions that do not specify an
+order of execution between them. This is useful when multiple machines need to
+sign or submit for the same sending account, but the order does not affect the
+outcome.
+
+See [Orderless Transactions](/build/guides/orderless-transactions) for the
+protocol overview ([AIP-123](https://github.com/aptos-foundation/AIPs/blob/main/aips/aip-123.md)
+and [AIP-129](https://github.com/aptos-foundation/AIPs/blob/main/aips/aip-129.md)).
+
+## Building Orderless Transactions
+
+Creating and executing an orderless transaction follows the same flow as the
+[simple transaction flow](/build/sdks/python-sdk/building-transactions). Pass
+`replay_protection_nonce` to `aptos.transaction.build` instead of relying on a
+sequence number.
+
+<Aside type="note">
+  The nonce must be unique for each transaction. Orderless transactions expire
+  at most 60 seconds after submission. If the transaction is not executed in
+  that window, it expires and will not execute.
+</Aside>
+
+```python filename="orderless.py"
+import random
+import time
+
+from aptos_sdk.v2.bcs import Serializer
+from aptos_sdk.v2.transactions import EntryFunction, TransactionArgument, TransactionPayload
+from aptos_sdk.v2.types import StructTag, TypeTag
+
+payload = EntryFunction.natural(
+    "0x1::coin",
+    "transfer",
+    [TypeTag(StructTag.from_str("0x1::aptos_coin::AptosCoin"))],
+    [
+        TransactionArgument(bob.address, Serializer.struct),
+        TransactionArgument(1_000, Serializer.u64),
+    ],
+)
+raw_txn = await aptos.transaction.build(
+    sender=alice.address,
+    payload=TransactionPayload(payload),
+    replay_protection_nonce=random.randint(0, 2**64 - 1),
+    expiration_timestamps_secs=int(time.time()) + 60,
+)
+result = await aptos.transaction.sign_submit_and_wait(raw_txn, alice)
+```
+
+After that, follow the same steps as a simple transaction:
+
+1. [**Simulate** the transaction (optional)](/build/sdks/python-sdk/building-transactions/simulating-transactions).
+2. **Sign** the transaction.
+3. **Submit** the transaction to the network.
+4. **Wait** for the transaction to be executed.
+
+To send many orderless transfers in parallel, see
+[Batching Transactions](/build/sdks/python-sdk/building-transactions/batching-transactions).
+
+## Tested example
+
+The SDK repository includes runnable examples that follow this API:
+
+- [`orderless_transfer.py`](https://github.com/aptos-labs/aptos-python-sdk/blob/main/v2/examples/orderless_transfer.py)
+- [`batch_orderless_transfers.py`](https://github.com/aptos-labs/aptos-python-sdk/blob/main/v2/examples/batch_orderless_transfers.py)
+
+When you clone the repository, those files import `aptos_sdk_v2`. After
+`pip install aptos-sdk`, import the same APIs from `aptos_sdk.v2`.

--- a/src/content/docs/build/sdks/python-sdk/building-transactions/simulating-transactions.mdx
+++ b/src/content/docs/build/sdks/python-sdk/building-transactions/simulating-transactions.mdx
@@ -58,3 +58,8 @@ You can also learn how to simulate more advanced transactions by looking at the 
 
 - [Sponsored Transactions](/build/sdks/python-sdk/building-transactions/sponsoring-transactions)
 - [Multi-Agent Transactions](/build/sdks/python-sdk/building-transactions/multi-agent-transactions)
+
+## Tested example
+
+See [`simulate_transaction.py`](https://github.com/aptos-labs/aptos-python-sdk/blob/main/v2/examples/simulate_transaction.py)
+in the SDK repository.

--- a/src/content/docs/build/sdks/python-sdk/building-transactions/sponsoring-transactions.mdx
+++ b/src/content/docs/build/sdks/python-sdk/building-transactions/sponsoring-transactions.mdx
@@ -121,3 +121,8 @@ async def main():
 
 asyncio.run(main())
 ```
+
+## Tested example
+
+See [`sponsored_transaction.py`](https://github.com/aptos-labs/aptos-python-sdk/blob/main/v2/examples/sponsored_transaction.py)
+in the SDK repository.

--- a/src/content/docs/build/sdks/python-sdk/fetch-data-via-sdk.mdx
+++ b/src/content/docs/build/sdks/python-sdk/fetch-data-via-sdk.mdx
@@ -76,3 +76,8 @@ GraphQL indexer queries are available on the v1 `IndexerClient` in the same
 package. The v2 client talks to the fullnode REST API. If you need aggregated
 indexer data, use `aptos_sdk.async_client.IndexerClient` or query the
 [Indexer API](/build/indexer) directly.
+
+## Tested example
+
+See [`fetch_on_chain_data.py`](https://github.com/aptos-labs/aptos-python-sdk/blob/main/v2/examples/fetch_on_chain_data.py)
+in the SDK repository.

--- a/src/content/docs/build/sdks/python-sdk/python-examples.mdx
+++ b/src/content/docs/build/sdks/python-sdk/python-examples.mdx
@@ -5,7 +5,7 @@ sidebar:
   label: "Examples"
 ---
 
-import { Steps } from '@astrojs/starlight/components';
+import { Aside, Steps } from '@astrojs/starlight/components';
 
 For sample code which explains the core concepts of how to use the SDK, see:
 
@@ -38,6 +38,13 @@ of `aptos_sdk_v2`.
 
 v1 examples such as `transfer_coin.py` and `fee_payer_transfer_coin.py` live in
 the top-level [`examples` folder](https://github.com/aptos-labs/aptos-python-sdk/tree/main/examples).
+New projects should use the v2 examples.
+
+<Aside type="note">
+  Prefer these repository examples over copying snippets from older blog posts.
+  The Python SDK v2 API is the supported surface; the examples folder tracks the
+  current API.
+</Aside>
 
 ### How to run examples
 

--- a/src/content/docs/build/sdks/python-sdk/python-examples.mdx
+++ b/src/content/docs/build/sdks/python-sdk/python-examples.mdx
@@ -9,6 +9,7 @@ import { Steps } from '@astrojs/starlight/components';
 
 For sample code which explains the core concepts of how to use the SDK, see:
 
+- [Quickstart](/build/sdks/python-sdk/quickstart)
 - [Fetching Data](/build/sdks/python-sdk/fetch-data-via-sdk)
 - [Building, Simulating, and Submitting Transactions](/build/sdks/python-sdk/building-transactions)
 
@@ -66,5 +67,6 @@ To run one of the v2 example scripts:
 
 ## Helpful Reference Code
 
+- [v2 tests](https://github.com/aptos-labs/aptos-python-sdk/tree/main/v2/tests) - Unit and integration tests that exercise the v2 API.
 - [SDK source code](https://github.com/aptos-labs/aptos-python-sdk) - This has in-line comments explaining what each function does.
 - [v1 to v2 migration guide](https://github.com/aptos-labs/aptos-python-sdk/blob/main/MIGRATION.md) - API mapping for existing v1 code.

--- a/src/content/docs/build/sdks/python-sdk/quickstart.mdx
+++ b/src/content/docs/build/sdks/python-sdk/quickstart.mdx
@@ -1,0 +1,153 @@
+---
+title: "Python SDK Quickstart"
+description: "Get started with the Aptos Python SDK by creating accounts, funding them, and transferring APT"
+sidebar:
+  label: "Python SDK Quickstart"
+---
+
+import { Aside, Steps } from '@astrojs/starlight/components';
+
+<Aside type="note">
+  The complete example is at [Full Quickstart Code](#full-quickstart-code) at
+  the bottom of this page. It follows the same flow as
+  [`transfer_apt.py`](https://github.com/aptos-labs/aptos-python-sdk/blob/main/v2/examples/transfer_apt.py)
+  in the SDK repository.
+</Aside>
+
+<Steps>
+  1. Install the Python SDK
+
+     The SDK requires **Python 3.12+**.
+
+     ```shellscript filename="Terminal"
+     pip install aptos-sdk
+     ```
+
+  2. Create a project file
+
+     ```shellscript filename="Terminal"
+     mkdir aptos-python-quickstart
+     cd aptos-python-quickstart
+     touch quickstart.py
+     ```
+
+  3. Set up the Aptos client
+
+     Use the v2 API (`aptos_sdk.v2`). A connection is established as soon as you
+     create the client.
+
+     ```python filename="quickstart.py"
+     import asyncio
+
+     from aptos_sdk.v2 import Account, Aptos, AptosConfig, Network
+
+     async def main():
+         async with Aptos(AptosConfig(network=Network.DEVNET)) as aptos:
+             print("Connected to Aptos devnet")
+
+     asyncio.run(main())
+     ```
+
+     <Aside type="note">
+       (Advanced) To connect to a specific node, pass a custom fullnode URL when
+       constructing `AptosConfig`.
+     </Aside>
+
+  4. Create and fund accounts
+
+     Generate credentials, then fund the accounts so the network knows they exist.
+     On localnet and devnet you can fund from a faucet.
+
+     ```python filename="quickstart.py"
+     alice = Account.generate()
+     bob = Account.generate()
+
+     await aptos.faucet.fund_account(alice.address, 100_000_000)
+     await aptos.faucet.fund_account(bob.address, 10_000_000)
+     ```
+
+     On testnet, mint from the [faucet page](/network/faucet).
+
+  5. Transfer APT
+
+     `aptos.coin.transfer` builds, signs, and submits an APT transfer. Then wait
+     for the transaction to land.
+
+     ```python filename="quickstart.py"
+     txn_hash = await aptos.coin.transfer(alice, bob.address, 1_000)
+     result = await aptos.transaction.wait_for_transaction(txn_hash)
+     print(f"Success: {result['success']}")
+     ```
+
+     For the lower-level build → simulate → sign → submit → wait flow, see
+     [Building Transactions](/build/sdks/python-sdk/building-transactions).
+</Steps>
+
+## Full Quickstart Code
+
+```python filename="quickstart.py"
+"""Create two accounts, fund them, and transfer APT on devnet."""
+
+import asyncio
+
+from aptos_sdk.v2 import Account, Aptos, AptosConfig, Network
+
+ALICE_INITIAL_BALANCE = 100_000_000
+BOB_INITIAL_BALANCE = 10_000_000
+TRANSFER_AMOUNT = 1_000
+
+
+async def main():
+    async with Aptos(AptosConfig(network=Network.DEVNET)) as aptos:
+        alice = Account.generate()
+        bob = Account.generate()
+
+        print("=== Addresses ===")
+        print(f"Alice: {alice.address}")
+        print(f"Bob:   {bob.address}")
+
+        await asyncio.gather(
+            aptos.faucet.fund_account(alice.address, ALICE_INITIAL_BALANCE),
+            aptos.faucet.fund_account(bob.address, BOB_INITIAL_BALANCE),
+        )
+
+        print("=== Initial Balances ===")
+        print(f"Alice: {await aptos.coin.balance(alice.address)}")
+        print(f"Bob:   {await aptos.coin.balance(bob.address)}")
+
+        txn_hash = await aptos.coin.transfer(alice, bob.address, TRANSFER_AMOUNT)
+        result = await aptos.transaction.wait_for_transaction(txn_hash)
+        print(f"Transaction: {txn_hash}")
+        print(f"Success: {result['success']}")
+
+        print("=== Final Balances ===")
+        print(f"Alice: {await aptos.coin.balance(alice.address)}")
+        print(f"Bob:   {await aptos.coin.balance(bob.address)}")
+
+
+asyncio.run(main())
+```
+
+Run it with:
+
+```shellscript filename="Terminal"
+python quickstart.py
+```
+
+## Summary
+
+You just learned how to transfer APT by:
+
+1. Connecting to the network with the `Aptos` client.
+2. Creating and funding accounts.
+3. Submitting a transfer and waiting for execution.
+
+<Aside type="note">
+  Bookmark the [v2 examples](https://github.com/aptos-labs/aptos-python-sdk/tree/main/v2/examples)
+  and [v2 tests](https://github.com/aptos-labs/aptos-python-sdk/tree/main/v2/tests)
+  in the SDK repository. Those suites are the source of truth for APIs shown in
+  these docs.
+
+  When you clone the SDK repo, examples import `aptos_sdk_v2`. After
+  `pip install aptos-sdk`, import the same APIs from `aptos_sdk.v2`.
+</Aside>

--- a/src/content/docs/build/sdks/rust-sdk.mdx
+++ b/src/content/docs/build/sdks/rust-sdk.mdx
@@ -7,9 +7,27 @@ sidebar:
 
 import { Aside, CardGrid, LinkCard } from '@astrojs/starlight/components';
 
+import { RemoteCodeblock } from '~/components/RemoteCodeblock';
+
+<div className="flex gap-2 mt-6 flex-wrap">
+  <a target="_blank" href="https://github.com/aptos-labs/aptos-rust-sdk">
+    ![Github Repo Stars](https://img.shields.io/github/stars/aptos-labs/aptos-rust-sdk)
+  </a>
+
+  <a target="_blank" href="https://crates.io/crates/aptos-sdk">
+    ![Crates.io Version](https://img.shields.io/crates/v/aptos-sdk)
+  </a>
+
+  <a target="_blank" href="https://docs.rs/aptos-sdk">
+    ![docs.rs](https://img.shields.io/docsrs/aptos-sdk)
+  </a>
+</div>
+
+The Rust SDK lets you connect, explore, and interact with the Aptos blockchain. You can use it to request data, send transactions, set up test environments, and more.
+
 ## Installing the Rust SDK
 
-Aptos provides an official Rust SDK in the
+Aptos publishes the official Rust SDK in the
 [aptos-rust-sdk GitHub](https://github.com/aptos-labs/aptos-rust-sdk) repository
 and on [crates.io](https://crates.io/crates/aptos-sdk). Add it to your
 `Cargo.toml`:
@@ -59,12 +77,27 @@ Minimal build:
 aptos-sdk = { version = "0.7", default-features = false, features = ["ed25519"] }
 ```
 
-## Usage
+## Examples
 
 <CardGrid>
-  <LinkCard href="/build/sdks/rust-sdk/fetch-data-via-sdk" title="Fetching Data" description="Learn how to fetch data with the Rust SDK" />
+  <LinkCard href="/build/sdks/rust-sdk/quickstart" title="Quickstart" description="Get a working transfer on devnet in a few minutes" />
 
-  <LinkCard href="/build/sdks/rust-sdk/building-transactions" title="Submitting Transactions" description="Learn how to submit transactions with the Rust SDK" />
+  <LinkCard href="/build/sdks/rust-sdk/account" title="Accounts" description="Generate, restore, and fund accounts" />
 
-  <LinkCard href="/build/sdks/rust-sdk/rust-examples" title="Examples" description="Explore Rust examples provided in the SDK" />
+  <LinkCard href="/build/sdks/rust-sdk/fetch-data-via-sdk" title="Fetching Data" description="Read ledger, account, and view-function data" />
+
+  <LinkCard href="/build/sdks/rust-sdk/building-transactions" title="Submitting Transactions" description="Build, simulate, sign, and submit transactions" />
+
+  <LinkCard href="/build/sdks/rust-sdk/rust-examples" title="Examples" description="Catalog of runnable examples in the SDK repository" />
+
+  <LinkCard href="https://github.com/aptos-labs/aptos-rust-sdk/tree/main/crates/aptos-sdk/tests" title="Tests" description="Crate tests that exercise the SDK APIs" target="_blank" />
 </CardGrid>
+
+### Transfer APT from the tested example suite
+
+The snippet below is pulled from
+[`transfer.rs`](https://github.com/aptos-labs/aptos-rust-sdk/blob/main/crates/aptos-sdk/examples/transfer.rs)
+in the SDK repository. Fund well above the transfer amount: the default
+`max_gas_amount` is `2_000_000`.
+
+<RemoteCodeblock permalink="https://github.com/aptos-labs/aptos-rust-sdk/blob/2a33e9aa8c0134f39671adfced5cf7263be2e1f2/crates/aptos-sdk/examples/transfer.rs#L38-L42" />

--- a/src/content/docs/build/sdks/rust-sdk/building-transactions.mdx
+++ b/src/content/docs/build/sdks/rust-sdk/building-transactions.mdx
@@ -195,6 +195,7 @@ Building and sending transactions on-chain involves the following 5 steps:
 Transactions have a couple of additional features which let them adapt to your needs which you can learn about here:
 
 1. [Multi-Agent Signatures](/build/sdks/rust-sdk/building-transactions/multi-agent-transactions) - Allowing multiple accounts to be used for a single contract.
-2. [Sponsoring Transactions](/build/sdks/rust-sdk/building-transactions/sponsoring-transactions) - Have another account pay gas fees for this transaction.
-3. [Batch Submit Transactions](/build/sdks/rust-sdk/building-transactions/batching-transactions) - How to send multiple transactions quickly from a single account.
-4. [Binary Canonical Serialization (BCS)](/build/sdks/rust-sdk/building-transactions/bcs-format) - The format used to serialize data for Aptos transactions.
+2. [Orderless Transactions](/build/sdks/rust-sdk/building-transactions/orderless-transactions) - Allowing for transactions to be executed out of order for easier management.
+3. [Sponsoring Transactions](/build/sdks/rust-sdk/building-transactions/sponsoring-transactions) - Have another account pay gas fees for this transaction.
+4. [Batch Submit Transactions](/build/sdks/rust-sdk/building-transactions/batching-transactions) - How to send multiple transactions quickly from a single account.
+5. [Binary Canonical Serialization (BCS)](/build/sdks/rust-sdk/building-transactions/bcs-format) - The format used to serialize data for Aptos transactions.

--- a/src/content/docs/build/sdks/rust-sdk/building-transactions/batching-transactions.mdx
+++ b/src/content/docs/build/sdks/rust-sdk/building-transactions/batching-transactions.mdx
@@ -52,3 +52,8 @@ let results = aptos
     .submit_batch_and_wait(&sender, vec![payload1, payload2, payload3], None)
     .await?;
 ```
+
+## Tested example
+
+See [`advanced_transactions.rs`](https://github.com/aptos-labs/aptos-rust-sdk/blob/main/crates/aptos-sdk/examples/advanced_transactions.rs)
+in the SDK repository for additional batching patterns.

--- a/src/content/docs/build/sdks/rust-sdk/building-transactions/multi-agent-transactions.mdx
+++ b/src/content/docs/build/sdks/rust-sdk/building-transactions/multi-agent-transactions.mdx
@@ -135,3 +135,8 @@ do multi-agent signing for a function which does not require that number of
 accounts. For example, if you try using multiple signatures for a
 `0x1::aptos_account::transfer` function - it only expects one address, and so
 produces an error when more than one is provided.
+
+## Tested example
+
+See [`multi_agent.rs`](https://github.com/aptos-labs/aptos-rust-sdk/blob/main/crates/aptos-sdk/examples/multi_agent.rs)
+in the SDK repository.

--- a/src/content/docs/build/sdks/rust-sdk/building-transactions/orderless-transactions.mdx
+++ b/src/content/docs/build/sdks/rust-sdk/building-transactions/orderless-transactions.mdx
@@ -1,0 +1,60 @@
+---
+title: "Rust SDK - Orderless Transactions"
+description: "Create transactions that can be executed in any order using replay-protection nonces with the Rust SDK"
+sidebar:
+  label: "Orderless Transactions"
+---
+
+import { Aside } from '@astrojs/starlight/components';
+
+Orderless transactions allow you to create transactions that do not specify an
+order of execution between them. This is useful when multiple machines need to
+sign or submit for the same sending account, but the order does not affect the
+outcome.
+
+See [Orderless Transactions](/build/guides/orderless-transactions) for the
+protocol overview ([AIP-123](https://github.com/aptos-foundation/AIPs/blob/main/aips/aip-123.md)
+and [AIP-129](https://github.com/aptos-foundation/AIPs/blob/main/aips/aip-129.md)).
+
+## Building Orderless Transactions
+
+`Aptos::sign_submit_and_wait_orderless` wraps an ordinary payload, attaches a
+replay-protection nonce, and submits. Pass `None` for the nonce to let the SDK
+generate a fresh random value.
+
+<Aside type="note">
+  The nonce must be unique for each transaction. Orderless transactions expire
+  at most 60 seconds after submission. If the transaction is not executed in
+  that window, it expires and will not execute.
+</Aside>
+
+```rust filename="orderless.rs"
+use aptos_sdk::{Aptos, AptosConfig, account::Ed25519Account, transaction::EntryFunction};
+
+let aptos = Aptos::new(AptosConfig::devnet())?;
+let sender = aptos.create_funded_account(1_000_000_000).await?;
+let recipient = Ed25519Account::generate();
+
+let payload = EntryFunction::apt_transfer(recipient.address(), 1_000_000)?;
+let result = aptos
+    .sign_submit_and_wait_orderless(&sender, payload.into(), None, None)
+    .await?;
+```
+
+The third argument is an optional explicit nonce (`Some(nonce)` to reuse a
+specific value). The fourth argument is an optional wait timeout.
+
+After that, treat the result like any other submitted transaction: inspect
+`success`, `hash`, and `vm_status` on `result.data`.
+
+## Tested example
+
+The SDK repository includes a runnable example that follows this API:
+
+- [`orderless_transaction.rs`](https://github.com/aptos-labs/aptos-rust-sdk/blob/main/crates/aptos-sdk/examples/orderless_transaction.rs)
+
+Run it with:
+
+```shellscript filename="Terminal"
+cargo run -p aptos-sdk --example orderless_transaction --features "ed25519,faucet"
+```

--- a/src/content/docs/build/sdks/rust-sdk/building-transactions/simulating-transactions.mdx
+++ b/src/content/docs/build/sdks/rust-sdk/building-transactions/simulating-transactions.mdx
@@ -51,3 +51,8 @@ You can also learn how to simulate more advanced transactions by looking at the 
 
 - [Sponsored Transactions](/build/sdks/rust-sdk/building-transactions/sponsoring-transactions)
 - [Multi-Agent Transactions](/build/sdks/rust-sdk/building-transactions/multi-agent-transactions)
+
+## Tested example
+
+See [`simulation.rs`](https://github.com/aptos-labs/aptos-rust-sdk/blob/main/crates/aptos-sdk/examples/simulation.rs)
+in the SDK repository.

--- a/src/content/docs/build/sdks/rust-sdk/building-transactions/sponsoring-transactions.mdx
+++ b/src/content/docs/build/sdks/rust-sdk/building-transactions/sponsoring-transactions.mdx
@@ -92,3 +92,8 @@ async fn main() -> anyhow::Result<()> {
     Ok(())
 }
 ```
+
+## Tested example
+
+See [`sponsored_transaction.rs`](https://github.com/aptos-labs/aptos-rust-sdk/blob/main/crates/aptos-sdk/examples/sponsored_transaction.rs)
+in the SDK repository.

--- a/src/content/docs/build/sdks/rust-sdk/fetch-data-via-sdk.mdx
+++ b/src/content/docs/build/sdks/rust-sdk/fetch-data-via-sdk.mdx
@@ -83,3 +83,9 @@ let result: serde_json::Value = indexer.query(my_query, None).await?;
   Custom GraphQL queries use `indexer.query::<T>(query, variables)`. Pass a type
   annotation so `T` is known.
 </Aside>
+
+## Tested example
+
+See [`view_function.rs`](https://github.com/aptos-labs/aptos-rust-sdk/blob/main/crates/aptos-sdk/examples/view_function.rs)
+and [`indexer_queries.rs`](https://github.com/aptos-labs/aptos-rust-sdk/blob/main/crates/aptos-sdk/examples/indexer_queries.rs)
+in the SDK repository.

--- a/src/content/docs/build/sdks/rust-sdk/quickstart.mdx
+++ b/src/content/docs/build/sdks/rust-sdk/quickstart.mdx
@@ -1,0 +1,139 @@
+---
+title: "Rust SDK Quickstart"
+description: "Get started with the Aptos Rust SDK by creating accounts, funding them, and transferring APT"
+sidebar:
+  label: "Rust SDK Quickstart"
+---
+
+import { Aside, Steps } from '@astrojs/starlight/components';
+
+<Aside type="note">
+  The complete example is at [Full Quickstart Code](#full-quickstart-code) at
+  the bottom of this page. It follows the same flow as
+  [`transfer.rs`](https://github.com/aptos-labs/aptos-rust-sdk/blob/main/crates/aptos-sdk/examples/transfer.rs)
+  in the SDK repository.
+</Aside>
+
+<Steps>
+  1. Create a Cargo project and add the SDK
+
+     The SDK requires **Rust 1.95+**.
+
+     ```shellscript filename="Terminal"
+     cargo new aptos-rust-quickstart
+     cd aptos-rust-quickstart
+     ```
+
+     Add dependencies to `Cargo.toml`:
+
+     ```toml filename="Cargo.toml"
+     [dependencies]
+     aptos-sdk = "0.7"
+     tokio = { version = "1", features = ["full"] }
+     anyhow = "1"
+     serde_json = "1"
+     ```
+
+  2. Set up the Aptos client
+
+     ```rust filename="src/main.rs"
+     use aptos_sdk::{Aptos, AptosConfig};
+
+     let aptos = Aptos::new(AptosConfig::devnet())?;
+     println!("Connected to Aptos devnet");
+     ```
+
+     <Aside type="note">
+       (Advanced) To connect to a specific node, chain `AptosConfig::devnet()`
+       with `.with_fullnode_url(...)`.
+     </Aside>
+
+  3. Create and fund accounts
+
+     ```rust filename="src/main.rs"
+     use aptos_sdk::account::Ed25519Account;
+
+     let alice = Ed25519Account::generate();
+     let bob = Ed25519Account::generate();
+
+     // Default max_gas_amount is 2_000_000. Fund well above the transfer amount.
+     aptos.fund_account(alice.address(), 1_000_000_000).await?;
+     ```
+
+     You can also generate and fund in one step with
+     `aptos.create_funded_account(amount)`. On testnet, mint from the
+     [faucet page](/network/faucet).
+
+  4. Transfer APT
+
+     `aptos.transfer_apt` builds, signs, submits, and waits.
+
+     ```rust filename="src/main.rs"
+     let result = aptos.transfer_apt(&alice, bob.address(), 1_000).await?;
+     println!("Submitted: {:?}", result.data.get("hash"));
+     ```
+
+     For the lower-level build → simulate → sign → submit → wait flow, see
+     [Building Transactions](/build/sdks/rust-sdk/building-transactions).
+</Steps>
+
+## Full Quickstart Code
+
+```rust filename="src/main.rs"
+use aptos_sdk::{Aptos, AptosConfig, account::Ed25519Account};
+
+const FUND_AMOUNT: u64 = 1_000_000_000;
+const TRANSFER_AMOUNT: u64 = 1_000;
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    let aptos = Aptos::new(AptosConfig::devnet())?;
+
+    let alice = Ed25519Account::generate();
+    let bob = Ed25519Account::generate();
+
+    println!("=== Addresses ===");
+    println!("Alice: {}", alice.address());
+    println!("Bob:   {}", bob.address());
+
+    aptos.fund_account(alice.address(), FUND_AMOUNT).await?;
+
+    println!("=== Initial Balances ===");
+    println!("Alice: {}", aptos.get_balance(alice.address()).await?);
+    println!("Bob:   {}", aptos.get_balance(bob.address()).await?);
+
+    let result = aptos
+        .transfer_apt(&alice, bob.address(), TRANSFER_AMOUNT)
+        .await?;
+    println!("Submitted: {:?}", result.data.get("hash"));
+
+    println!("=== Final Balances ===");
+    println!("Alice: {}", aptos.get_balance(alice.address()).await?);
+    println!("Bob:   {}", aptos.get_balance(bob.address()).await?);
+
+    Ok(())
+}
+```
+
+Run it with:
+
+```shellscript filename="Terminal"
+cargo run
+```
+
+## Summary
+
+You just learned how to transfer APT by:
+
+1. Connecting to the network with `Aptos::new`.
+2. Creating and funding accounts.
+3. Submitting a transfer and waiting for execution.
+
+<Aside type="note">
+  Bookmark the
+  [examples](https://github.com/aptos-labs/aptos-rust-sdk/tree/main/crates/aptos-sdk/examples)
+  and [tests](https://github.com/aptos-labs/aptos-rust-sdk/tree/main/crates/aptos-sdk/tests)
+  in the SDK repository. Those suites are the source of truth for APIs shown in
+  these docs. Generated rustdoc lives at
+  [aptos-labs.github.io/aptos-rust-sdk](https://aptos-labs.github.io/aptos-rust-sdk/aptos_sdk/index.html).
+</Aside>

--- a/src/content/docs/build/sdks/rust-sdk/rust-examples.mdx
+++ b/src/content/docs/build/sdks/rust-sdk/rust-examples.mdx
@@ -9,6 +9,7 @@ import { Steps } from '@astrojs/starlight/components';
 
 For sample code which explains the core concepts of how to use the SDK, see:
 
+- [Quickstart](/build/sdks/rust-sdk/quickstart)
 - [Fetching Data](/build/sdks/rust-sdk/fetch-data-via-sdk)
 - [Building, Simulating, and Submitting Transactions](/build/sdks/rust-sdk/building-transactions)
 
@@ -26,10 +27,13 @@ in the SDK repo has many code snippets you can customize to your needs.
 | `simulation.rs`              | Simulate transactions before submission    |
 | `sponsored_transaction.rs`   | Fee payer (sponsored) transactions         |
 | `multi_agent.rs`             | Multi-signer transactions                  |
+| `orderless_transaction.rs`   | Orderless (nonce-based) transactions       |
 | `account_management.rs`      | Account creation, mnemonics, and key types |
+| `multi_key_account.rs`       | Mixed-scheme multi-key accounts            |
 | `indexer_queries.rs`         | Query the Aptos indexer via GraphQL        |
 | `fungible_asset_transfer.rs` | Transfer a fungible asset                  |
-| `orderless_transaction.rs`   | Orderless (nonce-based) transactions       |
+| `script_transaction.rs`      | Script payload construction                |
+| `deploy_module.rs`           | Publish a Move package                     |
 
 ### How to run examples
 
@@ -52,6 +56,7 @@ To run one of the example scripts:
 
 ## Helpful Reference Code
 
+- [Crate tests](https://github.com/aptos-labs/aptos-rust-sdk/tree/main/crates/aptos-sdk/tests) - Tests that exercise the SDK APIs.
 - [SDK source code](https://github.com/aptos-labs/aptos-rust-sdk) - This has in-line comments explaining what each function does.
 - [API reference](https://aptos-labs.github.io/aptos-rust-sdk/aptos_sdk/index.html) - Generated rustdoc for the crate.
 - [Migration guide](https://github.com/aptos-labs/aptos-rust-sdk/blob/main/MIGRATION.md) - Mapping from the legacy `aptos-core` SDK.

--- a/src/content/docs/build/sdks/rust-sdk/rust-examples.mdx
+++ b/src/content/docs/build/sdks/rust-sdk/rust-examples.mdx
@@ -5,7 +5,7 @@ sidebar:
   label: "Examples"
 ---
 
-import { Steps } from '@astrojs/starlight/components';
+import { Aside, Steps } from '@astrojs/starlight/components';
 
 For sample code which explains the core concepts of how to use the SDK, see:
 
@@ -34,6 +34,12 @@ in the SDK repo has many code snippets you can customize to your needs.
 | `fungible_asset_transfer.rs` | Transfer a fungible asset                  |
 | `script_transaction.rs`      | Script payload construction                |
 | `deploy_module.rs`           | Publish a Move package                     |
+
+<Aside type="note">
+  Prefer these repository examples over copying snippets from older blog posts
+  or the legacy `aptos-core` SDK. The standalone `aptos-sdk` crate tracks the
+  current API.
+</Aside>
 
 ### How to run examples
 

--- a/src/content/docs/build/sdks/ts-sdk.mdx
+++ b/src/content/docs/build/sdks/ts-sdk.mdx
@@ -42,11 +42,21 @@ npm i @aptos-labs/ts-sdk
 <CardGrid>
   <LinkCard href="/build/sdks/ts-sdk/quickstart" title="Quickstart" description="See the quickstart to get a working demo in < 5 minutes" />
 
-  <LinkCard href="https://github.com/aptos-labs/aptos-ts-sdk/tree/main/examples/typescript" title="20+ Examples" description="Explore all of the TypeScript examples provided in the SDK repository" target="_blank" />
+  <LinkCard href="/build/sdks/ts-sdk/account" title="Accounts" description="Generate, restore, and fund accounts" />
 
-  <LinkCard href="https://github.com/aptos-labs/aptos-ts-sdk/tree/main/tests/e2e" title="Comprehensive Tests" description="See end to end tests which demonstrate how to use each feature of the SDK" target="_blank" />
+  <LinkCard href="/build/sdks/ts-sdk/fetch-data-via-sdk" title="Fetching Data" description="Read ledger, account, and view-function data" />
+
+  <LinkCard href="/build/sdks/ts-sdk/building-transactions" title="Submitting Transactions" description="Build, simulate, sign, and submit transactions" />
+
+  <LinkCard href="/build/sdks/ts-sdk/ts-examples" title="Examples" description="Catalog of runnable examples in the SDK repository" />
+
+  <LinkCard href="https://github.com/aptos-labs/aptos-ts-sdk/tree/main/tests/e2e" title="Tests" description="End-to-end tests that demonstrate each SDK feature" target="_blank" />
 </CardGrid>
 
-### Transfer APT in 10 lines or less
+### Transfer APT from the tested example suite
 
-<RemoteCodeblock permalink="https://github.com/aptos-labs/aptos-ts-sdk/blob/bcde1e3af2f09615015c774fb0c2f5206377346e/examples/typescript/simple_transfer.ts#L77-L91" />
+The snippet below is pulled from
+[`simple_transfer.ts`](https://github.com/aptos-labs/aptos-ts-sdk/blob/main/examples/typescript/simple_transfer.ts)
+in the SDK repository.
+
+<RemoteCodeblock permalink="https://github.com/aptos-labs/aptos-ts-sdk/blob/da6319287572e8f62f38c73be0e2346ca7447e21/examples/typescript/simple_transfer.ts#L68-L81" />

--- a/src/content/docs/build/sdks/ts-sdk/ts-examples.mdx
+++ b/src/content/docs/build/sdks/ts-sdk/ts-examples.mdx
@@ -5,10 +5,11 @@ sidebar:
   label: "Examples"
 ---
 
-import { Steps } from '@astrojs/starlight/components';
+import { Aside, Steps } from '@astrojs/starlight/components';
 
 For sample code which explains the core concepts of how to use the SDK, see:
 
+- [Quickstart](/build/sdks/ts-sdk/quickstart)
 - [Fetching Data](/build/sdks/ts-sdk/fetch-data-via-sdk)
 - [Building, Simulating, and Submitting Transactions](/build/sdks/ts-sdk/building-transactions)
 
@@ -16,17 +17,41 @@ Below are additional resources which may be more suited for your individual use 
 
 ## Code Snippets
 
-The [`examples` folder](https://github.com/aptos-labs/aptos-ts-sdk/tree/main/examples) in the SDK repo has dozens of code snippets you can customize to your needs.
+The [`examples` folder](https://github.com/aptos-labs/aptos-ts-sdk/tree/main/examples)
+in the SDK repository has dozens of code snippets you can customize. These
+examples are part of the SDK's CI surface.
+
+| Example                           | Description                                       |
+| --------------------------------- | ------------------------------------------------- |
+| `simple_transfer.ts`              | Basic APT transfer between two accounts           |
+| `simple_orderless_transfer.ts`    | Orderless transfer with a replay-protection nonce |
+| `simple_sponsored_transaction.ts` | Fee-payer sponsored transaction                   |
+| `multi_agent_transfer.ts`         | Multi-agent transaction with two signers          |
+| `batch_funds.ts`                  | Batch funding from a single account               |
+| `transfer_coin.ts`                | Coin API transfer                                 |
+| `your_fungible_asset.ts`          | Publish and transfer a fungible asset             |
+| `simple_digital_asset.ts`         | Digital asset (NFT) flow                          |
+| `rotate_key.ts`                   | Authentication key rotation                       |
+| `keyless.ts`                      | Keyless account flow                              |
+| `custom_client.ts`                | Custom HTTP client                                |
+| `external_signing.ts`             | Sign with an external signer                      |
+
+<Aside type="note">
+  Prefer these repository examples over copying snippets from older blog posts.
+  The TypeScript SDK evolves quickly, and the examples folder tracks the current
+  API.
+</Aside>
 
 ### How to run examples
 
 To run one of the example scripts:
 
 <Steps>
-  1. Clone the
+  1. Clone the repository.
 
      ```shellscript filename="Terminal"
      git clone https://github.com/aptos-labs/aptos-ts-sdk.git
+     cd aptos-ts-sdk
      ```
 
   2. From the top-level of the package, install all dependencies.

--- a/src/content/docs/network/blockchain/txns-states.mdx
+++ b/src/content/docs/network/blockchain/txns-states.mdx
@@ -65,7 +65,7 @@ Within a given transaction, the two most common types of payloads include:
 - An entry point
 - [A script (payload)](/build/smart-contracts/scripts)
 
-Currently, the SDKs [Python](/build/sdks/python-sdk) and [Typescript](/build/sdks/ts-sdk) support both. This guide points out many of those entry points, such as `coin::transfer` and `aptos_account::create_account`.
+Currently, the official [TypeScript](/build/sdks/ts-sdk), [Python](/build/sdks/python-sdk), [Go](/build/sdks/go-sdk), and [Rust](/build/sdks/rust-sdk) SDKs support both. This guide points out many of those entry points, such as `coin::transfer` and `aptos_account::create_account`.
 
 All operations on the Aptos blockchain should be available via entry point calls. While one could submit multiple transactions calling entry points in series, many such operations may benefit from being called atomically from a single transaction. A script payload transaction can call any entry point or public function defined within any module.
 

--- a/src/content/docs/zh/build/get-started.mdx
+++ b/src/content/docs/zh/build/get-started.mdx
@@ -20,7 +20,7 @@ import { CardGrid, LinkCard } from '@astrojs/starlight/components';
 ## 我可以使用哪些开发工具?
 
 <CardGrid>
-  <LinkCard href="/zh/build/sdks" title="SDK" description="使用我们的 TypeScript、Python、Rust 和其他 SDK 提交交易和读取链上数据" />
+  <LinkCard href="/zh/build/sdks" title="SDK" description="使用 TypeScript、Python、Go 和 Rust SDK 提交交易并读取链上数据" />
 
   <LinkCard href="/zh/build/indexer" title="索引器" description="查询链上数据，如账户余额、历史交易、账户的 NFT 等" />
 

--- a/src/content/docs/zh/build/guides/first-coin.mdx
+++ b/src/content/docs/zh/build/guides/first-coin.mdx
@@ -397,4 +397,6 @@ Aptos 提供多个构件支持 coin 转移：
 - [Aptos CLI](/zh/build/cli)
 - [TypeScript SDK](/zh/build/sdks/ts-sdk)
 - [Python SDK](/zh/build/sdks/python-sdk)
+- [Go SDK](/zh/build/sdks/go-sdk)
+- [Rust SDK](/zh/build/sdks/rust-sdk)
 - [REST API 规范](/zh/rest-api)

--- a/src/content/docs/zh/build/guides/first-transaction.mdx
+++ b/src/content/docs/zh/build/guides/first-transaction.mdx
@@ -1,6 +1,6 @@
 ---
 title: "您的第一笔交易"
-description: "在 Aptos 区块链上创建和提交您的第一笔交易 - 使用 TypeScript 和 Python 示例在账户之间转移代币。"
+description: "在 Aptos 区块链上创建和提交您的第一笔交易 - 使用 TypeScript、Python、Go 和 Rust 示例在账户之间转移代币。"
 sidebar:
   label: "第一笔交易"
 ---
@@ -22,6 +22,13 @@ import { Aside, Steps, TabItem, Tabs } from '@astrojs/starlight/components';
   本教程建立在Aptos区块链概念的基础上。如果您是区块链开发的新手，不用担心 - 我们将在过程中解释关键概念。
 
   您可以跳转到完整代码示例[这里](#完整代码示例)或继续阅读逐步演练。
+
+  官方 SDK 中提供相同转账流程的演练：
+
+  - [TypeScript 快速入门](/zh/build/sdks/ts-sdk/quickstart)
+  - [Python 快速入门（v2 API）](/zh/build/sdks/python-sdk/quickstart)
+  - [Go 快速入门](/zh/build/sdks/go-sdk/quickstart)
+  - [Rust 快速入门](/zh/build/sdks/rust-sdk/quickstart)
 </Aside>
 
 ## 1. 设置您的环境
@@ -506,6 +513,10 @@ import { Aside, Steps, TabItem, Tabs } from '@astrojs/starlight/components';
 - [您的第一个Move模块](/zh/build/guides/first-move-module) - 学习如何编写智能合约
 - [构建端到端DApp](/zh/build/guides/build-e2e-dapp) - 创建完整的去中心化应用
 - [Aptos SDK文档](/zh/build/sdks) - 深入了解SDK功能
+- [TypeScript 快速入门](/zh/build/sdks/ts-sdk/quickstart)
+- [Python 快速入门（v2 API）](/zh/build/sdks/python-sdk/quickstart)
+- [Go 快速入门](/zh/build/sdks/go-sdk/quickstart)
+- [Rust 快速入门](/zh/build/sdks/rust-sdk/quickstart)
 
 <Aside type="tip">
   **故障排除提示**：如果您遇到任何问题，请检查：

--- a/src/content/docs/zh/build/guides/orderless-transactions.mdx
+++ b/src/content/docs/zh/build/guides/orderless-transactions.mdx
@@ -18,7 +18,9 @@ sidebar:
 
 ## SDK 支持
 
-以下是赞助交易的演示：
+每个官方 SDK 都记录了无序交易，并提供已测试示例：
 
-- [TypeScript SDK](/zh/build/sdks/ts-sdk/building-transactions/orderless-transactions) 提供相关文档。
-- [Go SDK](https://github.com/aptos-labs/aptos-go-sdk/tree/main/examples/orderless_transaction) 提供示例。
+- [TypeScript SDK](/zh/build/sdks/ts-sdk/building-transactions/orderless-transactions) — [`simple_orderless_transfer.ts`](https://github.com/aptos-labs/aptos-ts-sdk/blob/main/examples/typescript/simple_orderless_transfer.ts)
+- [Python SDK](/zh/build/sdks/python-sdk/building-transactions/orderless-transactions) — [`orderless_transfer.py`](https://github.com/aptos-labs/aptos-python-sdk/blob/main/v2/examples/orderless_transfer.py)
+- [Go SDK](/zh/build/sdks/go-sdk/building-transactions/orderless-transactions) — [`examples/orderless_transaction`](https://github.com/aptos-labs/aptos-go-sdk/tree/main/examples/orderless_transaction)
+- [Rust SDK](/zh/build/sdks/rust-sdk/building-transactions/orderless-transactions) — [`orderless_transaction.rs`](https://github.com/aptos-labs/aptos-rust-sdk/blob/main/crates/aptos-sdk/examples/orderless_transaction.rs)

--- a/src/content/docs/zh/build/guides/sponsored-transactions.mdx
+++ b/src/content/docs/zh/build/guides/sponsored-transactions.mdx
@@ -76,8 +76,9 @@ pub enum RawTransactionWithData {
 
 ## SDK 支持
 
-以下为赞助交易示例：
+每个官方 SDK 都记录了赞助交易，并提供已测试示例：
 
-- TypeScript SDK 提供[多个示例](https://github.com/aptos-labs/aptos-ts-sdk/tree/main/examples/typescript-esm/sponsored_transactions)。
-- Python SDK 在 [fee\_payer\_transfer\_coin.py](https://github.com/aptos-labs/aptos-python-sdk/blob/main/examples/fee_payer_transfer_coin.py) 中提供示例。
-- Rust SDK 在 [API 测试](https://github.com/aptos-labs/aptos-core/blob/0a62e54e13bc5da604ceaf39efed5c012a292078/api/src/tests/transactions_test.rs#L255)中提供测试用例。
+- [TypeScript SDK](/zh/build/sdks/ts-sdk/building-transactions/sponsoring-transactions) — [`simple_sponsored_transaction.ts`](https://github.com/aptos-labs/aptos-ts-sdk/blob/main/examples/typescript/simple_sponsored_transaction.ts)
+- [Python SDK](/zh/build/sdks/python-sdk/building-transactions/sponsoring-transactions) — [`sponsored_transaction.py`](https://github.com/aptos-labs/aptos-python-sdk/blob/main/v2/examples/sponsored_transaction.py)
+- [Go SDK](/zh/build/sdks/go-sdk/building-transactions/sponsoring-transactions) — [`examples/sponsored_transaction`](https://github.com/aptos-labs/aptos-go-sdk/tree/main/examples/sponsored_transaction)
+- [Rust SDK](/zh/build/sdks/rust-sdk/building-transactions/sponsoring-transactions) — [`sponsored_transaction.rs`](https://github.com/aptos-labs/aptos-rust-sdk/blob/main/crates/aptos-sdk/examples/sponsored_transaction.rs)

--- a/src/content/docs/zh/build/sdks/go-sdk.mdx
+++ b/src/content/docs/zh/build/sdks/go-sdk.mdx
@@ -7,20 +7,48 @@ sidebar:
 
 import { CardGrid, LinkCard } from '@astrojs/starlight/components';
 
+import { RemoteCodeblock } from '~/components/RemoteCodeblock';
+
+<div className="flex gap-2 mt-6 flex-wrap">
+  <a target="_blank" href="https://github.com/aptos-labs/aptos-go-sdk">
+    ![Github Repo Stars](https://img.shields.io/github/stars/aptos-labs/aptos-go-sdk)
+  </a>
+
+  <a target="_blank" href="https://pkg.go.dev/github.com/aptos-labs/aptos-go-sdk">
+    ![Go Reference](https://pkg.go.dev/badge/github.com/aptos-labs/aptos-go-sdk.svg)
+  </a>
+</div>
+
+Go SDK 可让你连接、探索并与 Aptos 区块链交互。你可以用它请求数据、发送交易、设置测试环境等。
+
 ## 安装 Go SDK
 
-Aptos 在 [aptos-go-sdk GitHub](https://github.com/aptos-labs/aptos-go-sdk) 仓库中提供官方 Go SDK。要使用 Go SDK，请获取主包：
+Aptos 在 [aptos-go-sdk GitHub](https://github.com/aptos-labs/aptos-go-sdk) 仓库中提供官方 Go SDK。
+该 SDK 需要 **Go 1.25+**。
 
-```shellscript
+```shellscript filename="Terminal"
 go get github.com/aptos-labs/aptos-go-sdk
 ```
 
-## 使用方式
+## 示例
 
 <CardGrid>
-  <LinkCard href="/zh/build/sdks/go-sdk/fetch-data-via-sdk" title="获取数据" description="了解如何使用 Go SDK 获取数据" />
+  <LinkCard href="/zh/build/sdks/go-sdk/quickstart" title="快速入门" description="几分钟内在 Devnet 上完成一笔可运行的转账" />
 
-  <LinkCard href="/zh/build/sdks/go-sdk/building-transactions" title="提交交易" description="了解如何使用 Go SDK 提交交易" />
+  <LinkCard href="/zh/build/sdks/go-sdk/account" title="账户" description="生成、恢复并为账户注资" />
 
-  <LinkCard href="/zh/build/sdks/go-sdk/go-examples" title="示例" description="浏览 SDK 提供的 Go 示例" />
+  <LinkCard href="/zh/build/sdks/go-sdk/fetch-data-via-sdk" title="获取数据" description="读取账本、账户和 View 函数数据" />
+
+  <LinkCard href="/zh/build/sdks/go-sdk/building-transactions" title="提交交易" description="构建、模拟、签名并提交交易" />
+
+  <LinkCard href="/zh/build/sdks/go-sdk/go-examples" title="示例" description="SDK 仓库中的可运行示例目录" />
+
+  <LinkCard href="https://github.com/aptos-labs/aptos-go-sdk/tree/main/integration_test" title="测试" description="覆盖 SDK 的集成测试和包测试" target="_blank" />
 </CardGrid>
+
+### 来自已测试示例套件的 APT 转账
+
+以下片段取自 SDK 仓库中的
+[`examples/transfer_coin`](https://github.com/aptos-labs/aptos-go-sdk/tree/main/examples/transfer_coin)。
+
+<RemoteCodeblock permalink="https://github.com/aptos-labs/aptos-go-sdk/blob/8b983c5acabd61b0f2c0ab725500cacccdf77301/examples/transfer_coin/main.go#L132-L153" />

--- a/src/content/docs/zh/build/sdks/go-sdk/account.mdx
+++ b/src/content/docs/zh/build/sdks/go-sdk/account.mdx
@@ -11,15 +11,23 @@ Go SDK 提供多种生成账户凭据的方式，可使用：
 - `aptos.NewSecp256k1Account()`
 - `aptos.NewEd25519SingleSenderAccount()`
 - `aptos.NewAccountFromSigner()`
+- `aptos.NewEd25519AccountFromMnemonic()`
+- `aptos.NewEd25519AccountFromDerivationPath()`
 
-`Account.NewEd25519Account()` 是最常用于为新账户创建密钥的方法。它默认使用 `ED25519` 密钥类型，但也可按以下方式指定所需的签名方案：
+`NewEd25519Account()` 是最常用于为新账户创建密钥的方法。它默认使用 `ED25519` 密钥类型，但也可按以下方式指定所需的签名方案：
 
 ```go
 // To derive an ed25519 account
-account1 := aptos.NewEd25519Account()
+account1, err := aptos.NewEd25519Account()
+if err != nil {
+  panic("Failed to create account:" + err.Error())
+}
 
 // To derive a secp256k1 account
-account2 := aptos.NewSecp256k1Account()
+account2, err := aptos.NewSecp256k1Account()
+if err != nil {
+  panic("Failed to create account:" + err.Error())
+}
 ```
 
 生成凭据后，**必须**为账户注资，网络才能识别其存在。
@@ -27,13 +35,16 @@ account2 := aptos.NewSecp256k1Account()
 在 Devnet 环境中，可通过 faucet 使用以下命令完成：
 
 ```go filename="fund.go"
-client, err = aptos.NewClient(aptos.DevnetConfig)
+client, err := aptos.NewClient(aptos.DevnetConfig)
 if err != nil {
   panic("Failed to create client:" + err.Error())
 }
 
 // Fund an account with 1 Devnet APT
-client.Fund(account1.Address, 100_000_000)
+err = client.Fund(account1.Address, 100_000_000)
+if err != nil {
+  panic("Failed to fund account:" + err.Error())
+}
 ```
 
 在 Testnet 上，可在[铸造页面](/zh/network/faucet)领取代币。
@@ -57,7 +68,10 @@ err := privateKey.FromHex(privateKeyHex)
 if err != nil {
   panic("Failed to parse private key:" + err.Error())
 }
-account := aptos.NewAccountFromSigner(privateKey)
+account, err := aptos.NewAccountFromSigner(privateKey)
+if err != nil {
+  panic("Failed to derive account:" + err.Error())
+}
 
 // to derive an account with a Single Sender Ed25519 key scheme
 privateKey := &aptos.Ed25519PrivateKey{}
@@ -66,7 +80,10 @@ if err != nil {
   panic("Failed to parse private key:" + err.Error())
 }
 singleSigner := &crypto.SingleSigner{Signer: privateKey}
-account := aptos.NewAccountFromSigner(singleSigner)
+account, err = aptos.NewAccountFromSigner(singleSigner)
+if err != nil {
+  panic("Failed to derive account:" + err.Error())
+}
 
 // to derive an account with a Single Sender Secp256k1 key scheme
 privateKey := &aptos.Secp256k1PrivateKey{}
@@ -75,20 +92,38 @@ if err != nil {
   panic("Failed to parse private key:" + err.Error())
 }
 singleSigner := &crypto.SingleSigner{Signer: privateKey}
-account := aptos.NewAccountFromSigner(singleSigner)
+account, err = aptos.NewAccountFromSigner(singleSigner)
+if err != nil {
+  panic("Failed to derive account:" + err.Error())
+}
 
 // to derive an account with a private key and account address
-address := &aptos.AccountAddress{}
-err := address.ParseStringRelaxed(addressHex)
+var address aptos.AccountAddress
+err = address.ParseStringRelaxed(addressHex)
 if err != nil {
   panic("Failed to parse address:" + err.Error())
 }
 privateKey := &aptos.Ed25519PrivateKey{}
-err := privateKey.FromHex(privateKeyHex)
+err = privateKey.FromHex(privateKeyHex)
 if err != nil {
   panic("Failed to parse private key:" + err.Error())
 }
-account := aptos.NewAccountFromSigner(privateKey, address.AuthKey())
+account, err = aptos.NewAccountFromSigner(privateKey, address)
+if err != nil {
+  panic("Failed to derive account:" + err.Error())
+}
 ```
 
-{/* TODO: Once derivation path is supported ### Derive an account from derivation path */}
+### 从助记词派生账户
+
+```go
+account, err := aptos.NewEd25519AccountFromMnemonic(mnemonic)
+if err != nil {
+  panic("Failed to derive account:" + err.Error())
+}
+
+account, err = aptos.NewEd25519AccountFromDerivationPath(mnemonic, "m/44'/637'/0'/0'/0'")
+if err != nil {
+  panic("Failed to derive account:" + err.Error())
+}
+```

--- a/src/content/docs/zh/build/sdks/go-sdk/building-transactions.mdx
+++ b/src/content/docs/zh/build/sdks/go-sdk/building-transactions.mdx
@@ -304,6 +304,7 @@ func main() {
 交易还提供一些额外功能，可帮助它们适应需求，详情请参阅：
 
 1. [多代理签名](/zh/build/sdks/go-sdk/building-transactions/multi-agent-transactions)：允许多个账户用于单个合约。
-2. [赞助交易](/zh/build/sdks/go-sdk/building-transactions/sponsoring-transactions)：让另一账户支付此交易的 Gas 费用。
-3. [批量提交交易](/zh/build/sdks/go-sdk/building-transactions/batching-transactions)：如何从单个账户快速发送多笔交易。
-4. [二进制规范序列化（BCS）](/zh/build/sdks/go-sdk/building-transactions/bcs-format)：用于序列化 Aptos 交易数据的格式。
+2. [无序交易](/zh/build/sdks/go-sdk/building-transactions/orderless-transactions)：允许交易无序执行，便于管理。
+3. [赞助交易](/zh/build/sdks/go-sdk/building-transactions/sponsoring-transactions)：让另一账户支付此交易的 Gas 费用。
+4. [批量提交交易](/zh/build/sdks/go-sdk/building-transactions/batching-transactions)：如何从单个账户快速发送多笔交易。
+5. [二进制规范序列化（BCS）](/zh/build/sdks/go-sdk/building-transactions/bcs-format)：用于序列化 Aptos 交易数据的格式。

--- a/src/content/docs/zh/build/sdks/go-sdk/building-transactions/batching-transactions.mdx
+++ b/src/content/docs/zh/build/sdks/go-sdk/building-transactions/batching-transactions.mdx
@@ -144,3 +144,7 @@ func main() {
 	example(aptos.DevnetConfig, 100)
 }
 ```
+
+## 已测试示例
+
+请参阅 SDK 仓库中的 [`examples/sending_concurrent_transactions`](https://github.com/aptos-labs/aptos-go-sdk/tree/main/examples/sending_concurrent_transactions)。

--- a/src/content/docs/zh/build/sdks/go-sdk/building-transactions/multi-agent-transactions.mdx
+++ b/src/content/docs/zh/build/sdks/go-sdk/building-transactions/multi-agent-transactions.mdx
@@ -83,6 +83,10 @@ import { Aside, Steps } from '@astrojs/starlight/components';
 
 {/* TODO: Add full code snippet for Go */}
 
+## 已测试示例
+
+请参阅 SDK 仓库中的 [`examples/multi_agent`](https://github.com/aptos-labs/aptos-go-sdk/tree/main/examples/multi_agent)。使用 `go run examples/multi_agent/main.go` 运行。
+
 ## 常见错误
 
 `NUMBER_OF_SIGNER_ARGUMENTS_MISMATCH`：当你尝试为不需要该数量账户的函数进行多代理签名时出现。例如，若尝试为 `0x1::aptos_account::transfer` 函数使用多个签名，由于它只预期一个地址，提供多个地址便会产生错误。

--- a/src/content/docs/zh/build/sdks/go-sdk/building-transactions/orderless-transactions.mdx
+++ b/src/content/docs/zh/build/sdks/go-sdk/building-transactions/orderless-transactions.mdx
@@ -1,0 +1,81 @@
+---
+title: "Go SDK：无序交易"
+description: "使用 Go SDK 的重放保护 nonce 创建可按任意顺序执行的交易"
+sidebar:
+  label: "无序交易"
+---
+
+import { Aside } from '@astrojs/starlight/components';
+
+无序交易允许创建彼此之间不指定执行顺序的交易。这在多台机器需要为同一发送账户签名或提交、但顺序不影响结果的场景中很有用。
+
+协议概览请参阅[无序交易](/zh/build/guides/orderless-transactions)（[AIP-123](https://github.com/aptos-foundation/AIPs/blob/main/aips/aip-123.md) 和 [AIP-129](https://github.com/aptos-foundation/AIPs/blob/main/aips/aip-129.md)）。
+
+## 构建无序交易
+
+将入口函数包装在 `TransactionInnerPayload` 中，并在 `TransactionExtraConfigV1` 上设置 `ReplayProtectionNonce`。使用 `aptos.ExpirationSeconds(60)` 将过期时间限制为 60 秒。
+
+<Aside type="note">
+  每笔交易的 nonce 必须唯一。无序交易在提交后最多 60 秒内过期。若未在该窗口内执行，交易将过期且不会执行。
+</Aside>
+
+```go filename="orderless.go"
+replayNonce := uint64(100)
+accountBytes, err := bcs.Serialize(&bob.Address)
+if err != nil {
+    panic("Failed to serialize bob's address:" + err.Error())
+}
+amountBytes, err := bcs.SerializeU64(TransferAmount)
+if err != nil {
+    panic("Failed to serialize transfer amount:" + err.Error())
+}
+
+rawTxn, err := client.BuildTransaction(
+    alice.AccountAddress(),
+    aptos.TransactionPayload{
+        Payload: &aptos.TransactionInnerPayload{
+            Payload: &aptos.TransactionInnerPayloadV1{
+                Executable: aptos.TransactionExecutable{
+                    Inner: &aptos.EntryFunction{
+                        Module: aptos.ModuleId{
+                            Address: aptos.AccountOne,
+                            Name:    "aptos_account",
+                        },
+                        Function: "transfer",
+                        ArgTypes: []aptos.TypeTag{},
+                        Args:     [][]byte{accountBytes, amountBytes},
+                    },
+                },
+                ExtraConfig: aptos.TransactionExtraConfig{
+                    Inner: &aptos.TransactionExtraConfigV1{
+                        MultisigAddress:       nil,
+                        ReplayProtectionNonce: &replayNonce,
+                    },
+                },
+            },
+        },
+    },
+    aptos.ExpirationSeconds(60),
+)
+```
+
+之后遵循与简单交易相同的步骤：
+
+1. [**模拟**交易（可选）](/zh/build/sdks/go-sdk/building-transactions/simulating-transactions)。
+2. **签名**交易。
+3. **将**交易提交到网络。
+4. **等待**交易执行。
+
+若要跳过手动签名和提交步骤，`BuildSignAndSubmitTransaction` 也接受相同的 inner payload。
+
+## 已测试示例
+
+SDK 仓库包含遵循此 API 的可运行示例：
+
+- [`examples/orderless_transaction`](https://github.com/aptos-labs/aptos-go-sdk/tree/main/examples/orderless_transaction)
+
+运行：
+
+```shellscript filename="Terminal"
+go run examples/orderless_transaction/main.go
+```

--- a/src/content/docs/zh/build/sdks/go-sdk/building-transactions/simulating-transactions.mdx
+++ b/src/content/docs/zh/build/sdks/go-sdk/building-transactions/simulating-transactions.mdx
@@ -121,3 +121,7 @@ func main() {
 
 - [赞助交易](/zh/build/sdks/go-sdk/building-transactions/sponsoring-transactions)
 - [多代理交易](/zh/build/sdks/go-sdk/building-transactions/multi-agent-transactions)
+
+## 已测试示例
+
+请参阅 SDK 仓库中的 [`examples/transfer_coin`](https://github.com/aptos-labs/aptos-go-sdk/tree/main/examples/transfer_coin)，其中包含模拟步骤。

--- a/src/content/docs/zh/build/sdks/go-sdk/building-transactions/sponsoring-transactions.mdx
+++ b/src/content/docs/zh/build/sdks/go-sdk/building-transactions/sponsoring-transactions.mdx
@@ -302,3 +302,7 @@ func main() {
 	example(aptos.DevnetConfig)
 }
 ```
+
+## 已测试示例
+
+请参阅 SDK 仓库中的 [`examples/sponsored_transaction`](https://github.com/aptos-labs/aptos-go-sdk/tree/main/examples/sponsored_transaction)。

--- a/src/content/docs/zh/build/sdks/go-sdk/fetch-data-via-sdk.mdx
+++ b/src/content/docs/zh/build/sdks/go-sdk/fetch-data-via-sdk.mdx
@@ -18,14 +18,24 @@ if err != nil {
 }
 
 address := aptos.AccountAddress{}
-err := address.ParseStringRelaxed("0x123")
+err = address.ParseStringRelaxed("0x123")
 if err != nil {
   panic("Failed to parse address:" + err.Error())
 }
 
 accountInfo, err := client.Account(address)
+if err != nil {
+  panic("Failed to get account:" + err.Error())
+}
 resources, err := client.AccountResources(address)
+if err != nil {
+  panic("Failed to get resources:" + err.Error())
+}
 transactions, err := client.Transactions()
+if err != nil {
+  panic("Failed to get transactions:" + err.Error())
+}
+fmt.Println(accountInfo, resources, len(transactions))
 ```
 
 <Aside type="note">
@@ -47,10 +57,9 @@ transactions, err := client.Transactions()
 	variables := map[string]any{
 		"address": address.StringLong(),
 	}
-	err := ic.Query(&q, variables)
-
+	err = client.QueryIndexer(&q, variables)
 	if err != nil {
-		return nil, err
+		panic("Failed to query indexer:" + err.Error())
 	}
 
 	for _, coin := range q.Current_coin_balances {
@@ -72,12 +81,15 @@ transactions, err := client.Transactions()
 例如，可通过 `chain_id` view 函数查询正在使用的网络：
 
 ```go filename="fetch_data.go"
-viewResponse, err := client.View(&aptos.ViewPayload {
-  Module: aptos.ModuleId{Address: aptos.AccountAddress{}, Name: "chain_id"},
+viewResponse, err := client.View(&aptos.ViewPayload{
+  Module:   aptos.ModuleId{Address: aptos.AccountOne, Name: "chain_id"},
   Function: "get",
   ArgTypes: []aptos.TypeTag{},
-  Args: [][]byte{},
-)
+  Args:     [][]byte{},
+})
+if err != nil {
+  panic("Failed to call view:" + err.Error())
+}
 
 chainId := viewResponse[0]
 ```

--- a/src/content/docs/zh/build/sdks/go-sdk/go-examples.mdx
+++ b/src/content/docs/zh/build/sdks/go-sdk/go-examples.mdx
@@ -5,10 +5,11 @@ sidebar:
   label: "示例"
 ---
 
-import { Steps } from '@astrojs/starlight/components';
+import { Aside, Steps } from '@astrojs/starlight/components';
 
 有关说明如何使用 SDK 核心概念的示例代码，请参阅：
 
+- [快速入门](/zh/build/sdks/go-sdk/quickstart)
 - [获取数据](/zh/build/sdks/go-sdk/fetch-data-via-sdk)
 - [构建、模拟和提交交易](/zh/build/sdks/go-sdk/building-transactions)
 
@@ -16,39 +17,50 @@ import { Steps } from '@astrojs/starlight/components';
 
 ## 代码片段
 
-SDK 仓库中的 [`examples` 文件夹](https://github.com/aptos-labs/aptos-go-sdk/tree/main/examples)包含许多可按需定制的代码片段。
+SDK 仓库中的 [`examples` 文件夹](https://github.com/aptos-labs/aptos-go-sdk/tree/main/examples)包含许多可按需定制的代码片段。这些示例属于 SDK 的 CI 范围。
+
+| 示例                                | 说明                |
+| --------------------------------- | ----------------- |
+| `transfer_coin`                   | 两个账户之间的基本 APT 转账  |
+| `orderless_transaction`           | 带重放保护 nonce 的无序转账 |
+| `sponsored_transaction`           | 由费用支付方赞助的交易       |
+| `multi_agent`                     | 带有两个签名人的多代理交易     |
+| `sending_concurrent_transactions` | 从同一账户并发提交         |
+| `fungible_asset`                  | 同质化资产转账           |
+| `onchain_multisig`                | 链上多签账户流程          |
+| `offchain_multisig`               | 链下多签              |
+| `script_transaction`              | Script payload 构造 |
+| `alternative_signing`             | 自定义 / 替代签名器       |
+| `external_signing`                | 使用外部签名器签名         |
+
+<Aside type="note">
+  请优先使用这些仓库示例，而不是复制旧博客中的片段。Go SDK 会跟踪当前链上交易 payload 格式，包括无序 inner payload。
+</Aside>
 
 ### 如何运行示例
 
 要运行其中一个示例脚本：
 
 <Steps>
-  1. 克隆仓库
+  1. 克隆仓库。
 
      ```shellscript filename="Terminal"
      git clone https://github.com/aptos-labs/aptos-go-sdk.git
+     cd aptos-go-sdk
      ```
 
-  2. 在包的顶层目录安装所有依赖。
-
-     ```shellscript filename="Terminal"
-     go install
-     ```
-
-  3. 构建包。
-
-     ```shellscript filename="Terminal"
-     go build ./...
-     ```
-
-  4. 运行示例
+  2. 从仓库根目录运行示例。Go 会自动下载模块依赖。
 
      ```shellscript filename="Terminal"
      go run examples/transfer_coin/main.go
      ```
 </Steps>
 
+该 SDK 需要 **Go 1.25+**。
+
 ## 有用的参考代码
 
+- [集成测试](https://github.com/aptos-labs/aptos-go-sdk/tree/main/integration_test) - 针对实时网络使用 SDK 的更广泛流程。
+- [包测试](https://github.com/aptos-labs/aptos-go-sdk) - 实现旁边的 `*_test.go` 文件。
 - [SDK 源代码](https://github.com/aptos-labs/aptos-go-sdk/tree/main)：包含解释每个函数用途的内联注释。
 - [SDK 参考文档](https://pkg.go.dev/github.com/aptos-labs/aptos-go-sdk)：以带内置搜索的形式查看内联文档的另一种方式。

--- a/src/content/docs/zh/build/sdks/go-sdk/quickstart.mdx
+++ b/src/content/docs/zh/build/sdks/go-sdk/quickstart.mdx
@@ -1,0 +1,209 @@
+---
+title: "Go SDK 快速入门"
+description: "使用 Aptos Go SDK 创建账户、为账户注资并转移 APT"
+sidebar:
+  label: "Go SDK 快速入门"
+---
+
+import { Aside, Steps } from '@astrojs/starlight/components';
+
+<Aside type="note">
+  完整示例见页面底部的[完整快速入门代码](#full-quickstart-code)。流程与 SDK 仓库中的
+  [`examples/transfer_coin`](https://github.com/aptos-labs/aptos-go-sdk/tree/main/examples/transfer_coin)
+  相同。
+</Aside>
+
+<Steps>
+  1. 安装 Go SDK
+
+     该 SDK 需要 **Go 1.25+**。
+
+     ```shellscript filename="Terminal"
+     mkdir aptos-go-quickstart
+     cd aptos-go-quickstart
+     go mod init example/aptos-go-quickstart
+     go get github.com/aptos-labs/aptos-go-sdk
+     ```
+
+  2. 设置 Aptos 客户端
+
+     ```go filename="quickstart.go"
+     client, err := aptos.NewClient(aptos.DevnetConfig)
+     if err != nil {
+         panic("Failed to create client:" + err.Error())
+     }
+     ```
+
+     <Aside type="note">
+       （进阶）若要连接特定节点，请使用自定义 `NodeUrl` 构造 `aptos.NetworkConfig`。
+     </Aside>
+
+  3. 创建并为账户注资
+
+     `NewEd25519Account` 会同时返回账户和 error。
+
+     ```go filename="quickstart.go"
+     alice, err := aptos.NewEd25519Account()
+     if err != nil {
+         panic("Failed to create alice:" + err.Error())
+     }
+     bob, err := aptos.NewEd25519Account()
+     if err != nil {
+         panic("Failed to create bob:" + err.Error())
+     }
+
+     err = client.Fund(alice.Address, 1_000_000_000)
+     if err != nil {
+         panic("Failed to fund alice:" + err.Error())
+     }
+     ```
+
+     在 testnet 上，请从[水龙头页面](/zh/network/faucet)铸造。
+
+  4. 转移 APT
+
+     构建 `aptos_account::transfer` payload，然后签名、提交并等待。
+     `BuildSignAndSubmitTransaction` 会合并这些步骤。
+
+     ```go filename="quickstart.go"
+     accountBytes, err := bcs.Serialize(&bob.Address)
+     amountBytes, err := bcs.SerializeU64(1_000)
+     resp, err := client.BuildSignAndSubmitTransaction(alice, aptos.TransactionPayload{
+         Payload: &aptos.EntryFunction{
+             Module: aptos.ModuleId{
+                 Address: aptos.AccountOne,
+                 Name:    "aptos_account",
+             },
+             Function: "transfer",
+             ArgTypes: []aptos.TypeTag{},
+             Args:     [][]byte{accountBytes, amountBytes},
+         },
+     })
+     _, err = client.WaitForTransaction(resp.Hash)
+     ```
+
+     有关更底层的构建 → 模拟 → 签名 → 提交 → 等待流程，请参阅
+     [构建交易](/zh/build/sdks/go-sdk/building-transactions)。
+</Steps>
+
+## 完整快速入门代码
+
+```go filename="quickstart.go"
+package main
+
+import (
+	"fmt"
+
+	"github.com/aptos-labs/aptos-go-sdk"
+	"github.com/aptos-labs/aptos-go-sdk/bcs"
+)
+
+const (
+	FundAmount     = 1_000_000_000
+	TransferAmount = 1_000
+)
+
+func main() {
+	client, err := aptos.NewClient(aptos.DevnetConfig)
+	if err != nil {
+		panic("Failed to create client:" + err.Error())
+	}
+
+	alice, err := aptos.NewEd25519Account()
+	if err != nil {
+		panic("Failed to create alice:" + err.Error())
+	}
+	bob, err := aptos.NewEd25519Account()
+	if err != nil {
+		panic("Failed to create bob:" + err.Error())
+	}
+
+	fmt.Printf("=== Addresses ===\n")
+	fmt.Printf("Alice: %s\n", alice.Address.String())
+	fmt.Printf("Bob:   %s\n", bob.Address.String())
+
+	err = client.Fund(alice.Address, FundAmount)
+	if err != nil {
+		panic("Failed to fund alice:" + err.Error())
+	}
+
+	aliceBalance, err := client.AccountAPTBalance(alice.Address)
+	if err != nil {
+		panic("Failed to retrieve alice balance:" + err.Error())
+	}
+	bobBalance, err := client.AccountAPTBalance(bob.Address)
+	if err != nil {
+		panic("Failed to retrieve bob balance:" + err.Error())
+	}
+	fmt.Printf("=== Initial Balances ===\n")
+	fmt.Printf("Alice: %d\n", aliceBalance)
+	fmt.Printf("Bob:   %d\n", bobBalance)
+
+	accountBytes, err := bcs.Serialize(&bob.Address)
+	if err != nil {
+		panic("Failed to serialize bob's address:" + err.Error())
+	}
+	amountBytes, err := bcs.SerializeU64(TransferAmount)
+	if err != nil {
+		panic("Failed to serialize transfer amount:" + err.Error())
+	}
+
+	resp, err := client.BuildSignAndSubmitTransaction(alice, aptos.TransactionPayload{
+		Payload: &aptos.EntryFunction{
+			Module: aptos.ModuleId{
+				Address: aptos.AccountOne,
+				Name:    "aptos_account",
+			},
+			Function: "transfer",
+			ArgTypes: []aptos.TypeTag{},
+			Args: [][]byte{
+				accountBytes,
+				amountBytes,
+			},
+		},
+	})
+	if err != nil {
+		panic("Failed to submit transaction:" + err.Error())
+	}
+
+	_, err = client.WaitForTransaction(resp.Hash)
+	if err != nil {
+		panic("Failed to wait for transaction:" + err.Error())
+	}
+
+	aliceBalance, err = client.AccountAPTBalance(alice.Address)
+	if err != nil {
+		panic("Failed to retrieve alice balance:" + err.Error())
+	}
+	bobBalance, err = client.AccountAPTBalance(bob.Address)
+	if err != nil {
+		panic("Failed to retrieve bob balance:" + err.Error())
+	}
+	fmt.Printf("=== Final Balances ===\n")
+	fmt.Printf("Alice: %d\n", aliceBalance)
+	fmt.Printf("Bob:   %d\n", bobBalance)
+	fmt.Printf("See txn: https://explorer.aptoslabs.com/txn/%s?network=devnet\n", resp.Hash)
+}
+```
+
+运行：
+
+```shellscript filename="Terminal"
+go run quickstart.go
+```
+
+## 总结
+
+你刚刚学习了如何通过以下步骤转移 APT：
+
+1. 使用 `aptos.NewClient` 连接网络。
+2. 创建并为账户注资。
+3. 提交转账并等待执行。
+
+<Aside type="note">
+  建议收藏 SDK 仓库中的
+  [示例](https://github.com/aptos-labs/aptos-go-sdk/tree/main/examples)
+  和 [集成测试](https://github.com/aptos-labs/aptos-go-sdk/tree/main/integration_test)。
+  这些套件是本文档所示 API 的权威来源。生成的 API 文档位于
+  [pkg.go.dev](https://pkg.go.dev/github.com/aptos-labs/aptos-go-sdk)。
+</Aside>

--- a/src/content/docs/zh/build/sdks/python-sdk.mdx
+++ b/src/content/docs/zh/build/sdks/python-sdk.mdx
@@ -7,6 +7,24 @@ sidebar:
 
 import { Aside, CardGrid, LinkCard } from '@astrojs/starlight/components';
 
+import { RemoteCodeblock } from '~/components/RemoteCodeblock';
+
+<div className="flex gap-2 mt-6 flex-wrap">
+  <a target="_blank" href="https://github.com/aptos-labs/aptos-python-sdk">
+    ![Github Repo Stars](https://img.shields.io/github/stars/aptos-labs/aptos-python-sdk)
+  </a>
+
+  <a target="_blank" href="https://pypi.org/project/aptos-sdk/">
+    ![PyPI Version](https://img.shields.io/pypi/v/aptos-sdk)
+  </a>
+
+  <a target="_blank" href="https://pypi.org/project/aptos-sdk/">
+    ![Python Version](https://img.shields.io/pypi/pyversions/aptos-sdk)
+  </a>
+</div>
+
+Python SDK 可让你连接、探索并与 Aptos 区块链交互。你可以用它请求数据、发送交易、设置测试环境等。
+
 ## 安装 Python SDK
 
 Aptos 在 [PyPI](https://pypi.org/project/aptos-sdk/) 上提供官方 Python SDK，源代码位于
@@ -34,12 +52,26 @@ pip install .
   [v1 到 v2 迁移指南](https://github.com/aptos-labs/aptos-python-sdk/blob/main/MIGRATION.md)。
 </Aside>
 
-## 使用方式
+## 示例
 
 <CardGrid>
-  <LinkCard href="/zh/build/sdks/python-sdk/fetch-data-via-sdk" title="获取数据" description="了解如何使用 Python SDK 获取数据" />
+  <LinkCard href="/zh/build/sdks/python-sdk/quickstart" title="快速入门" description="几分钟内在 Devnet 上完成一笔可运行的转账" />
 
-  <LinkCard href="/zh/build/sdks/python-sdk/building-transactions" title="提交交易" description="了解如何使用 Python SDK 提交交易" />
+  <LinkCard href="/zh/build/sdks/python-sdk/account" title="账户" description="生成、恢复并为账户注资" />
 
-  <LinkCard href="/zh/build/sdks/python-sdk/python-examples" title="示例" description="浏览 SDK 提供的 Python 示例" />
+  <LinkCard href="/zh/build/sdks/python-sdk/fetch-data-via-sdk" title="获取数据" description="读取账本、账户和 View 函数数据" />
+
+  <LinkCard href="/zh/build/sdks/python-sdk/building-transactions" title="提交交易" description="构建、模拟、签名并提交交易" />
+
+  <LinkCard href="/zh/build/sdks/python-sdk/python-examples" title="示例" description="SDK 仓库中的可运行示例目录" />
+
+  <LinkCard href="https://github.com/aptos-labs/aptos-python-sdk/tree/main/v2/tests" title="测试" description="覆盖 v2 API 的单元测试和集成测试" target="_blank" />
 </CardGrid>
+
+### 来自已测试示例套件的 APT 转账
+
+以下片段取自 SDK 仓库中的
+[`v2/examples/transfer_apt.py`](https://github.com/aptos-labs/aptos-python-sdk/blob/main/v2/examples/transfer_apt.py)。
+从 PyPI 安装时，请从 `aptos_sdk.v2` 导入相同 API，而不是 `aptos_sdk_v2`。
+
+<RemoteCodeblock permalink="https://github.com/aptos-labs/aptos-python-sdk/blob/8480dca2804fb042ef8392f2ad5950a771ca9b8f/v2/examples/transfer_apt.py#L31-L36" />

--- a/src/content/docs/zh/build/sdks/python-sdk/building-transactions.mdx
+++ b/src/content/docs/zh/build/sdks/python-sdk/building-transactions.mdx
@@ -186,6 +186,7 @@ asyncio.run(main())
 交易还有一些额外功能，可按需使用：
 
 1. [多代理签名](/zh/build/sdks/python-sdk/building-transactions/multi-agent-transactions) - 允许将多个账户用于单个合约。
-2. [赞助交易](/zh/build/sdks/python-sdk/building-transactions/sponsoring-transactions) - 由另一账户支付此交易的 Gas 费用。
-3. [批量提交交易](/zh/build/sdks/python-sdk/building-transactions/batching-transactions) - 如何从同一账户快速发送多笔交易。
-4. [二进制规范序列化（BCS）](/zh/build/sdks/python-sdk/building-transactions/bcs-format) - 用于序列化 Aptos 交易数据的格式。
+2. [无序交易](/zh/build/sdks/python-sdk/building-transactions/orderless-transactions) - 允许交易无序执行，便于管理。
+3. [赞助交易](/zh/build/sdks/python-sdk/building-transactions/sponsoring-transactions) - 由另一账户支付此交易的 Gas 费用。
+4. [批量提交交易](/zh/build/sdks/python-sdk/building-transactions/batching-transactions) - 如何从同一账户快速发送多笔交易。
+5. [二进制规范序列化（BCS）](/zh/build/sdks/python-sdk/building-transactions/bcs-format) - 用于序列化 Aptos 交易数据的格式。

--- a/src/content/docs/zh/build/sdks/python-sdk/building-transactions/batching-transactions.mdx
+++ b/src/content/docs/zh/build/sdks/python-sdk/building-transactions/batching-transactions.mdx
@@ -5,7 +5,7 @@ sidebar:
   label: "批量交易"
 ---
 
-Python SDK 可通过[无序交易](/zh/build/guides/orderless-transactions)从同一账户并发提交多笔交易。每笔交易携带唯一的重放保护 nonce，而不是序列号，因此无需在本地协调序列号。
+Python SDK 可通过[无序交易](/zh/build/sdks/python-sdk/building-transactions/orderless-transactions)从同一账户并发提交多笔交易。每笔交易携带唯一的重放保护 nonce，而不是序列号，因此无需在本地协调序列号。
 
 向 `aptos.transaction.build` 传入 `replay_protection_nonce`。无序交易必须在 60 秒内过期。
 
@@ -72,3 +72,7 @@ asyncio.run(main())
 ```
 
 v1 API 还包含用于序列号批处理的 `TransactionWorker`。新项目应使用上面的 v2 无序流程。
+
+## 已测试示例
+
+请参阅 SDK 仓库中的 [`batch_orderless_transfers.py`](https://github.com/aptos-labs/aptos-python-sdk/blob/main/v2/examples/batch_orderless_transfers.py)。

--- a/src/content/docs/zh/build/sdks/python-sdk/building-transactions/multi-agent-transactions.mdx
+++ b/src/content/docs/zh/build/sdks/python-sdk/building-transactions/multi-agent-transactions.mdx
@@ -130,3 +130,7 @@ asyncio.run(main())
 ## 常见错误
 
 `NUMBER_OF_SIGNER_ARGUMENTS_MISMATCH` - 当尝试为不需要该数量账户的函数进行多代理签名时会出现此错误。例如，若对 `0x1::aptos_account::transfer` 使用多个签名，该函数只期望一个地址，因此提供多个时会报错。
+
+## 已测试示例
+
+请参阅 SDK 仓库中的 [`multi_agent_transfer.py`](https://github.com/aptos-labs/aptos-python-sdk/blob/main/v2/examples/multi_agent_transfer.py)。

--- a/src/content/docs/zh/build/sdks/python-sdk/building-transactions/orderless-transactions.mdx
+++ b/src/content/docs/zh/build/sdks/python-sdk/building-transactions/orderless-transactions.mdx
@@ -1,0 +1,64 @@
+---
+title: "Python SDK：无序交易"
+description: "使用 Python SDK 的重放保护 nonce 创建可按任意顺序执行的交易"
+sidebar:
+  label: "无序交易"
+---
+
+import { Aside } from '@astrojs/starlight/components';
+
+无序交易允许创建彼此之间不指定执行顺序的交易。这在多台机器需要为同一发送账户签名或提交、但顺序不影响结果的场景中很有用。
+
+协议概览请参阅[无序交易](/zh/build/guides/orderless-transactions)（[AIP-123](https://github.com/aptos-foundation/AIPs/blob/main/aips/aip-123.md) 和 [AIP-129](https://github.com/aptos-foundation/AIPs/blob/main/aips/aip-129.md)）。
+
+## 构建无序交易
+
+创建和执行无序交易的流程与[简单交易流程](/zh/build/sdks/python-sdk/building-transactions)相同。向 `aptos.transaction.build` 传入 `replay_protection_nonce`，而不是依赖序列号。
+
+<Aside type="note">
+  每笔交易的 nonce 必须唯一。无序交易在提交后最多 60 秒内过期。若未在该窗口内执行，交易将过期且不会执行。
+</Aside>
+
+```python filename="orderless.py"
+import random
+import time
+
+from aptos_sdk.v2.bcs import Serializer
+from aptos_sdk.v2.transactions import EntryFunction, TransactionArgument, TransactionPayload
+from aptos_sdk.v2.types import StructTag, TypeTag
+
+payload = EntryFunction.natural(
+    "0x1::coin",
+    "transfer",
+    [TypeTag(StructTag.from_str("0x1::aptos_coin::AptosCoin"))],
+    [
+        TransactionArgument(bob.address, Serializer.struct),
+        TransactionArgument(1_000, Serializer.u64),
+    ],
+)
+raw_txn = await aptos.transaction.build(
+    sender=alice.address,
+    payload=TransactionPayload(payload),
+    replay_protection_nonce=random.randint(0, 2**64 - 1),
+    expiration_timestamps_secs=int(time.time()) + 60,
+)
+result = await aptos.transaction.sign_submit_and_wait(raw_txn, alice)
+```
+
+之后遵循与简单交易相同的步骤：
+
+1. [**模拟**交易（可选）](/zh/build/sdks/python-sdk/building-transactions/simulating-transactions)。
+2. **签名**交易。
+3. **将**交易提交到网络。
+4. **等待**交易执行。
+
+要并行发送多笔无序转账，请参阅[批量提交交易](/zh/build/sdks/python-sdk/building-transactions/batching-transactions)。
+
+## 已测试示例
+
+SDK 仓库包含遵循此 API 的可运行示例：
+
+- [`orderless_transfer.py`](https://github.com/aptos-labs/aptos-python-sdk/blob/main/v2/examples/orderless_transfer.py)
+- [`batch_orderless_transfers.py`](https://github.com/aptos-labs/aptos-python-sdk/blob/main/v2/examples/batch_orderless_transfers.py)
+
+克隆仓库时，这些文件会导入 `aptos_sdk_v2`。执行 `pip install aptos-sdk` 后，请从 `aptos_sdk.v2` 导入相同 API。

--- a/src/content/docs/zh/build/sdks/python-sdk/building-transactions/simulating-transactions.mdx
+++ b/src/content/docs/zh/build/sdks/python-sdk/building-transactions/simulating-transactions.mdx
@@ -55,3 +55,7 @@ asyncio.run(main())
 
 - [Sponsored Transactions](/zh/build/sdks/python-sdk/building-transactions/sponsoring-transactions)
 - [Multi-Agent Transactions](/zh/build/sdks/python-sdk/building-transactions/multi-agent-transactions)
+
+## 已测试示例
+
+请参阅 SDK 仓库中的 [`simulate_transaction.py`](https://github.com/aptos-labs/aptos-python-sdk/blob/main/v2/examples/simulate_transaction.py)。

--- a/src/content/docs/zh/build/sdks/python-sdk/building-transactions/sponsoring-transactions.mdx
+++ b/src/content/docs/zh/build/sdks/python-sdk/building-transactions/sponsoring-transactions.mdx
@@ -119,3 +119,7 @@ async def main():
 
 asyncio.run(main())
 ```
+
+## 已测试示例
+
+请参阅 SDK 仓库中的 [`sponsored_transaction.py`](https://github.com/aptos-labs/aptos-python-sdk/blob/main/v2/examples/sponsored_transaction.py)。

--- a/src/content/docs/zh/build/sdks/python-sdk/fetch-data-via-sdk.mdx
+++ b/src/content/docs/zh/build/sdks/python-sdk/fetch-data-via-sdk.mdx
@@ -65,3 +65,7 @@ timestamp = await aptos.general.view_bcs(
 ## Indexer 查询
 
 同一软件包中的 v1 `IndexerClient` 支持 GraphQL Indexer 查询。v2 客户端与全节点 REST API 通信。如果需要聚合后的 Indexer 数据，请使用 `aptos_sdk.async_client.IndexerClient`，或直接查询 [Indexer API](/zh/build/indexer)。
+
+## 已测试示例
+
+请参阅 SDK 仓库中的 [`fetch_on_chain_data.py`](https://github.com/aptos-labs/aptos-python-sdk/blob/main/v2/examples/fetch_on_chain_data.py)。

--- a/src/content/docs/zh/build/sdks/python-sdk/python-examples.mdx
+++ b/src/content/docs/zh/build/sdks/python-sdk/python-examples.mdx
@@ -9,6 +9,7 @@ import { Steps } from '@astrojs/starlight/components';
 
 有关说明如何使用 SDK 核心概念的示例代码，请参阅：
 
+- [快速入门](/zh/build/sdks/python-sdk/quickstart)
 - [获取数据](/zh/build/sdks/python-sdk/fetch-data-via-sdk)
 - [构建、模拟和提交交易](/zh/build/sdks/python-sdk/building-transactions)
 
@@ -63,5 +64,6 @@ v1 示例如 `transfer_coin.py` 和 `fee_payer_transfer_coin.py` 位于顶层 [`
 
 ## 有用的参考代码
 
+- [v2 测试](https://github.com/aptos-labs/aptos-python-sdk/tree/main/v2/tests) - 覆盖 v2 API 的单元测试和集成测试。
 - [SDK 源代码](https://github.com/aptos-labs/aptos-python-sdk) - 内含解释每个函数作用的行内注释。
 - [v1 到 v2 迁移指南](https://github.com/aptos-labs/aptos-python-sdk/blob/main/MIGRATION.md) - 现有 v1 代码的 API 映射。

--- a/src/content/docs/zh/build/sdks/python-sdk/python-examples.mdx
+++ b/src/content/docs/zh/build/sdks/python-sdk/python-examples.mdx
@@ -5,7 +5,7 @@ sidebar:
   label: "示例"
 ---
 
-import { Steps } from '@astrojs/starlight/components';
+import { Aside, Steps } from '@astrojs/starlight/components';
 
 有关说明如何使用 SDK 核心概念的示例代码，请参阅：
 
@@ -34,7 +34,12 @@ SDK 仓库中的 [`v2/examples` 文件夹](https://github.com/aptos-labs/aptos-p
 | `custom_coin_fungible_asset.py` | Coin API 与 Fungible Asset API |
 | `script_transaction.py`         | Script payload 构造             |
 
-v1 示例如 `transfer_coin.py` 和 `fee_payer_transfer_coin.py` 位于顶层 [`examples` 文件夹](https://github.com/aptos-labs/aptos-python-sdk/tree/main/examples)。
+v1 示例如 `transfer_coin.py` 和 `fee_payer_transfer_coin.py` 位于顶层 [`examples` 文件夹](https://github.com/aptos-labs/aptos-python-sdk/tree/main/examples)。新项目应使用 v2 示例。
+
+<Aside type="note">
+  请优先使用这些仓库示例，而不是复制旧博客中的代码片段。Python SDK v2 API
+  是受支持的接口，examples 文件夹会跟踪当前 API。
+</Aside>
 
 ### 如何运行示例
 

--- a/src/content/docs/zh/build/sdks/python-sdk/quickstart.mdx
+++ b/src/content/docs/zh/build/sdks/python-sdk/quickstart.mdx
@@ -1,0 +1,148 @@
+---
+title: "Python SDK 快速入门"
+description: "使用 Aptos Python SDK 创建账户、为账户注资并转移 APT"
+sidebar:
+  label: "Python SDK 快速入门"
+---
+
+import { Aside, Steps } from '@astrojs/starlight/components';
+
+<Aside type="note">
+  完整示例见页面底部的[完整快速入门代码](#full-quickstart-code)。流程与 SDK 仓库中的
+  [`transfer_apt.py`](https://github.com/aptos-labs/aptos-python-sdk/blob/main/v2/examples/transfer_apt.py)
+  相同。
+</Aside>
+
+<Steps>
+  1. 安装 Python SDK
+
+     该 SDK 需要 **Python 3.12+**。
+
+     ```shellscript filename="Terminal"
+     pip install aptos-sdk
+     ```
+
+  2. 创建项目文件
+
+     ```shellscript filename="Terminal"
+     mkdir aptos-python-quickstart
+     cd aptos-python-quickstart
+     touch quickstart.py
+     ```
+
+  3. 设置 Aptos 客户端
+
+     使用 v2 API（`aptos_sdk.v2`）。创建客户端后即会建立连接。
+
+     ```python filename="quickstart.py"
+     import asyncio
+
+     from aptos_sdk.v2 import Account, Aptos, AptosConfig, Network
+
+     async def main():
+         async with Aptos(AptosConfig(network=Network.DEVNET)) as aptos:
+             print("Connected to Aptos devnet")
+
+     asyncio.run(main())
+     ```
+
+     <Aside type="note">
+       （进阶）若要连接特定节点，可在构造 `AptosConfig` 时传入自定义全节点 URL。
+     </Aside>
+
+  4. 创建并为账户注资
+
+     先生成凭据，再为账户注资，网络才会识别其存在。在 localnet 和 devnet 上可使用水龙头。
+
+     ```python filename="quickstart.py"
+     alice = Account.generate()
+     bob = Account.generate()
+
+     await aptos.faucet.fund_account(alice.address, 100_000_000)
+     await aptos.faucet.fund_account(bob.address, 10_000_000)
+     ```
+
+     在 testnet 上，请从[水龙头页面](/zh/network/faucet)铸造。
+
+  5. 转移 APT
+
+     `aptos.coin.transfer` 会构建、签名并提交 APT 转账。随后等待交易上链。
+
+     ```python filename="quickstart.py"
+     txn_hash = await aptos.coin.transfer(alice, bob.address, 1_000)
+     result = await aptos.transaction.wait_for_transaction(txn_hash)
+     print(f"Success: {result['success']}")
+     ```
+
+     有关更底层的构建 → 模拟 → 签名 → 提交 → 等待流程，请参阅
+     [构建交易](/zh/build/sdks/python-sdk/building-transactions)。
+</Steps>
+
+## 完整快速入门代码
+
+```python filename="quickstart.py"
+"""Create two accounts, fund them, and transfer APT on devnet."""
+
+import asyncio
+
+from aptos_sdk.v2 import Account, Aptos, AptosConfig, Network
+
+ALICE_INITIAL_BALANCE = 100_000_000
+BOB_INITIAL_BALANCE = 10_000_000
+TRANSFER_AMOUNT = 1_000
+
+
+async def main():
+    async with Aptos(AptosConfig(network=Network.DEVNET)) as aptos:
+        alice = Account.generate()
+        bob = Account.generate()
+
+        print("=== Addresses ===")
+        print(f"Alice: {alice.address}")
+        print(f"Bob:   {bob.address}")
+
+        await asyncio.gather(
+            aptos.faucet.fund_account(alice.address, ALICE_INITIAL_BALANCE),
+            aptos.faucet.fund_account(bob.address, BOB_INITIAL_BALANCE),
+        )
+
+        print("=== Initial Balances ===")
+        print(f"Alice: {await aptos.coin.balance(alice.address)}")
+        print(f"Bob:   {await aptos.coin.balance(bob.address)}")
+
+        txn_hash = await aptos.coin.transfer(alice, bob.address, TRANSFER_AMOUNT)
+        result = await aptos.transaction.wait_for_transaction(txn_hash)
+        print(f"Transaction: {txn_hash}")
+        print(f"Success: {result['success']}")
+
+        print("=== Final Balances ===")
+        print(f"Alice: {await aptos.coin.balance(alice.address)}")
+        print(f"Bob:   {await aptos.coin.balance(bob.address)}")
+
+
+asyncio.run(main())
+```
+
+运行：
+
+```shellscript filename="Terminal"
+python quickstart.py
+```
+
+## 总结
+
+你刚刚学习了如何通过以下步骤转移 APT：
+
+1. 使用 `Aptos` 客户端连接网络。
+2. 创建并为账户注资。
+3. 提交转账并等待执行。
+
+<Aside type="note">
+  建议收藏 SDK 仓库中的
+  [v2 示例](https://github.com/aptos-labs/aptos-python-sdk/tree/main/v2/examples)
+  和 [v2 测试](https://github.com/aptos-labs/aptos-python-sdk/tree/main/v2/tests)。
+  这些套件是本文档所示 API 的权威来源。
+
+  克隆 SDK 仓库时，示例会导入 `aptos_sdk_v2`。执行 `pip install aptos-sdk` 后，
+  请从 `aptos_sdk.v2` 导入相同 API。
+</Aside>

--- a/src/content/docs/zh/build/sdks/rust-sdk.mdx
+++ b/src/content/docs/zh/build/sdks/rust-sdk.mdx
@@ -7,6 +7,24 @@ sidebar:
 
 import { Aside, CardGrid, LinkCard } from '@astrojs/starlight/components';
 
+import { RemoteCodeblock } from '~/components/RemoteCodeblock';
+
+<div className="flex gap-2 mt-6 flex-wrap">
+  <a target="_blank" href="https://github.com/aptos-labs/aptos-rust-sdk">
+    ![Github Repo Stars](https://img.shields.io/github/stars/aptos-labs/aptos-rust-sdk)
+  </a>
+
+  <a target="_blank" href="https://crates.io/crates/aptos-sdk">
+    ![Crates.io Version](https://img.shields.io/crates/v/aptos-sdk)
+  </a>
+
+  <a target="_blank" href="https://docs.rs/aptos-sdk">
+    ![docs.rs](https://img.shields.io/docsrs/aptos-sdk)
+  </a>
+</div>
+
+Rust SDK 可让你连接、探索并与 Aptos 区块链交互。你可以用它请求数据、发送交易、设置测试环境等。
+
 ## 安装 Rust SDK
 
 Aptos 在 [aptos-rust-sdk GitHub](https://github.com/aptos-labs/aptos-rust-sdk)
@@ -57,12 +75,26 @@ git 补丁，也不需要 `.cargo/config.toml` 中的 `tokio_unstable` 标志。
 aptos-sdk = { version = "0.7", default-features = false, features = ["ed25519"] }
 ```
 
-## 使用方式
+## 示例
 
 <CardGrid>
-  <LinkCard href="/zh/build/sdks/rust-sdk/fetch-data-via-sdk" title="获取数据" description="了解如何使用 Rust SDK 获取数据" />
+  <LinkCard href="/zh/build/sdks/rust-sdk/quickstart" title="快速入门" description="几分钟内在 Devnet 上完成一笔可运行的转账" />
 
-  <LinkCard href="/zh/build/sdks/rust-sdk/building-transactions" title="提交交易" description="了解如何使用 Rust SDK 提交交易" />
+  <LinkCard href="/zh/build/sdks/rust-sdk/account" title="账户" description="生成、恢复并为账户注资" />
 
-  <LinkCard href="/zh/build/sdks/rust-sdk/rust-examples" title="示例" description="浏览 SDK 提供的 Rust 示例" />
+  <LinkCard href="/zh/build/sdks/rust-sdk/fetch-data-via-sdk" title="获取数据" description="读取账本、账户和 View 函数数据" />
+
+  <LinkCard href="/zh/build/sdks/rust-sdk/building-transactions" title="提交交易" description="构建、模拟、签名并提交交易" />
+
+  <LinkCard href="/zh/build/sdks/rust-sdk/rust-examples" title="示例" description="SDK 仓库中的可运行示例目录" />
+
+  <LinkCard href="https://github.com/aptos-labs/aptos-rust-sdk/tree/main/crates/aptos-sdk/tests" title="测试" description="覆盖 SDK API 的 crate 测试" target="_blank" />
 </CardGrid>
+
+### 来自已测试示例套件的 APT 转账
+
+以下片段取自 SDK 仓库中的
+[`transfer.rs`](https://github.com/aptos-labs/aptos-rust-sdk/blob/main/crates/aptos-sdk/examples/transfer.rs)。
+注资金额应明显高于转账金额：默认 `max_gas_amount` 为 `2_000_000`。
+
+<RemoteCodeblock permalink="https://github.com/aptos-labs/aptos-rust-sdk/blob/2a33e9aa8c0134f39671adfced5cf7263be2e1f2/crates/aptos-sdk/examples/transfer.rs#L38-L42" />

--- a/src/content/docs/zh/build/sdks/rust-sdk/building-transactions.mdx
+++ b/src/content/docs/zh/build/sdks/rust-sdk/building-transactions.mdx
@@ -173,6 +173,7 @@ async fn main() -> anyhow::Result<()> {
 交易还有一些额外功能，可按需使用：
 
 1. [多代理签名](/zh/build/sdks/rust-sdk/building-transactions/multi-agent-transactions) - 允许将多个账户用于单个合约。
-2. [赞助交易](/zh/build/sdks/rust-sdk/building-transactions/sponsoring-transactions) - 由另一账户支付此交易的 Gas 费用。
-3. [批量提交交易](/zh/build/sdks/rust-sdk/building-transactions/batching-transactions) - 如何从同一账户快速发送多笔交易。
-4. [二进制规范序列化（BCS）](/zh/build/sdks/rust-sdk/building-transactions/bcs-format) - 用于序列化 Aptos 交易数据的格式。
+2. [无序交易](/zh/build/sdks/rust-sdk/building-transactions/orderless-transactions) - 允许交易无序执行，便于管理。
+3. [赞助交易](/zh/build/sdks/rust-sdk/building-transactions/sponsoring-transactions) - 由另一账户支付此交易的 Gas 费用。
+4. [批量提交交易](/zh/build/sdks/rust-sdk/building-transactions/batching-transactions) - 如何从同一账户快速发送多笔交易。
+5. [二进制规范序列化（BCS）](/zh/build/sdks/rust-sdk/building-transactions/bcs-format) - 用于序列化 Aptos 交易数据的格式。

--- a/src/content/docs/zh/build/sdks/rust-sdk/building-transactions/batching-transactions.mdx
+++ b/src/content/docs/zh/build/sdks/rust-sdk/building-transactions/batching-transactions.mdx
@@ -49,3 +49,7 @@ let results = aptos
     .submit_batch_and_wait(&sender, vec![payload1, payload2, payload3], None)
     .await?;
 ```
+
+## 已测试示例
+
+请参阅 SDK 仓库中的 [`advanced_transactions.rs`](https://github.com/aptos-labs/aptos-rust-sdk/blob/main/crates/aptos-sdk/examples/advanced_transactions.rs)，其中包含更多批处理模式。

--- a/src/content/docs/zh/build/sdks/rust-sdk/building-transactions/multi-agent-transactions.mdx
+++ b/src/content/docs/zh/build/sdks/rust-sdk/building-transactions/multi-agent-transactions.mdx
@@ -126,3 +126,7 @@ async fn main() -> anyhow::Result<()> {
 ## 常见错误
 
 `NUMBER_OF_SIGNER_ARGUMENTS_MISMATCH` - 当尝试为不需要该数量账户的函数进行多代理签名时会出现此错误。例如，若对 `0x1::aptos_account::transfer` 使用多个签名，该函数只期望一个地址，因此提供多个时会报错。
+
+## 已测试示例
+
+请参阅 SDK 仓库中的 [`multi_agent.rs`](https://github.com/aptos-labs/aptos-rust-sdk/blob/main/crates/aptos-sdk/examples/multi_agent.rs)。

--- a/src/content/docs/zh/build/sdks/rust-sdk/building-transactions/orderless-transactions.mdx
+++ b/src/content/docs/zh/build/sdks/rust-sdk/building-transactions/orderless-transactions.mdx
@@ -1,0 +1,49 @@
+---
+title: "Rust SDK：无序交易"
+description: "使用 Rust SDK 的重放保护 nonce 创建可按任意顺序执行的交易"
+sidebar:
+  label: "无序交易"
+---
+
+import { Aside } from '@astrojs/starlight/components';
+
+无序交易允许创建彼此之间不指定执行顺序的交易。这在多台机器需要为同一发送账户签名或提交、但顺序不影响结果的场景中很有用。
+
+协议概览请参阅[无序交易](/zh/build/guides/orderless-transactions)（[AIP-123](https://github.com/aptos-foundation/AIPs/blob/main/aips/aip-123.md) 和 [AIP-129](https://github.com/aptos-foundation/AIPs/blob/main/aips/aip-129.md)）。
+
+## 构建无序交易
+
+`Aptos::sign_submit_and_wait_orderless` 会包装普通 payload、附加重放保护 nonce 并提交。对 nonce 传入 `None` 可让 SDK 生成新的随机值。
+
+<Aside type="note">
+  每笔交易的 nonce 必须唯一。无序交易在提交后最多 60 秒内过期。若未在该窗口内执行，交易将过期且不会执行。
+</Aside>
+
+```rust filename="orderless.rs"
+use aptos_sdk::{Aptos, AptosConfig, account::Ed25519Account, transaction::EntryFunction};
+
+let aptos = Aptos::new(AptosConfig::devnet())?;
+let sender = aptos.create_funded_account(1_000_000_000).await?;
+let recipient = Ed25519Account::generate();
+
+let payload = EntryFunction::apt_transfer(recipient.address(), 1_000_000)?;
+let result = aptos
+    .sign_submit_and_wait_orderless(&sender, payload.into(), None, None)
+    .await?;
+```
+
+第三个参数是可选的显式 nonce（使用 `Some(nonce)` 可复用特定值）。第四个参数是可选的等待超时。
+
+之后像处理其他已提交交易一样处理结果：检查 `result.data` 上的 `success`、`hash` 和 `vm_status`。
+
+## 已测试示例
+
+SDK 仓库包含遵循此 API 的可运行示例：
+
+- [`orderless_transaction.rs`](https://github.com/aptos-labs/aptos-rust-sdk/blob/main/crates/aptos-sdk/examples/orderless_transaction.rs)
+
+运行：
+
+```shellscript filename="Terminal"
+cargo run -p aptos-sdk --example orderless_transaction --features "ed25519,faucet"
+```

--- a/src/content/docs/zh/build/sdks/rust-sdk/building-transactions/simulating-transactions.mdx
+++ b/src/content/docs/zh/build/sdks/rust-sdk/building-transactions/simulating-transactions.mdx
@@ -48,3 +48,7 @@ let result = aptos.simulate_signed(&signed).await?;
 
 - [Sponsored Transactions](/zh/build/sdks/rust-sdk/building-transactions/sponsoring-transactions)
 - [Multi-Agent Transactions](/zh/build/sdks/rust-sdk/building-transactions/multi-agent-transactions)
+
+## 已测试示例
+
+请参阅 SDK 仓库中的 [`simulation.rs`](https://github.com/aptos-labs/aptos-rust-sdk/blob/main/crates/aptos-sdk/examples/simulation.rs)。

--- a/src/content/docs/zh/build/sdks/rust-sdk/building-transactions/sponsoring-transactions.mdx
+++ b/src/content/docs/zh/build/sdks/rust-sdk/building-transactions/sponsoring-transactions.mdx
@@ -90,3 +90,7 @@ async fn main() -> anyhow::Result<()> {
     Ok(())
 }
 ```
+
+## 已测试示例
+
+请参阅 SDK 仓库中的 [`sponsored_transaction.rs`](https://github.com/aptos-labs/aptos-rust-sdk/blob/main/crates/aptos-sdk/examples/sponsored_transaction.rs)。

--- a/src/content/docs/zh/build/sdks/rust-sdk/fetch-data-via-sdk.mdx
+++ b/src/content/docs/zh/build/sdks/rust-sdk/fetch-data-via-sdk.mdx
@@ -79,3 +79,8 @@ let result: serde_json::Value = indexer.query(my_query, None).await?;
 <Aside type="note">
   自定义 GraphQL 查询使用 `indexer.query::<T>(query, variables)`。请传入类型注解，以便确定 `T`。
 </Aside>
+
+## 已测试示例
+
+请参阅 SDK 仓库中的 [`view_function.rs`](https://github.com/aptos-labs/aptos-rust-sdk/blob/main/crates/aptos-sdk/examples/view_function.rs)
+和 [`indexer_queries.rs`](https://github.com/aptos-labs/aptos-rust-sdk/blob/main/crates/aptos-sdk/examples/indexer_queries.rs)。

--- a/src/content/docs/zh/build/sdks/rust-sdk/quickstart.mdx
+++ b/src/content/docs/zh/build/sdks/rust-sdk/quickstart.mdx
@@ -1,0 +1,136 @@
+---
+title: "Rust SDK 快速入门"
+description: "使用 Aptos Rust SDK 创建账户、为账户注资并转移 APT"
+sidebar:
+  label: "Rust SDK 快速入门"
+---
+
+import { Aside, Steps } from '@astrojs/starlight/components';
+
+<Aside type="note">
+  完整示例见页面底部的[完整快速入门代码](#full-quickstart-code)。流程与 SDK 仓库中的
+  [`transfer.rs`](https://github.com/aptos-labs/aptos-rust-sdk/blob/main/crates/aptos-sdk/examples/transfer.rs)
+  相同。
+</Aside>
+
+<Steps>
+  1. 创建 Cargo 项目并添加 SDK
+
+     该 SDK 需要 **Rust 1.95+**。
+
+     ```shellscript filename="Terminal"
+     cargo new aptos-rust-quickstart
+     cd aptos-rust-quickstart
+     ```
+
+     将依赖添加到 `Cargo.toml`：
+
+     ```toml filename="Cargo.toml"
+     [dependencies]
+     aptos-sdk = "0.7"
+     tokio = { version = "1", features = ["full"] }
+     anyhow = "1"
+     serde_json = "1"
+     ```
+
+  2. 设置 Aptos 客户端
+
+     ```rust filename="src/main.rs"
+     use aptos_sdk::{Aptos, AptosConfig};
+
+     let aptos = Aptos::new(AptosConfig::devnet())?;
+     println!("Connected to Aptos devnet");
+     ```
+
+     <Aside type="note">
+       （进阶）若要连接特定节点，可在 `AptosConfig::devnet()` 上链式调用
+       `.with_fullnode_url(...)`。
+     </Aside>
+
+  3. 创建并为账户注资
+
+     ```rust filename="src/main.rs"
+     use aptos_sdk::account::Ed25519Account;
+
+     let alice = Ed25519Account::generate();
+     let bob = Ed25519Account::generate();
+
+     // 默认 max_gas_amount 为 2_000_000。注资金额应明显高于转账金额。
+     aptos.fund_account(alice.address(), 1_000_000_000).await?;
+     ```
+
+     也可使用 `aptos.create_funded_account(amount)` 一步完成生成和注资。
+     在 testnet 上，请从[水龙头页面](/zh/network/faucet)铸造。
+
+  4. 转移 APT
+
+     `aptos.transfer_apt` 会构建、签名、提交并等待。
+
+     ```rust filename="src/main.rs"
+     let result = aptos.transfer_apt(&alice, bob.address(), 1_000).await?;
+     println!("Submitted: {:?}", result.data.get("hash"));
+     ```
+
+     有关更底层的构建 → 模拟 → 签名 → 提交 → 等待流程，请参阅
+     [构建交易](/zh/build/sdks/rust-sdk/building-transactions)。
+</Steps>
+
+## 完整快速入门代码
+
+```rust filename="src/main.rs"
+use aptos_sdk::{Aptos, AptosConfig, account::Ed25519Account};
+
+const FUND_AMOUNT: u64 = 1_000_000_000;
+const TRANSFER_AMOUNT: u64 = 1_000;
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    let aptos = Aptos::new(AptosConfig::devnet())?;
+
+    let alice = Ed25519Account::generate();
+    let bob = Ed25519Account::generate();
+
+    println!("=== Addresses ===");
+    println!("Alice: {}", alice.address());
+    println!("Bob:   {}", bob.address());
+
+    aptos.fund_account(alice.address(), FUND_AMOUNT).await?;
+
+    println!("=== Initial Balances ===");
+    println!("Alice: {}", aptos.get_balance(alice.address()).await?);
+    println!("Bob:   {}", aptos.get_balance(bob.address()).await?);
+
+    let result = aptos
+        .transfer_apt(&alice, bob.address(), TRANSFER_AMOUNT)
+        .await?;
+    println!("Submitted: {:?}", result.data.get("hash"));
+
+    println!("=== Final Balances ===");
+    println!("Alice: {}", aptos.get_balance(alice.address()).await?);
+    println!("Bob:   {}", aptos.get_balance(bob.address()).await?);
+
+    Ok(())
+}
+```
+
+运行：
+
+```shellscript filename="Terminal"
+cargo run
+```
+
+## 总结
+
+你刚刚学习了如何通过以下步骤转移 APT：
+
+1. 使用 `Aptos::new` 连接网络。
+2. 创建并为账户注资。
+3. 提交转账并等待执行。
+
+<Aside type="note">
+  建议收藏 SDK 仓库中的
+  [示例](https://github.com/aptos-labs/aptos-rust-sdk/tree/main/crates/aptos-sdk/examples)
+  和 [测试](https://github.com/aptos-labs/aptos-rust-sdk/tree/main/crates/aptos-sdk/tests)。
+  这些套件是本文档所示 API 的权威来源。生成的 rustdoc 位于
+  [aptos-labs.github.io/aptos-rust-sdk](https://aptos-labs.github.io/aptos-rust-sdk/aptos_sdk/index.html)。
+</Aside>

--- a/src/content/docs/zh/build/sdks/rust-sdk/rust-examples.mdx
+++ b/src/content/docs/zh/build/sdks/rust-sdk/rust-examples.mdx
@@ -5,7 +5,7 @@ sidebar:
   label: "示例"
 ---
 
-import { Steps } from '@astrojs/starlight/components';
+import { Aside, Steps } from '@astrojs/starlight/components';
 
 有关说明如何使用 SDK 核心概念的示例代码，请参阅：
 
@@ -34,6 +34,11 @@ SDK 仓库中的 [`examples` 文件夹](https://github.com/aptos-labs/aptos-rust
 | `fungible_asset_transfer.rs` | 转移同质化资产                     |
 | `script_transaction.rs`      | Script payload 构造           |
 | `deploy_module.rs`           | 发布 Move 包                   |
+
+<Aside type="note">
+  请优先使用这些仓库示例，而不是复制旧博客或旧版 `aptos-core` SDK 中的代码片段。
+  独立的 `aptos-sdk` crate 会跟踪当前 API。
+</Aside>
 
 ### 如何运行示例
 

--- a/src/content/docs/zh/build/sdks/rust-sdk/rust-examples.mdx
+++ b/src/content/docs/zh/build/sdks/rust-sdk/rust-examples.mdx
@@ -9,6 +9,7 @@ import { Steps } from '@astrojs/starlight/components';
 
 有关说明如何使用 SDK 核心概念的示例代码，请参阅：
 
+- [快速入门](/zh/build/sdks/rust-sdk/quickstart)
 - [获取数据](/zh/build/sdks/rust-sdk/fetch-data-via-sdk)
 - [构建、模拟和提交交易](/zh/build/sdks/rust-sdk/building-transactions)
 
@@ -26,10 +27,13 @@ SDK 仓库中的 [`examples` 文件夹](https://github.com/aptos-labs/aptos-rust
 | `simulation.rs`              | 提交前模拟交易                     |
 | `sponsored_transaction.rs`   | 费用支付方（赞助）交易                 |
 | `multi_agent.rs`             | 多签名人交易                      |
+| `orderless_transaction.rs`   | 无序（基于 nonce）交易              |
 | `account_management.rs`      | 账户创建、助记词和密钥类型               |
+| `multi_key_account.rs`       | 混合签名方案的多密钥账户                |
 | `indexer_queries.rs`         | 通过 GraphQL 查询 Aptos Indexer |
 | `fungible_asset_transfer.rs` | 转移同质化资产                     |
-| `orderless_transaction.rs`   | 无序（基于 nonce）交易              |
+| `script_transaction.rs`      | Script payload 构造           |
+| `deploy_module.rs`           | 发布 Move 包                   |
 
 ### 如何运行示例
 
@@ -52,6 +56,7 @@ SDK 仓库中的 [`examples` 文件夹](https://github.com/aptos-labs/aptos-rust
 
 ## 有用的参考代码
 
+- [Crate 测试](https://github.com/aptos-labs/aptos-rust-sdk/tree/main/crates/aptos-sdk/tests) - 覆盖 SDK API 的测试。
 - [SDK 源代码](https://github.com/aptos-labs/aptos-rust-sdk) - 内含解释每个函数作用的行内注释。
 - [API 参考](https://aptos-labs.github.io/aptos-rust-sdk/aptos_sdk/index.html) - 该 crate 的 rustdoc。
 - [迁移指南](https://github.com/aptos-labs/aptos-rust-sdk/blob/main/MIGRATION.md) - 从旧版 `aptos-core` SDK 的映射。

--- a/src/content/docs/zh/build/sdks/ts-sdk.mdx
+++ b/src/content/docs/zh/build/sdks/ts-sdk.mdx
@@ -42,11 +42,20 @@ npm i @aptos-labs/ts-sdk
 <CardGrid>
   <LinkCard href="/zh/build/sdks/ts-sdk/quickstart" title="快速入门" description="查看快速入门，在 5 分钟内获得可运行的演示" />
 
-  <LinkCard href="https://github.com/aptos-labs/aptos-ts-sdk/tree/main/examples/typescript" title="20 多个示例" description="浏览 SDK 仓库提供的全部 TypeScript 示例" target="_blank" />
+  <LinkCard href="/zh/build/sdks/ts-sdk/account" title="账户" description="生成、恢复并为账户注资" />
 
-  <LinkCard href="https://github.com/aptos-labs/aptos-ts-sdk/tree/main/tests/e2e" title="全面测试" description="查看展示 SDK 各项功能用法的端到端测试" target="_blank" />
+  <LinkCard href="/zh/build/sdks/ts-sdk/fetch-data-via-sdk" title="获取数据" description="读取账本、账户和 View 函数数据" />
+
+  <LinkCard href="/zh/build/sdks/ts-sdk/building-transactions" title="提交交易" description="构建、模拟、签名并提交交易" />
+
+  <LinkCard href="/zh/build/sdks/ts-sdk/ts-examples" title="示例" description="SDK 仓库中的可运行示例目录" />
+
+  <LinkCard href="https://github.com/aptos-labs/aptos-ts-sdk/tree/main/tests/e2e" title="测试" description="展示 SDK 各项功能用法的端到端测试" target="_blank" />
 </CardGrid>
 
-### 用不超过 10 行代码转移 APT
+### 来自已测试示例套件的 APT 转账
 
-<RemoteCodeblock permalink="https://github.com/aptos-labs/aptos-ts-sdk/blob/bcde1e3af2f09615015c774fb0c2f5206377346e/examples/typescript/simple_transfer.ts#L77-L91" />
+以下片段取自 SDK 仓库中的
+[`simple_transfer.ts`](https://github.com/aptos-labs/aptos-ts-sdk/blob/main/examples/typescript/simple_transfer.ts)。
+
+<RemoteCodeblock permalink="https://github.com/aptos-labs/aptos-ts-sdk/blob/da6319287572e8f62f38c73be0e2346ca7447e21/examples/typescript/simple_transfer.ts#L68-L81" />

--- a/src/content/docs/zh/build/sdks/ts-sdk/building-transactions.mdx
+++ b/src/content/docs/zh/build/sdks/ts-sdk/building-transactions.mdx
@@ -200,8 +200,9 @@ example();
 交易还具备一些额外的特性,可以根据您的需求进行调整,您可以在这里了解更多:
 
 1. [多代理签名](/zh/build/sdks/ts-sdk/building-transactions/multi-agent-transactions) - 允许多个账户共同作用于单个合约.
-2. [加密内存池](/zh/build/sdks/ts-sdk/building-transactions/encrypted-pending-transactions) - 在交易进入内存池前对 Move 负载进行加密,适用于支持此功能的网络(AIP-144).
-3. [交易赞助](/zh/build/sdks/ts-sdk/building-transactions/sponsoring-transactions) - 由其他账户代为支付该交易的 gas 费用.
-4. [批量提交交易](/zh/build/sdks/ts-sdk/building-transactions/batching-transactions) - 如何从单个账户快速发送多笔交易.
-5. [二进制规范序列化 (BCS)](/zh/build/sdks/ts-sdk/building-transactions/bcs-format) - Aptos 交易使用的数据序列化格式.
-6. [使用 ScriptComposer 组合多个 Move 调用](/zh/build/sdks/ts-sdk/building-transactions/script-composer) - (实验性功能) 构建更复杂的交易负载以动态调用多个 Move 函数.
+2. [无序交易](/zh/build/sdks/ts-sdk/building-transactions/orderless-transactions) - 允许交易无序执行，便于管理.
+3. [加密内存池](/zh/build/sdks/ts-sdk/building-transactions/encrypted-pending-transactions) - 在交易进入内存池前对 Move 负载进行加密,适用于支持此功能的网络(AIP-144).
+4. [交易赞助](/zh/build/sdks/ts-sdk/building-transactions/sponsoring-transactions) - 由其他账户代为支付该交易的 gas 费用.
+5. [批量提交交易](/zh/build/sdks/ts-sdk/building-transactions/batching-transactions) - 如何从单个账户快速发送多笔交易.
+6. [二进制规范序列化 (BCS)](/zh/build/sdks/ts-sdk/building-transactions/bcs-format) - Aptos 交易使用的数据序列化格式.
+7. [使用 ScriptComposer 组合多个 Move 调用](/zh/build/sdks/ts-sdk/building-transactions/script-composer) - (实验性功能) 构建更复杂的交易负载以动态调用多个 Move 函数.

--- a/src/content/docs/zh/build/sdks/ts-sdk/ts-examples.mdx
+++ b/src/content/docs/zh/build/sdks/ts-sdk/ts-examples.mdx
@@ -5,10 +5,11 @@ sidebar:
   label: "示例"
 ---
 
-import { Steps } from '@astrojs/starlight/components';
+import { Aside, Steps } from '@astrojs/starlight/components';
 
 以下示例代码展示了 SDK 的核心使用概念:
 
+- [快速入门](/zh/build/sdks/ts-sdk/quickstart)
 - [数据获取](/zh/build/sdks/ts-sdk/fetch-data-via-sdk)
 - [交易构建,模拟与提交](/zh/build/sdks/ts-sdk/building-transactions)
 
@@ -16,17 +17,37 @@ import { Steps } from '@astrojs/starlight/components';
 
 ## 代码片段
 
-SDK 仓库中的 [`examples` 文件夹](https://github.com/aptos-labs/aptos-ts-sdk/tree/main/examples) 包含数十个可自定义的代码片段.
+SDK 仓库中的 [`examples` 文件夹](https://github.com/aptos-labs/aptos-ts-sdk/tree/main/examples) 包含数十个可自定义的代码片段。这些示例属于 SDK 的 CI 范围。
+
+| 示例                                | 说明                |
+| --------------------------------- | ----------------- |
+| `simple_transfer.ts`              | 两个账户之间的基本 APT 转账  |
+| `simple_orderless_transfer.ts`    | 带重放保护 nonce 的无序转账 |
+| `simple_sponsored_transaction.ts` | 由费用支付方赞助的交易       |
+| `multi_agent_transfer.ts`         | 带有两个签名人的多代理交易     |
+| `batch_funds.ts`                  | 从同一账户批量注资         |
+| `transfer_coin.ts`                | Coin API 转账       |
+| `your_fungible_asset.ts`          | 发布并转移同质化资产        |
+| `simple_digital_asset.ts`         | 数字资产（NFT）流程       |
+| `rotate_key.ts`                   | 认证密钥轮换            |
+| `keyless.ts`                      | Keyless 账户流程      |
+| `custom_client.ts`                | 自定义 HTTP 客户端      |
+| `external_signing.ts`             | 使用外部签名器签名         |
+
+<Aside type="note">
+  请优先使用这些仓库示例，而不是复制旧博客中的片段。TypeScript SDK 更新很快，`examples` 文件夹会跟踪当前 API。
+</Aside>
 
 ### 如何运行示例
 
 运行示例脚本的步骤:
 
 <Steps>
-  1. 克隆
+  1. 克隆仓库。
 
      ```shellscript filename="终端"
      git clone https://github.com/aptos-labs/aptos-ts-sdk.git
+     cd aptos-ts-sdk
      ```
 
   2. 在项目根目录安装所有依赖

--- a/src/content/docs/zh/network/blockchain/txns-states.mdx
+++ b/src/content/docs/zh/network/blockchain/txns-states.mdx
@@ -65,7 +65,7 @@ Aptos交易包含诸如发送者的账户地址、来自发送者的认证、在
 - 入口点
 - [脚本（有效载荷）](/zh/build/smart-contracts/scripts)
 
-目前，SDK [Python](/zh/build/sdks/python-sdk)和[Typescript](/zh/build/sdks/ts-sdk)都支持这两种。本指南指出了许多这些入口点，例如`coin::transfer`和`aptos_account::create_account`。
+目前，官方 [TypeScript](/zh/build/sdks/ts-sdk)、[Python](/zh/build/sdks/python-sdk)、[Go](/zh/build/sdks/go-sdk) 和 [Rust](/zh/build/sdks/rust-sdk) SDK 都支持这两种。本指南指出了许多这些入口点，例如`coin::transfer`和`aptos_account::create_account`。
 
 Aptos区块链上的所有操作都应通过入口点调用可用。虽然可以提交多个交易串行调用入口点，但许多这样的操作可能会受益于从单个交易原子调用。脚本有效载荷交易可以调用任何模块内定义的任何入口点或公共函数。
 

--- a/src/lib/llms-curated-ids.ts
+++ b/src/lib/llms-curated-ids.ts
@@ -48,7 +48,16 @@ export const LLMS_INDEX_SECTIONS: LlmsSection[] = [
   },
   {
     title: "SDKs",
-    ids: ["build/sdks/ts-sdk", "build/sdks/python-sdk", "build/sdks/go-sdk", "build/sdks/rust-sdk"],
+    ids: [
+      "build/sdks/ts-sdk",
+      "build/sdks/ts-sdk/quickstart",
+      "build/sdks/python-sdk",
+      "build/sdks/python-sdk/quickstart",
+      "build/sdks/go-sdk",
+      "build/sdks/go-sdk/quickstart",
+      "build/sdks/rust-sdk",
+      "build/sdks/rust-sdk/quickstart",
+    ],
   },
   {
     title: "Advanced Topics",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Audit of the official SDK docs (TypeScript, Python, Go, Rust) to give each SDK the same getting-started surface and to point readers at **tested repository examples**, not stale snippets.

Deprecated SDKs (.NET, C++, Unity, Swift, Unity OpenDive) and the community Kotlin SDK were left out of this parity pass.

## What was missing

| Surface | TypeScript | Python | Go | Rust |
| --- | --- | --- | --- | --- |
| Quickstart | existed | **added** | **added** | **added** |
| Accounts / fetch / transactions | yes | yes | **fixed compile issues** | yes |
| Orderless transactions | existed | **added** | **added** | **added** |
| Examples catalog + how to run | expanded | expanded | **rewritten** | expanded |
| Overview badges + `RemoteCodeblock` from a pinned example | yes | yes | yes | yes |

Go pages previously called APIs that do not match the current SDK (`NewEd25519Account` / `NewAccountFromSigner` return `(account, error)`; indexer `QueryIndexer`; `AccountOne` for `0x1`). The Go examples page also suggested `go install`, which is not how those examples are run.

Sponsored-transaction **guide** still pointed at a Python v1 example and an `aptos-core` API test, and omitted Go entirely. Get Started named TypeScript, Python, and Rust but not Go.

## Shared page set (each official SDK)

- Overview (install + cards for Quickstart, Accounts, Fetch, Transactions, Examples, Tests)
- Quickstart (create accounts, fund, transfer APT)
- Accounts, Fetch data, Building transactions
- Batching, simulating, BCS, multi-agent, orderless, sponsoring
- Examples catalog with clone/run steps and links into SDK tests

Transfer snippets on the overviews are `RemoteCodeblock`s pinned to:

- TS `examples/typescript/simple_transfer.ts`
- Python `v2/examples/transfer_apt.py` (docs note PyPI imports `aptos_sdk.v2`)
- Go `examples/transfer_coin/main.go`
- Rust `crates/aptos-sdk/examples/transfer.rs`

Chinese (`zh`) mirrors are included. Spanish is out of scope.

## Intentionally not copied

TypeScript-only topics (Surf, confidential asset, account abstraction, encrypted mempool, ScriptComposer, legacy TS SDK) stay TypeScript-only. Those APIs are not a shared official-SDK surface.

## Known follow-ups (not in this PR)

- **Your First Transaction** still walks Python through the **v1** API, with a note to use the v2 quickstart for new work. Expanding that long guide into Go/Rust tabs is a separate rewrite.
- Go multi-agent still links `examples/multi_agent` rather than embedding a full in-page sample.
- **Your First NFT / FA / e2e dapp** remain TypeScript-first tutorials by design.

## Verification

- `astro check --noSync`: 0 errors
- Production `pnpm build` + Starlight link validator: all internal links valid
- `pnpm lint`: pass (pre-existing Biome `recommended` deprecation info only)
- `pnpm test`: 9 files, 109 tests passed
- Built HTML for the four SDK overviews and the new Python/Go/Rust quickstart and orderless pages includes the expected titles and GitHub example links

New quickstarts are in the curated `/llms.txt` SDK section.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a04145-d745-76de-b2bf-c214a782a05d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a04145-d745-76de-b2bf-c214a782a05d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

