### PR TITLE
docs: validate and update the APIs section

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -249,6 +249,7 @@ export default defineConfig({
               "/.well-known/oauth-authorization-server",
               "/auth.md",
               "/.well-known/ai-catalog.json",
+              "/aptos-spec.json",
             ];
             if (knownWellKnown.some((path) => link.endsWith(path))) {
               return true;

--- a/public/aptos-spec.json
+++ b/public/aptos-spec.json
@@ -12269,6 +12269,650 @@
         "operationId": "get_account_transaction_summaries"
       }
     },
+    "/transactions/auxiliary_info": {
+      "get": {
+        "tags": [
+          "Transactions"
+        ],
+        "summary": "Get transactions auxiliary info",
+        "description": "Retrieves persisted auxiliary information (such as transaction indices within blocks) for\ntransactions in a given version range.\n\nIf the version range has been pruned, a 410 will be returned.",
+        "parameters": [
+          {
+            "name": "start_version",
+            "schema": {
+              "$ref": "#/components/schemas/U64"
+            },
+            "in": "query",
+            "description": "Starting ledger version to retrieve auxiliary info for",
+            "required": true,
+            "deprecated": false,
+            "explode": true
+          },
+          {
+            "name": "limit",
+            "schema": {
+              "type": "integer",
+              "format": "uint16"
+            },
+            "in": "query",
+            "description": "Max number of transactions to retrieve auxiliary info for.\n\nIf not provided, defaults to default page size",
+            "required": false,
+            "deprecated": false,
+            "explode": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/PersistedAuxiliaryInfo"
+                  }
+                }
+              },
+              "application/x-bcs": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "type": "integer",
+                    "format": "uint8"
+                  }
+                }
+              }
+            },
+            "headers": {
+              "X-APTOS-CHAIN-ID": {
+                "description": "Chain ID of the current chain",
+                "required": true,
+                "deprecated": false,
+                "schema": {
+                  "type": "integer",
+                  "format": "uint8"
+                }
+              },
+              "X-APTOS-LEDGER-VERSION": {
+                "description": "Current ledger version of the chain",
+                "required": true,
+                "deprecated": false,
+                "schema": {
+                  "type": "integer",
+                  "format": "uint64"
+                }
+              },
+              "X-APTOS-LEDGER-OLDEST-VERSION": {
+                "description": "Oldest non-pruned ledger version of the chain",
+                "required": true,
+                "deprecated": false,
+                "schema": {
+                  "type": "integer",
+                  "format": "uint64"
+                }
+              },
+              "X-APTOS-LEDGER-TIMESTAMPUSEC": {
+                "description": "Current timestamp of the chain",
+                "required": true,
+                "deprecated": false,
+                "schema": {
+                  "type": "integer",
+                  "format": "uint64"
+                }
+              },
+              "X-APTOS-EPOCH": {
+                "description": "Current epoch of the chain",
+                "required": true,
+                "deprecated": false,
+                "schema": {
+                  "type": "integer",
+                  "format": "uint64"
+                }
+              },
+              "X-APTOS-BLOCK-HEIGHT": {
+                "description": "Current block height of the chain",
+                "required": true,
+                "deprecated": false,
+                "schema": {
+                  "type": "integer",
+                  "format": "uint64"
+                }
+              },
+              "X-APTOS-OLDEST-BLOCK-HEIGHT": {
+                "description": "Oldest non-pruned block height of the chain",
+                "required": true,
+                "deprecated": false,
+                "schema": {
+                  "type": "integer",
+                  "format": "uint64"
+                }
+              },
+              "X-APTOS-GAS-USED": {
+                "description": "The cost of the call in terms of gas",
+                "deprecated": false,
+                "schema": {
+                  "type": "integer",
+                  "format": "uint64"
+                }
+              },
+              "X-APTOS-CURSOR": {
+                "description": "Cursor to be used for endpoints that support cursor-based\npagination. Pass this to the `start` field of the endpoint\non the next call to get the next page of results.",
+                "deprecated": false,
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "X-APTOS-TXN-ENCRYPTION-KEY": {
+                "description": "Per-epoch transaction encryption key (hex-encoded)",
+                "deprecated": false,
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AptosError"
+                }
+              }
+            },
+            "headers": {
+              "X-APTOS-CHAIN-ID": {
+                "description": "Chain ID of the current chain",
+                "deprecated": false,
+                "schema": {
+                  "type": "integer",
+                  "format": "uint8"
+                }
+              },
+              "X-APTOS-LEDGER-VERSION": {
+                "description": "Current ledger version of the chain",
+                "deprecated": false,
+                "schema": {
+                  "type": "integer",
+                  "format": "uint64"
+                }
+              },
+              "X-APTOS-LEDGER-OLDEST-VERSION": {
+                "description": "Oldest non-pruned ledger version of the chain",
+                "deprecated": false,
+                "schema": {
+                  "type": "integer",
+                  "format": "uint64"
+                }
+              },
+              "X-APTOS-LEDGER-TIMESTAMPUSEC": {
+                "description": "Current timestamp of the chain",
+                "deprecated": false,
+                "schema": {
+                  "type": "integer",
+                  "format": "uint64"
+                }
+              },
+              "X-APTOS-EPOCH": {
+                "description": "Current epoch of the chain",
+                "deprecated": false,
+                "schema": {
+                  "type": "integer",
+                  "format": "uint64"
+                }
+              },
+              "X-APTOS-BLOCK-HEIGHT": {
+                "description": "Current block height of the chain",
+                "deprecated": false,
+                "schema": {
+                  "type": "integer",
+                  "format": "uint64"
+                }
+              },
+              "X-APTOS-OLDEST-BLOCK-HEIGHT": {
+                "description": "Oldest non-pruned block height of the chain",
+                "deprecated": false,
+                "schema": {
+                  "type": "integer",
+                  "format": "uint64"
+                }
+              },
+              "X-APTOS-GAS-USED": {
+                "description": "The cost of the call in terms of gas",
+                "deprecated": false,
+                "schema": {
+                  "type": "integer",
+                  "format": "uint64"
+                }
+              },
+              "X-APTOS-TXN-ENCRYPTION-KEY": {
+                "description": "Per-epoch transaction encryption key (hex-encoded)",
+                "deprecated": false,
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AptosError"
+                }
+              }
+            },
+            "headers": {
+              "X-APTOS-CHAIN-ID": {
+                "description": "Chain ID of the current chain",
+                "deprecated": false,
+                "schema": {
+                  "type": "integer",
+                  "format": "uint8"
+                }
+              },
+              "X-APTOS-LEDGER-VERSION": {
+                "description": "Current ledger version of the chain",
+                "deprecated": false,
+                "schema": {
+                  "type": "integer",
+                  "format": "uint64"
+                }
+              },
+              "X-APTOS-LEDGER-OLDEST-VERSION": {
+                "description": "Oldest non-pruned ledger version of the chain",
+                "deprecated": false,
+                "schema": {
+                  "type": "integer",
+                  "format": "uint64"
+                }
+              },
+              "X-APTOS-LEDGER-TIMESTAMPUSEC": {
+                "description": "Current timestamp of the chain",
+                "deprecated": false,
+                "schema": {
+                  "type": "integer",
+                  "format": "uint64"
+                }
+              },
+              "X-APTOS-EPOCH": {
+                "description": "Current epoch of the chain",
+                "deprecated": false,
+                "schema": {
+                  "type": "integer",
+                  "format": "uint64"
+                }
+              },
+              "X-APTOS-BLOCK-HEIGHT": {
+                "description": "Current block height of the chain",
+                "deprecated": false,
+                "schema": {
+                  "type": "integer",
+                  "format": "uint64"
+                }
+              },
+              "X-APTOS-OLDEST-BLOCK-HEIGHT": {
+                "description": "Oldest non-pruned block height of the chain",
+                "deprecated": false,
+                "schema": {
+                  "type": "integer",
+                  "format": "uint64"
+                }
+              },
+              "X-APTOS-GAS-USED": {
+                "description": "The cost of the call in terms of gas",
+                "deprecated": false,
+                "schema": {
+                  "type": "integer",
+                  "format": "uint64"
+                }
+              },
+              "X-APTOS-TXN-ENCRYPTION-KEY": {
+                "description": "Per-epoch transaction encryption key (hex-encoded)",
+                "deprecated": false,
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AptosError"
+                }
+              }
+            },
+            "headers": {
+              "X-APTOS-CHAIN-ID": {
+                "description": "Chain ID of the current chain",
+                "deprecated": false,
+                "schema": {
+                  "type": "integer",
+                  "format": "uint8"
+                }
+              },
+              "X-APTOS-LEDGER-VERSION": {
+                "description": "Current ledger version of the chain",
+                "deprecated": false,
+                "schema": {
+                  "type": "integer",
+                  "format": "uint64"
+                }
+              },
+              "X-APTOS-LEDGER-OLDEST-VERSION": {
+                "description": "Oldest non-pruned ledger version of the chain",
+                "deprecated": false,
+                "schema": {
+                  "type": "integer",
+                  "format": "uint64"
+                }
+              },
+              "X-APTOS-LEDGER-TIMESTAMPUSEC": {
+                "description": "Current timestamp of the chain",
+                "deprecated": false,
+                "schema": {
+                  "type": "integer",
+                  "format": "uint64"
+                }
+              },
+              "X-APTOS-EPOCH": {
+                "description": "Current epoch of the chain",
+                "deprecated": false,
+                "schema": {
+                  "type": "integer",
+                  "format": "uint64"
+                }
+              },
+              "X-APTOS-BLOCK-HEIGHT": {
+                "description": "Current block height of the chain",
+                "deprecated": false,
+                "schema": {
+                  "type": "integer",
+                  "format": "uint64"
+                }
+              },
+              "X-APTOS-OLDEST-BLOCK-HEIGHT": {
+                "description": "Oldest non-pruned block height of the chain",
+                "deprecated": false,
+                "schema": {
+                  "type": "integer",
+                  "format": "uint64"
+                }
+              },
+              "X-APTOS-GAS-USED": {
+                "description": "The cost of the call in terms of gas",
+                "deprecated": false,
+                "schema": {
+                  "type": "integer",
+                  "format": "uint64"
+                }
+              },
+              "X-APTOS-TXN-ENCRYPTION-KEY": {
+                "description": "Per-epoch transaction encryption key (hex-encoded)",
+                "deprecated": false,
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "410": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AptosError"
+                }
+              }
+            },
+            "headers": {
+              "X-APTOS-CHAIN-ID": {
+                "description": "Chain ID of the current chain",
+                "deprecated": false,
+                "schema": {
+                  "type": "integer",
+                  "format": "uint8"
+                }
+              },
+              "X-APTOS-LEDGER-VERSION": {
+                "description": "Current ledger version of the chain",
+                "deprecated": false,
+                "schema": {
+                  "type": "integer",
+                  "format": "uint64"
+                }
+              },
+              "X-APTOS-LEDGER-OLDEST-VERSION": {
+                "description": "Oldest non-pruned ledger version of the chain",
+                "deprecated": false,
+                "schema": {
+                  "type": "integer",
+                  "format": "uint64"
+                }
+              },
+              "X-APTOS-LEDGER-TIMESTAMPUSEC": {
+                "description": "Current timestamp of the chain",
+                "deprecated": false,
+                "schema": {
+                  "type": "integer",
+                  "format": "uint64"
+                }
+              },
+              "X-APTOS-EPOCH": {
+                "description": "Current epoch of the chain",
+                "deprecated": false,
+                "schema": {
+                  "type": "integer",
+                  "format": "uint64"
+                }
+              },
+              "X-APTOS-BLOCK-HEIGHT": {
+                "description": "Current block height of the chain",
+                "deprecated": false,
+                "schema": {
+                  "type": "integer",
+                  "format": "uint64"
+                }
+              },
+              "X-APTOS-OLDEST-BLOCK-HEIGHT": {
+                "description": "Oldest non-pruned block height of the chain",
+                "deprecated": false,
+                "schema": {
+                  "type": "integer",
+                  "format": "uint64"
+                }
+              },
+              "X-APTOS-GAS-USED": {
+                "description": "The cost of the call in terms of gas",
+                "deprecated": false,
+                "schema": {
+                  "type": "integer",
+                  "format": "uint64"
+                }
+              },
+              "X-APTOS-TXN-ENCRYPTION-KEY": {
+                "description": "Per-epoch transaction encryption key (hex-encoded)",
+                "deprecated": false,
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AptosError"
+                }
+              }
+            },
+            "headers": {
+              "X-APTOS-CHAIN-ID": {
+                "description": "Chain ID of the current chain",
+                "deprecated": false,
+                "schema": {
+                  "type": "integer",
+                  "format": "uint8"
+                }
+              },
+              "X-APTOS-LEDGER-VERSION": {
+                "description": "Current ledger version of the chain",
+                "deprecated": false,
+                "schema": {
+                  "type": "integer",
+                  "format": "uint64"
+                }
+              },
+              "X-APTOS-LEDGER-OLDEST-VERSION": {
+                "description": "Oldest non-pruned ledger version of the chain",
+                "deprecated": false,
+                "schema": {
+                  "type": "integer",
+                  "format": "uint64"
+                }
+              },
+              "X-APTOS-LEDGER-TIMESTAMPUSEC": {
+                "description": "Current timestamp of the chain",
+                "deprecated": false,
+                "schema": {
+                  "type": "integer",
+                  "format": "uint64"
+                }
+              },
+              "X-APTOS-EPOCH": {
+                "description": "Current epoch of the chain",
+                "deprecated": false,
+                "schema": {
+                  "type": "integer",
+                  "format": "uint64"
+                }
+              },
+              "X-APTOS-BLOCK-HEIGHT": {
+                "description": "Current block height of the chain",
+                "deprecated": false,
+                "schema": {
+                  "type": "integer",
+                  "format": "uint64"
+                }
+              },
+              "X-APTOS-OLDEST-BLOCK-HEIGHT": {
+                "description": "Oldest non-pruned block height of the chain",
+                "deprecated": false,
+                "schema": {
+                  "type": "integer",
+                  "format": "uint64"
+                }
+              },
+              "X-APTOS-GAS-USED": {
+                "description": "The cost of the call in terms of gas",
+                "deprecated": false,
+                "schema": {
+                  "type": "integer",
+                  "format": "uint64"
+                }
+              },
+              "X-APTOS-TXN-ENCRYPTION-KEY": {
+                "description": "Per-epoch transaction encryption key (hex-encoded)",
+                "deprecated": false,
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AptosError"
+                }
+              }
+            },
+            "headers": {
+              "X-APTOS-CHAIN-ID": {
+                "description": "Chain ID of the current chain",
+                "deprecated": false,
+                "schema": {
+                  "type": "integer",
+                  "format": "uint8"
+                }
+              },
+              "X-APTOS-LEDGER-VERSION": {
+                "description": "Current ledger version of the chain",
+                "deprecated": false,
+                "schema": {
+                  "type": "integer",
+                  "format": "uint64"
+                }
+              },
+              "X-APTOS-LEDGER-OLDEST-VERSION": {
+                "description": "Oldest non-pruned ledger version of the chain",
+                "deprecated": false,
+                "schema": {
+                  "type": "integer",
+                  "format": "uint64"
+                }
+              },
+              "X-APTOS-LEDGER-TIMESTAMPUSEC": {
+                "description": "Current timestamp of the chain",
+                "deprecated": false,
+                "schema": {
+                  "type": "integer",
+                  "format": "uint64"
+                }
+              },
+              "X-APTOS-EPOCH": {
+                "description": "Current epoch of the chain",
+                "deprecated": false,
+                "schema": {
+                  "type": "integer",
+                  "format": "uint64"
+                }
+              },
+              "X-APTOS-BLOCK-HEIGHT": {
+                "description": "Current block height of the chain",
+                "deprecated": false,
+                "schema": {
+                  "type": "integer",
+                  "format": "uint64"
+                }
+              },
+              "X-APTOS-OLDEST-BLOCK-HEIGHT": {
+                "description": "Oldest non-pruned block height of the chain",
+                "deprecated": false,
+                "schema": {
+                  "type": "integer",
+                  "format": "uint64"
+                }
+              },
+              "X-APTOS-GAS-USED": {
+                "description": "The cost of the call in terms of gas",
+                "deprecated": false,
+                "schema": {
+                  "type": "integer",
+                  "format": "uint64"
+                }
+              },
+              "X-APTOS-TXN-ENCRYPTION-KEY": {
+                "description": "Per-epoch transaction encryption key (hex-encoded)",
+                "deprecated": false,
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        },
+        "operationId": "get_transactions_auxiliary_info"
+      }
+    },
     "/transactions/batch": {
       "post": {
         "tags": [
@@ -17060,6 +17704,17 @@
           },
           "replay_protection_nonce": {
             "$ref": "#/components/schemas/U64"
+          }
+        }
+      },
+      "PersistedAuxiliaryInfo": {
+        "type": "object",
+        "description": "API representation of persisted auxiliary transaction information",
+        "properties": {
+          "transaction_index": {
+            "type": "integer",
+            "format": "uint32",
+            "description": "Optional transaction index in the block (None indicates no auxiliary info available)"
           }
         }
       },

--- a/src/content/docs/build/apis.mdx
+++ b/src/content/docs/build/apis.mdx
@@ -1,64 +1,96 @@
 ---
 title: "Aptos APIs"
-description: "Access the Aptos blockchain through various APIs including REST API, GraphQL, and specialized endpoints for different use cases"
+description: "Access the Aptos blockchain through the Fullnode REST API, Indexer GraphQL, Transaction Stream gRPC, faucet, and Geomi-hosted endpoints"
 sidebar:
   label: "APIs Overview"
 ---
 
-import { CardGrid, LinkCard } from '@astrojs/starlight/components';
+import { Aside, CardGrid, LinkCard } from '@astrojs/starlight/components';
 
-The Aptos Blockchain network can be accessed by several APIs, depending on your use-case.
+Use these APIs to read chain state, submit transactions, index historical data, and fund test accounts. Most application code should go through an [official SDK](/build/sdks); the HTTP, GraphQL, and gRPC endpoints below are the underlying services those SDKs call.
 
-## Aptos Fullnode
+## Choose an API
 
-This API - embedded into Fullnodes - provides a simple, low latency, yet low-level way of _reading_ state and
-_submitting_ transactions to the Aptos Blockchain. It also supports transaction simulation.
+| You need                                                        | Use                                                    |
+| --------------------------------------------------------------- | ------------------------------------------------------ |
+| Latest on-chain state, transaction submission, or simulation    | [Fullnode REST API](/build/apis/fullnode-rest-api)     |
+| NFTs, objects, historical activity, or aggregated tables        | [Indexer GraphQL API](/build/indexer)                  |
+| A real-time or historical transaction feed for a custom indexer | [Transaction Stream (gRPC)](/build/indexer/txn-stream) |
+| Test APT on Devnet or Testnet                                   | [Faucet API](/build/apis/faucet-api)                   |
+| SQL, dashboards, or third-party RPC                             | [Data providers](/build/apis/data-providers)           |
+
+## Official Aptos Labs endpoints
+
+[Aptos Labs](https://aptoslabs.com) operates these deployments for each [Aptos network](/network/nodes/networks) on behalf of the [Aptos Foundation](https://aptosnetwork.com/foundation). `fullnode.{network}.aptoslabs.com` is an alias of `api.{network}.aptoslabs.com`; prefer the `api.` hostnames.
+
+| Network | REST API (`/v1`)                       | Indexer GraphQL                                | Transaction Stream gRPC          | Faucet                                                                                   |
+| ------- | -------------------------------------- | ---------------------------------------------- | -------------------------------- | ---------------------------------------------------------------------------------------- |
+| Mainnet | `https://api.mainnet.aptoslabs.com/v1` | `https://api.mainnet.aptoslabs.com/v1/graphql` | `grpc.mainnet.aptoslabs.com:443` | —                                                                                        |
+| Testnet | `https://api.testnet.aptoslabs.com/v1` | `https://api.testnet.aptoslabs.com/v1/graphql` | `grpc.testnet.aptoslabs.com:443` | [Mint page](/network/faucet) and `https://faucet.testnet.aptoslabs.com` (Google sign-in) |
+| Devnet  | `https://api.devnet.aptoslabs.com/v1`  | `https://api.devnet.aptoslabs.com/v1/graphql`  | `grpc.devnet.aptoslabs.com:443`  | `https://faucet.devnet.aptoslabs.com` (programmatic)                                     |
+
+The Node API spec is published on this site as [OpenAPI JSON](/aptos-spec.json) and a browsable [REST API reference](/rest-api). Live Swagger UIs also run on each fullnode at `/v1/spec`.
+
+## Fullnode REST API
+
+This API ships with every fullnode. It is the low-latency path for reading state, submitting transactions, and simulating transactions.
 
 <CardGrid>
-  <LinkCard href="/build/apis/fullnode-rest-api?network=mainnet" title="Aptos Fullnode REST API (Mainnet)" description="Mainnet API playground for Aptos Fullnode REST API" />
+  <LinkCard href="/rest-api" title="REST API reference" description="Browsable docs generated from the Aptos Node API OpenAPI spec" />
 
-  <LinkCard href="/build/apis/fullnode-rest-api?network=testnet" title="Aptos Fullnode REST API (Testnet)" description="Testnet API playground for Aptos Fullnode REST API" />
+  <LinkCard href="/build/apis/fullnode-rest-api" title="REST API guide" description="Rate limits, pruning, view functions, and how to query state" />
 
-  <LinkCard href="/build/apis/fullnode-rest-api?network=devnet" title="Aptos Fullnode REST API (Devnet)" description="Devnet API playground for Aptos Fullnode REST API" />
+  <LinkCard href="https://api.mainnet.aptoslabs.com/v1/spec#/" title="Mainnet explorer" description="Live Swagger UI against api.mainnet.aptoslabs.com" target="_blank" />
+
+  <LinkCard href="https://api.testnet.aptoslabs.com/v1/spec#/" title="Testnet explorer" description="Live Swagger UI against api.testnet.aptoslabs.com" target="_blank" />
+
+  <LinkCard href="https://api.devnet.aptoslabs.com/v1/spec#/" title="Devnet explorer" description="Live Swagger UI against api.devnet.aptoslabs.com" target="_blank" />
 </CardGrid>
 
 ## Indexer
 
 <CardGrid>
-  <LinkCard
-    href="/build/indexer"
-    title="Indexer GraphQL API"
-    description="This GraphQL API offers a high-level, opinionated GraphQL interface to read state from the Aptos Blockchain.
-It's ideal for interacting with NFTs, Aptos Objects, or custom Move contracts.
-Learn more about the Indexer-powered GraphQL API here."
-  />
+  <LinkCard href="/build/indexer" title="Indexer GraphQL API" description="High-level GraphQL for NFTs, Aptos Objects, fungible assets, and custom contract data" />
 
-  <LinkCard
-    href="/build/indexer/txn-stream"
-    title="Transaction Stream API"
-    description="This GRPC API streams historical and real-time transaction data to an indexing processor.
-It's used by Aptos Core Indexing and can also support custom app-specific indexing processors
-for real-time blockchain data processing. Learn more here."
-  />
+  <LinkCard href="/build/indexer/txn-stream" title="Transaction Stream API" description="gRPC stream of historical and real-time transactions for Aptos Core Indexing and app-specific processors" />
 </CardGrid>
 
-## Faucet (Only Testnet/Devnet)
+## Faucet (Devnet and Testnet)
 
 <CardGrid>
-  <LinkCard
-    href="/build/apis/faucet-api"
-    title="Faucet API"
-    description="This API provides the ability to receive test tokens on devnet. Its primary purpose is the development
-and testing of applications and Move contracts before deploying them to mainnet. On testnet you can mint at the mint page."
-  />
+  <LinkCard href="/build/apis/faucet-api" title="Faucet API" description="Mint test APT on Devnet programmatically, or on Testnet through Google sign-in / the mint page" />
 </CardGrid>
 
-The code of each of the above-mentioned APIs is open-sourced on [GitHub](https://github.com/aptos-labs/aptos-core). As
-such anyone can operate these APIs and many independent operators and builders worldwide choose to do so.
+## Geomi and data providers
 
-### Aptos Labs operated API Deployments
+<CardGrid>
+  <LinkCard href="/build/apis/aptos-labs-developer-portal" title="Geomi" description="API keys, higher rate limits, gas station, and no-code indexing for Aptos Labs hosted APIs" />
 
-[Aptos Labs](https://aptoslabs.com) operates a deployment of these APIs on behalf of [Aptos Foundation](https://aptosnetwork.com/foundation)
-for each [Aptos Network](/network/nodes/networks) and makes them available for public consumption.
+  <LinkCard href="/build/apis/data-providers" title="Data providers" description="SQL datasets, analytics dashboards, and third-party RPC endpoints" />
+</CardGrid>
 
-These APIs allow for limited access on a per-IP basis without an API key (anonymous access). To get much higher rate limits you can sign up for an [Geomi](https://geomi.dev/) account.
+The Node API, Indexer, Transaction Stream, and faucet implementations are open source in [aptos-core](https://github.com/aptos-labs/aptos-core). Anyone can run them; independent operators and builders do so worldwide. Additional RPC vendors are listed in the [Aptos ecosystem directory](https://aptosnetwork.com/ecosystem/directory/category/rpc).
+
+## Authentication and rate limits
+
+Labs-hosted Node, Indexer, and Transaction Stream APIs allow **anonymous** access with a low per-IP rate limit. For higher limits and usage metrics, create a [Geomi](https://geomi.dev/) API key and send it as a bearer token.
+
+```shellscript filename="Terminal"
+curl "https://api.mainnet.aptoslabs.com/v1" \
+  -H "Authorization: Bearer YOUR_API_KEY"
+```
+
+```typescript filename="index.ts"
+import { Aptos, AptosConfig, Network } from "@aptos-labs/ts-sdk";
+
+const aptos = new Aptos(
+  new AptosConfig({
+    network: Network.MAINNET,
+    clientConfig: { API_KEY: process.env.APTOS_API_KEY },
+  }),
+);
+```
+
+<Aside type="note">
+  Usage is metered in compute units (CUs), and organizations also have HTTP rate limits. See the [Geomi billing docs](https://geomi.dev/docs/admin/billing) for current limits and pricing. Create a key from the [Geomi getting started guide](https://geomi.dev/docs/start).
+</Aside>

--- a/src/content/docs/build/apis/aptos-labs-developer-portal.mdx
+++ b/src/content/docs/build/apis/aptos-labs-developer-portal.mdx
@@ -5,6 +5,43 @@ sidebar:
   label: "Geomi"
 ---
 
-[Geomi](https://geomi.dev) is your gateway to access Aptos Labs provided APIs in a quick and easy fashion to power your dapp. Beyond API access it offers gas station and no code indexing services.
+import { Aside } from '@astrojs/starlight/components';
 
-Learn more about Geomi at the dedicated [Geomi docs site](https://geomi.dev/docs).
+[Geomi](https://geomi.dev) is the Aptos Labs developer portal for hosted Node API, Indexer GraphQL, Transaction Stream, gas station, and no-code indexing. Create an account to get API keys, higher rate limits, and usage metrics.
+
+<Aside type="note">
+  Geomi is in beta. Report problems by opening an issue in [aptos-core](https://github.com/aptos-labs/aptos-core/issues/new). Older `developers.aptoslabs.com` URLs redirect to Geomi.
+</Aside>
+
+## API keys
+
+Anonymous requests to Labs-hosted APIs are allowed with a low per-IP limit. Attach a Geomi API key as a bearer token for higher limits:
+
+```shellscript filename="Terminal"
+curl "https://api.mainnet.aptoslabs.com/v1" \
+  -H "Authorization: Bearer YOUR_API_KEY"
+```
+
+```typescript filename="index.ts"
+import { Aptos, AptosConfig, Network } from "@aptos-labs/ts-sdk";
+
+const aptos = new Aptos(
+  new AptosConfig({
+    network: Network.MAINNET,
+    clientConfig: { API_KEY: process.env.APTOS_API_KEY },
+  }),
+);
+```
+
+**Server keys** (prefix `aptoslabs_`) stay on a backend. **Client keys** (prefix `AG-`) are for browsers, mobile apps, and extensions; configure allowed origins and per-IP limits when you create them. See [API keys](https://geomi.dev/docs/api-keys) and [Getting started](https://geomi.dev/docs/start).
+
+## What Geomi hosts
+
+| Service                                       | Docs                                                        |
+| --------------------------------------------- | ----------------------------------------------------------- |
+| Node API, Indexer GraphQL, Transaction Stream | [Geomi API reference](https://geomi.dev/docs/api-reference) |
+| Rate limits and compute-unit billing          | [Billing](https://geomi.dev/docs/admin/billing)             |
+| Gas Station                                   | [Gas Stations](https://geomi.dev/docs/gas-stations)         |
+| No-code indexing                              | [No-code indexing](https://geomi.dev/docs/no-code-indexing) |
+
+Official network URLs are listed on [Aptos APIs](/build/apis) and [Networks](/network/nodes/networks).

--- a/src/content/docs/build/apis/data-providers.mdx
+++ b/src/content/docs/build/apis/data-providers.mdx
@@ -84,8 +84,8 @@ You'll need to make an account to access stablecoin details.
 
 ### Pangea
 
-Provides [raw data](https://docs.pangea.foundation/api-reference/aptosvm/reference),
-coin/fa transfers, and some dex parsing.
+Provides [raw data](https://docs.pangea.foundation/overview/),
+coin/FA transfers, and some DEX parsing.
 
 ### Other vendors
 
@@ -98,11 +98,12 @@ We also have some partners who target more enterprise use cases
 ## Vendors for real-time data
 
 - [Geomi](https://geomi.dev/) (prev. Aptos Build)
-  - Provides [API key](https://geomi.dev/docs/start) for higher rate limits on REST API and GRPC transaction stream.
-  - Provides [no code indexing](https://geomi.dev/docs/no-code-indexing) to parse and turn events into tables that can be queried.
+  - Provides an [API key](https://geomi.dev/docs/start) for higher rate limits on the REST API and gRPC transaction stream.
+  - Provides [no-code indexing](https://geomi.dev/docs/no-code-indexing) to parse events into queryable tables.
 - [NODEREAL](https://nodereal.io/aptos) for REST API endpoint
-- [SHINAMI](https://docs.shinami.com/reference/api-references-overview) for REST API and GraphQL endpoints
+- [Shinami](https://docs.shinami.com/developer-guides/aptos) for Aptos node access, gas station, and wallet services
 - [QuickNode](https://www.quicknode.com/chains/apt) for REST API endpoint
+- [Codex](https://docs.codex.io/networks/aptos) GraphQL API and WebSocket subscriptions for Aptos token prices, trading pairs, holders, and wallet balances (network ID `49705`)
 
 Additional RPC vendors can be found [here](https://aptosnetwork.com/ecosystem/directory/category/rpc)
 

--- a/src/content/docs/build/apis/faucet-api.mdx
+++ b/src/content/docs/build/apis/faucet-api.mdx
@@ -1,76 +1,122 @@
 ---
 title: "Faucet API"
-description: "Get free APT tokens on devnet and testnet for development and testing purposes using the faucet API"
+description: "Mint test APT on Devnet and Testnet using the faucet API, SDKs, CLI, or the Testnet mint page"
 sidebar:
   label: "Faucet API"
 ---
 
-The faucet allows users to get `APT` on devnet. On testnet you can only mint at the [mint page](/network/faucet). It is not available on Mainnet.
+import { Aside } from '@astrojs/starlight/components';
 
-The endpoints for each faucet are:
+The faucet mints test `APT` so you can develop before Mainnet. **Devnet** is programmable with no Google login. **Testnet** requires Google sign-in (the [mint page](/network/faucet) or `POST /fund` with a Firebase ID token). There is no Mainnet faucet.
 
-- Devnet: [https://faucet.devnet.aptoslabs.com](https://faucet.devnet.aptoslabs.com)
+Amounts are in [Octas](/network/glossary#octa) (`1 APT = 100,000,000` Octas).
 
-## Using the faucet
+| Network | Endpoint                               | How to mint                                                          |
+| ------- | -------------------------------------- | -------------------------------------------------------------------- |
+| Devnet  | `https://faucet.devnet.aptoslabs.com`  | SDKs, CLI, or `POST /fund` with no auth                              |
+| Testnet | `https://faucet.testnet.aptoslabs.com` | [Mint page](/network/faucet), or `POST /fund` with a Google ID token |
+| Mainnet | —                                      | Not available                                                        |
 
-Each SDK has integration for devnet to use the faucet. Below are a few examples, but you can
-see more information on each individual [SDK's documentation](/build/sdks).
+OpenAPI (live): [Devnet spec](https://faucet.devnet.aptoslabs.com/spec.yaml) and [Testnet spec](https://faucet.testnet.aptoslabs.com/spec.yaml). Explorer: [Devnet `/spec`](https://faucet.devnet.aptoslabs.com/spec). Source: [crates/aptos-faucet/doc/spec.yaml](https://github.com/aptos-labs/aptos-core/blob/main/crates/aptos-faucet/doc/spec.yaml).
 
-### Using the faucet in a wallet
+The current operation is **`POST /fund`** with a JSON `FundRequest` body (`address`, `auth_key`, or `pub_key`, and optional `amount`). Devnet still accepts a legacy **`POST /mint?amount=&address=`** query; new integrations should use `/fund`.
 
-Most wallets, such as [Petra](https://aptosnetwork.com/ecosystem/directory/petra),
-will have a faucet button for devnet. See full list of [Aptos Wallets](https://aptosnetwork.com/ecosystem/projects/wallets).
+## Using the faucet in a wallet
 
-### Using the faucet in the Aptos CLI
+Most wallets, such as [Petra](https://aptosnetwork.com/ecosystem/directory/petra), have a Devnet faucet button. See the [Aptos wallets directory](https://aptosnetwork.com/ecosystem/projects/wallets).
 
-Once you've [set up your CLI](/build/cli/setup-cli), you can simply call fund-with-faucet.  The amount used is in Octas (1 APT = 100,000,000 Octas).
+## Using the faucet in the Aptos CLI
+
+After [CLI setup](/build/cli/setup-cli), fund an account on **Devnet**:
 
 ```shellscript filename="Terminal"
 aptos account fund-with-faucet --account 0xd0f523c9e73e6f3d68c16ae883a9febc616e484c4998a72d8899a1009e5a89d6 --amount 100000000
 ```
 
-### Using the faucet in the TypeScript SDK
+On Testnet, use the [mint page](/network/faucet) instead of this command.
 
-Here is an example funding the account `0xd0f523c9e73e6f3d68c16ae883a9febc616e484c4998a72d8899a1009e5a89d6` with 1 APT in Devnet. The amount used is in Octas (1 APT = 100,000,000 Octas).
+## Using the faucet in the TypeScript SDK
+
+This example funds `0xd0f523c9e73e6f3d68c16ae883a9febc616e484c4998a72d8899a1009e5a89d6` with 1 APT on Devnet.
 
 ```typescript filename="index.ts"
 import { Aptos, AptosConfig, Network } from "@aptos-labs/ts-sdk";
 
-const aptos = new Aptos(new AptosConfig({network: Network.Devnet}));
-aptos.fundAccount({accountAddress: "0xd0f523c9e73e6f3d68c16ae883a9febc616e484c4998a72d8899a1009e5a89d6", amount: 100000000});
+const aptos = new Aptos(new AptosConfig({ network: Network.DEVNET }));
+await aptos.fundAccount({
+  accountAddress: "0xd0f523c9e73e6f3d68c16ae883a9febc616e484c4998a72d8899a1009e5a89d6",
+  amount: 100_000_000,
+});
 ```
 
-### Using the faucet in the Go SDK
+See each [SDK](/build/sdks) for more client examples.
 
-Here is an example funding the account `0xd0f523c9e73e6f3d68c16ae883a9febc616e484c4998a72d8899a1009e5a89d6` with 1 APT in Devnet. The amount used is in Octas (1 APT = 100,000,000 Octas).
+## Using the faucet in the Python SDK
 
-```go filename="index.go"
-import "github.com/aptos-labs/aptos-go-sdk"
+```python filename="fund.py"
+from aptos_sdk.v2 import Aptos, AptosConfig, Network
+
+async with Aptos(AptosConfig(network=Network.DEVNET)) as aptos:
+    await aptos.faucet.fund_account(
+        "0xd0f523c9e73e6f3d68c16ae883a9febc616e484c4998a72d8899a1009e5a89d6",
+        100_000_000,
+    )
+```
+
+## Using the faucet in the Go SDK
+
+```go filename="fund.go"
+package main
+
+import (
+	"github.com/aptos-labs/aptos-go-sdk"
+)
 
 func main() {
-	client, err := aptos.NewClient(aptos.LocalnetConfig)
+	client, err := aptos.NewClient(aptos.DevnetConfig)
 	if err != nil {
-		panic(err)
+		panic("Failed to create client: " + err.Error())
 	}
 
-  client.Fund("0xd0f523c9e73e6f3d68c16ae883a9febc616e484c4998a72d8899a1009e5a89d6", 100000000)
+	address := aptos.AccountAddress{}
+	err = address.ParseStringRelaxed("0xd0f523c9e73e6f3d68c16ae883a9febc616e484c4998a72d8899a1009e5a89d6")
+	if err != nil {
+		panic("Failed to parse address: " + err.Error())
+	}
+
+	err = client.Fund(address, 100_000_000)
+	if err != nil {
+		panic("Failed to fund account: " + err.Error())
+	}
 }
 ```
 
-### Calling the faucet: Other languages not supported by SDKs
+## Calling the faucet without an SDK
 
-If you are trying to call the faucet in other languages, you have two options:
-
-1. Generate a client from
-   the [OpenAPI spec](https://github.com/aptos-labs/aptos-core/blob/main/crates/aptos-faucet/doc/spec.yaml).
-2. Call the faucet on your own.
-
-For the latter, you will want to build a query similar to this:
+`POST /fund` on Devnet:
 
 ```shellscript filename="Terminal"
-curl -X POST
-'https://faucet.devnet.aptoslabs.com/mint?amount=10000&address=0xd0f523c9e73e6f3d68c16ae883a9febc616e484c4998a72d8899a1009e5a89d6'
+curl -X POST "https://faucet.devnet.aptoslabs.com/fund" \
+  -H "Content-Type: application/json" \
+  -d '{"address":"0xd0f523c9e73e6f3d68c16ae883a9febc616e484c4998a72d8899a1009e5a89d6","amount":100000000}'
 ```
 
-This means mint 10000 [octas](/network/glossary#Octa) to
-address `0xd0f523c9e73e6f3d68c16ae883a9febc616e484c4998a72d8899a1009e5a89d6`.
+A successful response looks like `{"txn_hashes":["..."]}`. If `amount` is omitted, the faucet uses its configured default (capped at the maximum mint).
+
+<Aside type="note">
+  You can generate a typed client from the [OpenAPI spec](https://faucet.devnet.aptoslabs.com/spec.yaml) if you are not using an official SDK.
+</Aside>
+
+### Testnet: Google sign-in
+
+Testnet `POST /fund` requires a human Google login. The [mint page](/network/faucet) does this for you. To call the API directly, send a Firebase ID token for project `aptos-api-gateway-prod` (scopes `openid`, `email`, `profile`):
+
+```shellscript filename="Terminal"
+curl -X POST "https://faucet.testnet.aptoslabs.com/fund" \
+  -H "Authorization: Bearer FIREBASE_ID_TOKEN" \
+  -H "x-is-jwt: true" \
+  -H "Content-Type: application/json" \
+  -d '{"address":"0xd0f523c9e73e6f3d68c16ae883a9febc616e484c4998a72d8899a1009e5a89d6"}'
+```
+
+There is no agent-registration shortcut. See [`/auth.md`](/auth.md) for the OAuth discovery documents.

--- a/src/content/docs/build/apis/fullnode-rest-api.mdx
+++ b/src/content/docs/build/apis/fullnode-rest-api.mdx
@@ -7,107 +7,104 @@ sidebar:
 
 import { Aside, CardGrid, LinkCard } from '@astrojs/starlight/components';
 
-This API - embedded into Fullnodes - provides a simple, low latency, yet low-level way of reading state and submitting transactions to the Aptos Blockchain. It also supports transaction simulation.
-For more advanced queries, we recommend using the [Indexer GraphQL API](/build/indexer).
+This API ships with every fullnode. It is a simple, low-latency, low-level way to read state, submit transactions, and simulate transactions on Aptos. For NFTs, objects, historical activity, and aggregated tables, use the [Indexer GraphQL API](/build/indexer) instead.
 
-## Fullnode REST API Explorer
+Base URL (Aptos Labs): `https://api.{network}.aptoslabs.com/v1` — for example `https://api.mainnet.aptoslabs.com/v1`. `fullnode.{network}.aptoslabs.com` is an alias of the same service.
+
+## Spec and explorers
+
+The Node API is OpenAPI 3.0 (`Aptos Node API` 1.2.0). This site publishes the spec and a generated reference; each network also hosts a live Swagger UI.
 
 <CardGrid>
-  <LinkCard href="https://fullnode.mainnet.aptoslabs.com/v1/spec#/" title="Mainnet Fullnode REST API" description="REST API Explorer for Mainnet" target="_blank" />
+  <LinkCard href="/rest-api" title="REST API reference" description="Browsable docs generated from aptos-spec.json" />
 
-  <LinkCard href="https://fullnode.testnet.aptoslabs.com/v1/spec#/" title="Testnet Fullnode REST API" description="REST API Explorer for Testnet" target="_blank" />
+  <LinkCard href="/aptos-spec.json" title="OpenAPI spec (JSON)" description="Machine-readable Aptos Node API specification" />
 
-  <LinkCard href="https://fullnode.devnet.aptoslabs.com/v1/spec#/" title="Devnet Fullnode REST API" description="REST API Explorer for Devnet" target="_blank" />
+  <LinkCard href="https://api.mainnet.aptoslabs.com/v1/spec#/" title="Mainnet explorer" description="Live Swagger UI for Mainnet" target="_blank" />
+
+  <LinkCard href="https://api.testnet.aptoslabs.com/v1/spec#/" title="Testnet explorer" description="Live Swagger UI for Testnet" target="_blank" />
+
+  <LinkCard href="https://api.devnet.aptoslabs.com/v1/spec#/" title="Devnet explorer" description="Live Swagger UI for Devnet" target="_blank" />
 </CardGrid>
 
-## Understanding rate limits
+The spec YAML on a node is `GET /v1/spec.yaml`. Health is `GET /v1/-/healthy`. Ledger info (chain ID, version, epoch, role) is `GET /v1`. Node identity is `GET /v1/info`.
 
-As with the [Aptos Indexer](/build/indexer/indexer-api), the Aptos REST API has rate limits based on compute units. You can learn more about how the ratelimiting works by reading the [Geomi docs](https://geomi.dev/docs/admin/billing).
+```shellscript filename="Terminal"
+curl "https://api.mainnet.aptoslabs.com/v1"
+```
+
+## Authentication and rate limits
+
+Anonymous access is limited per IP. Attach a [Geomi](https://geomi.dev/) API key for higher limits:
+
+```shellscript filename="Terminal"
+curl "https://api.mainnet.aptoslabs.com/v1/accounts/0x1" \
+  -H "Authorization: Bearer YOUR_API_KEY"
+```
+
+Labs-hosted Node and Indexer APIs bill in compute units and also enforce HTTP rate limits. See the [Geomi billing docs](https://geomi.dev/docs/admin/billing).
+
+## Common operations
+
+| Operation              | Method and path                                                 | Reference                                                                         |
+| ---------------------- | --------------------------------------------------------------- | --------------------------------------------------------------------------------- |
+| Ledger info            | `GET /v1`                                                       | [get\_ledger\_info](/rest-api/operations/get_ledger_info)                         |
+| Health                 | `GET /v1/-/healthy`                                             | [healthy](/rest-api/operations/healthy)                                           |
+| Account                | `GET /v1/accounts/{address}`                                    | [get\_account](/rest-api/operations/get_account)                                  |
+| Coin or FA balance     | `GET /v1/accounts/{address}/balance/{asset_type}`               | [get\_account\_balance](/rest-api/operations/get_account_balance)                 |
+| View function          | `POST /v1/view`                                                 | [view](/rest-api/operations/view)                                                 |
+| Submit transaction     | `POST /v1/transactions`                                         | [submit\_transaction](/rest-api/operations/submit_transaction)                    |
+| Simulate transaction   | `POST /v1/transactions/simulate`                                | [simulate\_transaction](/rest-api/operations/simulate_transaction)                |
+| Transaction by version | `GET /v1/transactions/by_version/{txn_version}`                 | [get\_transaction\_by\_version](/rest-api/operations/get_transaction_by_version)  |
+| Account transactions   | `GET /v1/accounts/{address}/transactions`                       | [get\_account\_transactions](/rest-api/operations/get_account_transactions)       |
+| Events by handle       | `GET /v1/accounts/{address}/events/{event_handle}/{field_name}` | [get\_events\_by\_event\_handle](/rest-api/operations/get_events_by_event_handle) |
+
+`asset_type` for [get\_account\_balance](/rest-api/operations/get_account_balance) can be a coin type such as `0x1::aptos_coin::AptosCoin` or a fungible asset metadata address such as `0xa` (APT). After the [Fungible Asset migration](/build/smart-contracts/fungible-asset), prefer this endpoint (or SDK helpers such as `getAccountAPTAmount`) over reading a `CoinStore` resource.
 
 ## Viewing current and historical state
 
-Most integrations into the Aptos blockchain benefit from a holistic and comprehensive overview of the current and
-historical state of the blockchain. Aptos provides historical transactions, state, and events, all the result of
-transaction execution.
+Most integrations need both current and historical state. Aptos provides historical transactions, state, and events as the result of transaction execution.
 
-- Historical transactions specify the execution status, output, and tie to related events. Each transaction has a unique
-  version number associated with it that dictates its global sequential ordering in the history of the blockchain ledger.
-- The state is the representation of all transaction outputs up to a specific version. In other words, a state version
-  is the accumulation of all transactions inclusive of that transaction version.
-- As transactions execute, they may emit events. [Events](/network/blockchain/events) are hints about changes in on-chain
-  data.
+- Historical transactions include execution status, output, and related events. Each transaction has a unique **version** that is its global sequential position in the ledger.
+- State at a version is the accumulation of all transaction outputs up to and including that version.
+- Executing transactions may emit [events](/network/blockchain/events), which hint at on-chain data changes.
 
 <Aside type="note">
-  Ensure the [fullnode](/network/nodes/networks) you are communicating with is up-to-date. The fullnode must reach the
-  version containing your transaction to retrieve relevant data from it. There can be latency from the fullnodes
-  retrieving state from [validator fullnodes](/network/blockchain/fullnodes), which in turn rely upon
-  [validator nodes](/network/blockchain/validator-nodes) as the source of truth.
+  The [fullnode](/network/nodes/networks) you query must have reached the version that contains your data. Public fullnodes lag [validator fullnodes](/network/blockchain/fullnodes), which follow [validator nodes](/network/blockchain/validator-nodes).
 </Aside>
 
-The storage service on a node employs two forms of pruning that erase data from nodes:
+Nodes prune old ledger history (and can prune state) to bound disk use. The default window keeps the most recent 150 million transactions; almost all Mainnet and Testnet nodes use that default. Disable or resize pruning only if you run your own node — see [Data Pruning](/network/nodes/configure/data-pruning). For historical data beyond a pruned window, use the [Indexer](/build/indexer).
 
-- state
-- events, transactions, and everything else
-
-While either of these may be disabled, storing the state versions is not particularly sustainable.
-
-Events and transactions pruning can be disabled via setting the [`enable_ledger_pruner`](https://github.com/aptos-labs/aptos-core/blob/cf0bc2e4031a843cdc0c04e70b3f7cd92666afcf/config/src/config/storage_config.rs#L141)
-to `false` in `storage_config.rs`. This is default behavior in Mainnet. In the near future, Aptos will provide indexers
-that mitigate the need to directly query from a node.
-
-The REST API offers querying transactions and events in these ways:
-
-- [Transactions for an account](https://api.devnet.aptoslabs.com/v1/spec#/operations/get_account_transactions)
-- [Transactions by version](https://api.devnet.aptoslabs.com/v1/spec#/operations/get_transaction_by_version)
-- [Events by event handle](https://api.devnet.aptoslabs.com/v1/spec#/operations/get_events_by_event_handle)
+Account transaction queries return sequence-number transactions from that account. They do not return [orderless](/build/guides/orderless-transactions) transactions sent from the account.
 
 ## Reading state with the View function
 
-View functions do not modify blockchain state when called from the API. A [View function](https://github.com/aptos-labs/aptos-core/blob/main/api/src/view_function.rs)
-and its [input](https://github.com/aptos-labs/aptos-core/blob/main/api/types/src/view.rs) can be used to read
-potentially complex on-chain state using Move. For example, you can evaluate who has the highest bid in an auction
-contract. Here are related files:
+View functions do not modify blockchain state when you call them through the API. A view function and its arguments can compute complex on-chain state in Move — for example, the highest bid in an auction. The REST operation is [POST /view](/rest-api/operations/view).
 
-- [`view_function.rs`](https://github.com/aptos-labs/aptos-core/blob/main/api/src/tests/view_function.rs) for an example
-- related [Move](https://github.com/aptos-labs/aptos-core/blob/90c33dc7a18662839cd50f3b70baece0e2dbfc71/aptos-move/framework/aptos-framework/sources/coin.move#L226) code
-- [specification](https://github.com/aptos-labs/aptos-core/blob/90c33dc7a18662839cd50f3b70baece0e2dbfc71/api/doc/spec.yaml#L8513).
+The call looks like simulation, but it has no side effects and returns the function output. You pass the module, function name, type arguments, and values. A function does not have to be immutable to use `#[view]`; if it is mutable, the API still will not commit state. Prefer making such functions private so they cannot be called as entry functions at runtime.
 
-The view function operates like the Aptos simulation API,
-though with no side effects and an accessible output path. View functions can be called via the `/view` endpoint. Calls
-to view functions require the module and function names along with input type parameters and values.
-
-A function does not have to be immutable to be tagged as `#[view]`, but if the function is mutable it will not result in
-state mutation when called from the API. If you want to tag a mutable function as `#[view]`, consider making it private
-so that it cannot be maliciously called during runtime.
-
-In order to use the View functions, you need to [publish the module](/build/cli/working-with-move-contracts)
-through the [Aptos CLI](/build/cli).
-
-In the Aptos CLI, a view function request would look like this:
+Framework modules already expose view functions, so you do not need to publish a module to try the endpoint:
 
 ```shellscript filename="Terminal"
-aptos move view --function-id devnet::message::get_message --profile devnet --args address:devnet
-{
-  "Result": [
-    "View functions rock!"
-  ]
-}
+curl -X POST "https://api.mainnet.aptoslabs.com/v1/view" \
+  -H "Content-Type: application/json" \
+  -d '{"function":"0x1::chain_id::get","type_arguments":[],"arguments":[]}'
 ```
 
-In the TypeScript SDK, a view function request would look like this:
+```shellscript filename="Terminal"
+aptos move view --function-id 0x1::chain_id::get
+```
 
 ```typescript filename="index.ts"
-import { Aptos } from "@aptos-labs/ts-sdk";
+import { Aptos, AptosConfig, Network, type InputViewFunctionData } from "@aptos-labs/ts-sdk";
 
-const aptos = new Aptos();
-const [balance] = aptos.view<[string]>({
-  function: "0x1::coin::balance",
-  typeArguments: ["0x1::aptos_coin::AptosCoin"],
-  functionArguments: [alice.accountAddress]
-});
-
-expect(balance).toBe("100000000");
+const aptos = new Aptos(new AptosConfig({ network: Network.MAINNET }));
+const payload: InputViewFunctionData = {
+  function: "0x1::chain_id::get",
+};
+const [chainId] = await aptos.view<[number]>({ payload });
 ```
 
-The view function returns a list of values as a vector. By default, the results are returned in JSON format; however,
-they can be optionally returned in Binary Canonical Serialization (BCS) encoded format.
+For your own module, [publish it](/build/cli/working-with-move-contracts) with the [Aptos CLI](/build/cli), then call `aptos move view --function-id <address>::<module>::<function>`.
+
+The response is a JSON array of return values. You can also request Binary Canonical Serialization (BCS) by setting the appropriate `Accept` / content type on the REST call.

--- a/src/content/docs/network/glossary.mdx
+++ b/src/content/docs/network/glossary.mdx
@@ -37,9 +37,9 @@ See [Accounts](/network/blockchain/accounts) for more information.
 
 - An **Application Programming Interface (API)** is a set of protocols and tools
   that allow users to interact with Aptos blockchain nodes and client networks
-  via external applications. Aptos offers a REST API to communicate with our
-  nodes.
-- See [documentation](/build/apis) for more details.
+  via external applications. Aptos nodes expose a REST API; Aptos Labs also
+  hosts an Indexer GraphQL API and a Transaction Stream gRPC API.
+- See [Aptos APIs](/build/apis) for more details.
 
 ### APT
 
@@ -306,7 +306,8 @@ that:
 
 ### Faucet
 
-- The **faucet** is a service that mints APT on devnet. For testnet see the [mint page](/network/faucet).
+- The **faucet** is a service that mints APT on Devnet (programmatically) and
+  Testnet (Google sign-in / the [mint page](/network/faucet)).
 - APT on devnet and testnet has no real world value, it is only for development purposes.
 - To use a faucet, see [Faucet API](/build/apis/faucet-api).
 

--- a/src/content/docs/zh/build/apis.mdx
+++ b/src/content/docs/zh/build/apis.mdx
@@ -1,62 +1,96 @@
 ---
 title: "Aptos APIs"
-description: "通过各种 API 访问 Aptos 区块链，包括 REST API、GraphQL 和针对不同用例的专用端点"
+description: "通过全节点 REST API、Indexer GraphQL、Transaction Stream gRPC、水龙头和 Geomi 托管端点访问 Aptos 区块链"
 sidebar:
   label: "API"
 ---
 
-Aptos 区块链网络可以通过多种 API 进行访问,具体取决于您的使用场景.
+import { Aside, CardGrid, LinkCard } from '@astrojs/starlight/components';
 
-## Aptos Fullnode
+使用这些 API 读取链上状态、提交交易、索引历史数据，以及为测试账户充值。大多数应用代码应通过[官方 SDK](/zh/build/sdks) 调用；下面的 HTTP、GraphQL 和 gRPC 端点是这些 SDK 所使用的底层服务。
 
-import { CardGrid, LinkCard } from '@astrojs/starlight/components';
+## 选择 API
 
-此 API 嵌入在 Fullnodes 中,提供了一种简单,低延迟但低级别的方式来读取状态和提交交易到 Aptos 区块链.它还支持交易模拟.
+| 需求                           | 使用                                                       |
+| ---------------------------- | -------------------------------------------------------- |
+| 最新链上状态、提交交易或模拟交易             | [全节点 REST API](/zh/build/apis/fullnode-rest-api)         |
+| NFT、对象、历史活动或聚合表              | [Indexer GraphQL API](/zh/build/indexer)                 |
+| 用于自定义索引器的实时或历史交易流            | [Transaction Stream（gRPC）](/zh/build/indexer/txn-stream) |
+| 在 Devnet 或 Testnet 上获取测试 APT | [水龙头 API](/zh/build/apis/faucet-api)                     |
+| SQL、仪表板或第三方 RPC              | [数据提供商](/zh/build/apis/data-providers)                   |
+
+## Aptos Labs 官方端点
+
+[Aptos Labs](https://aptoslabs.com) 代表 [Aptos Foundation](https://aptosnetwork.com/foundation) 为每个 [Aptos 网络](/zh/network/nodes/networks) 运营这些部署。`fullnode.{network}.aptoslabs.com` 是 `api.{network}.aptoslabs.com` 的别名；请优先使用 `api.` 主机名。
+
+| 网络  | REST API（`/v1`）                        | Indexer GraphQL                                | Transaction Stream gRPC          | 水龙头                                                                            |
+| --- | -------------------------------------- | ---------------------------------------------- | -------------------------------- | ------------------------------------------------------------------------------ |
+| 主网  | `https://api.mainnet.aptoslabs.com/v1` | `https://api.mainnet.aptoslabs.com/v1/graphql` | `grpc.mainnet.aptoslabs.com:443` | —                                                                              |
+| 测试网 | `https://api.testnet.aptoslabs.com/v1` | `https://api.testnet.aptoslabs.com/v1/graphql` | `grpc.testnet.aptoslabs.com:443` | [铸币页面](/zh/network/faucet) 和 `https://faucet.testnet.aptoslabs.com`（Google 登录） |
+| 开发网 | `https://api.devnet.aptoslabs.com/v1`  | `https://api.devnet.aptoslabs.com/v1/graphql`  | `grpc.devnet.aptoslabs.com:443`  | `https://faucet.devnet.aptoslabs.com`（可编程）                                     |
+
+本站发布节点 API 规范：[OpenAPI JSON](/aptos-spec.json) 和可浏览的 [REST API 参考](/rest-api)。每个全节点还在 `/v1/spec` 提供实时 Swagger UI。
+
+## 全节点 REST API
+
+该 API 随每个全节点一起提供，是读取状态、提交交易和模拟交易的低延迟路径。
 
 <CardGrid>
-  <LinkCard href="/zh/build/apis/fullnode-rest-api?network=mainnet" title="Aptos Fullnode REST API（主网）" description="Aptos Fullnode REST API 的主网 API playground" />
+  <LinkCard href="/rest-api" title="REST API 参考" description="由 Aptos 节点 API OpenAPI 规范生成的可浏览文档" />
 
-  <LinkCard href="/zh/build/apis/fullnode-rest-api?network=testnet" title="Aptos Fullnode REST API（测试网）" description="Aptos Fullnode REST API 的测试网 API playground" />
+  <LinkCard href="/zh/build/apis/fullnode-rest-api" title="REST API 指南" description="速率限制、数据裁剪、View 函数以及如何查询状态" />
 
-  <LinkCard href="/zh/build/apis/fullnode-rest-api?network=devnet" title="Aptos Fullnode REST API（开发网）" description="Aptos Fullnode REST API 的开发网 API playground" />
+  <LinkCard href="https://api.mainnet.aptoslabs.com/v1/spec#/" title="主网浏览器" description="针对 api.mainnet.aptoslabs.com 的实时 Swagger UI" target="_blank" />
+
+  <LinkCard href="https://api.testnet.aptoslabs.com/v1/spec#/" title="测试网浏览器" description="针对 api.testnet.aptoslabs.com 的实时 Swagger UI" target="_blank" />
+
+  <LinkCard href="https://api.devnet.aptoslabs.com/v1/spec#/" title="开发网浏览器" description="针对 api.devnet.aptoslabs.com 的实时 Swagger UI" target="_blank" />
 </CardGrid>
 
 ## Indexer
 
 <CardGrid>
-  <LinkCard
-    href="/zh/build/indexer"
-    title="Indexer GraphQL API"
-    description="GraphQL API 提供可传参数可定制的 GraphQL 接口，用于从 Aptos 区块链读取状态。
-它非常适合与 NFTs、Aptos Objects 或自定义 Move 合约进行交互。
-在这里了解更多关于 Indexer 支持的 GraphQL API。"
-  />
+  <LinkCard href="/zh/build/indexer" title="Indexer GraphQL API" description="用于 NFT、Aptos Objects、同质化资产和自定义合约数据的高级 GraphQL 接口" />
 
-  <LinkCard
-    href="/zh/build/indexer/txn-stream"
-    title="Transaction Stream API"
-    description="这个 GRPC API 将历史和实时交易数据流式传输到索引处理器。
-它正在被 Aptos Core Indexing 使用，也可以支持自定义应用程序特定的索引处理器
-进行实时区块链数据处理。在这里了解更多。"
-  />
+  <LinkCard href="/zh/build/indexer/txn-stream" title="Transaction Stream API" description="面向 Aptos Core Indexing 和自定义处理器的历史与实时交易 gRPC 流" />
 </CardGrid>
 
-## Faucet (Only Devnet)
+## 水龙头（Devnet 和 Testnet）
 
 <CardGrid>
-  <LinkCard href="/zh/build/apis/faucet-api" title="Faucet API" description="该 API 提供在开发网和测试网上接收测试代币的能力。其主要目的是在将应用程序和 Move 合约部署到主网之前进行开发和测试。" />
+  <LinkCard href="/zh/build/apis/faucet-api" title="水龙头 API" description="在 Devnet 上以编程方式铸造测试 APT，或在 Testnet 上通过 Google 登录 / 铸币页面铸造" />
 </CardGrid>
 
-上述 API 的代码在 [GitHub](https://github.com/aptos-labs/aptos-core) 上开源.因此,任何人都可以操作这些 API,全球有许多独立的运营商和开发者选择这样做.
+## Geomi 与数据提供商
 
-todo translate
-For testnet, you can mint APT at the [mint page](/zh/network/faucet).
+<CardGrid>
+  <LinkCard href="/zh/build/apis/aptos-labs-developer-portal" title="Geomi" description="为 Aptos Labs 托管 API 提供 API 密钥、更高速率限制、gas 代付和无代码索引" />
 
-### Aptos Labs 运营的 API 部署
+  <LinkCard href="/zh/build/apis/data-providers" title="数据提供商" description="SQL 数据集、分析仪表板和第三方 RPC 端点" />
+</CardGrid>
 
-[Aptos Labs](https://aptoslabs.com) 代表 [Aptos Foundation](https://aptosnetwork.com/foundation) 为每个 [Aptos Network](/zh/network/nodes/networks) 运营这些 API 部署,并将其公开供大家使用.
+节点 API、Indexer、Transaction Stream 和水龙头的实现均在 [aptos-core](https://github.com/aptos-labs/aptos-core) 开源。任何人都可以运行它们；全球有许多独立运营商和开发者选择这样做。更多 RPC 供应商见 [Aptos 生态目录](https://aptosnetwork.com/ecosystem/directory/category/rpc)。
 
-目前有两组 Aptos Labs API 部署:
+## 身份验证与速率限制
 
-1. [具有匿名访问和基于 IP 的速率限制的 API](/zh/network/nodes/networks)
-2. [\[Beta\] 通过 Aptos Labs Developer Portal 进行身份验证和基于开发者账户的速率限制的 API](/zh/build/apis/aptos-labs-developer-portal)
+Labs 托管的节点、Indexer 和 Transaction Stream API 允许**匿名**访问，并按 IP 设置较低的速率限制。要获得更高限额和使用指标，请创建 [Geomi](https://geomi.dev/) API 密钥，并以 bearer token 发送。
+
+```shellscript filename="Terminal"
+curl "https://api.mainnet.aptoslabs.com/v1" \
+  -H "Authorization: Bearer YOUR_API_KEY"
+```
+
+```typescript filename="index.ts"
+import { Aptos, AptosConfig, Network } from "@aptos-labs/ts-sdk";
+
+const aptos = new Aptos(
+  new AptosConfig({
+    network: Network.MAINNET,
+    clientConfig: { API_KEY: process.env.APTOS_API_KEY },
+  }),
+);
+```
+
+<Aside type="note">
+  用量以计算单元（CU）计量，组织同时还受 HTTP 速率限制。当前限额和定价见 [Geomi 计费文档](https://geomi.dev/docs/admin/billing)。请按 [Geomi 入门指南](https://geomi.dev/docs/start) 创建密钥。
+</Aside>

--- a/src/content/docs/zh/build/apis/aptos-labs-developer-portal.mdx
+++ b/src/content/docs/zh/build/apis/aptos-labs-developer-portal.mdx
@@ -1,16 +1,47 @@
 ---
-title: "Aptos Labs API Gateway"
-description: "通过 Aptos Labs API Gateway 访问 API、gas 代付服务和无代码索引功能"
+title: "Aptos Labs Geomi"
+description: "通过 Geomi 开发者门户访问 Aptos Labs API、gas 代付服务和无代码索引"
 sidebar:
-  label: "API Gateway"
+  label: "Geomi"
 ---
 
 import { Aside } from '@astrojs/starlight/components';
 
+[Geomi](https://geomi.dev) 是 Aptos Labs 的开发者门户，提供托管的节点 API、Indexer GraphQL、Transaction Stream、gas 代付以及无代码索引。创建账户即可获得 API 密钥、更高的速率限制和使用指标。
+
 <Aside type="note">
-  API Gateway 目前处于测试阶段.如果您遇到任何问题,请在aptos-core存储库中创建一个问题报告 [issue](https://github.com/aptos-labs/aptos-core/issues/new?assignees=@geekflyer,@dport,@blakezimmerman\&labels=api-gateway\&projects=\&template=dev_portal_issue.md\&title=%5BDev+Portal%5D).
+  Geomi 目前处于测试阶段。如遇问题，请在 [aptos-core](https://github.com/aptos-labs/aptos-core/issues/new) 中提交 issue。旧的 `developers.aptoslabs.com` 网址会重定向到 Geomi。
 </Aside>
 
-[API Gateway](https://developers.aptoslabs.com) 是 Aptos Labs 提供的 API 的入口,为您的 dapp 提供快速,简便的支持.它由一个门户(UI)和由 Aptos Labs 运营的一组 API 网关组成.
+## API 密钥
 
-在专门的 [API Gateway 文档网站](https://developers.aptoslabs.com/docs) 上了解更多关于 API Gateway 的信息.
+Labs 托管 API 允许匿名请求，但按 IP 限额较低。将 Geomi API 密钥作为 bearer token 附加即可获得更高限额：
+
+```shellscript filename="Terminal"
+curl "https://api.mainnet.aptoslabs.com/v1" \
+  -H "Authorization: Bearer YOUR_API_KEY"
+```
+
+```typescript filename="index.ts"
+import { Aptos, AptosConfig, Network } from "@aptos-labs/ts-sdk";
+
+const aptos = new Aptos(
+  new AptosConfig({
+    network: Network.MAINNET,
+    clientConfig: { API_KEY: process.env.APTOS_API_KEY },
+  }),
+);
+```
+
+**服务端密钥**（前缀 `aptoslabs_`）应保留在后端。**客户端密钥**（前缀 `AG-`）用于浏览器、移动应用和扩展；创建时请配置允许的来源和每 IP 限额。详见 [API 密钥](https://geomi.dev/docs/api-keys) 和[入门指南](https://geomi.dev/docs/start)。
+
+## Geomi 托管的服务
+
+| 服务                                        | 文档                                                   |
+| ----------------------------------------- | ---------------------------------------------------- |
+| 节点 API、Indexer GraphQL、Transaction Stream | [Geomi API 参考](https://geomi.dev/docs/api-reference) |
+| 速率限制与计算单元计费                               | [计费](https://geomi.dev/docs/admin/billing)           |
+| Gas Station                               | [Gas Stations](https://geomi.dev/docs/gas-stations)  |
+| 无代码索引                                     | [无代码索引](https://geomi.dev/docs/no-code-indexing)     |
+
+官方网络 URL 见 [Aptos APIs](/zh/build/apis) 和[网络](/zh/network/nodes/networks)。

--- a/src/content/docs/zh/build/apis/data-providers.mdx
+++ b/src/content/docs/zh/build/apis/data-providers.mdx
@@ -5,44 +5,45 @@ sidebar:
   label: "数据提供商"
 ---
 
-如果您需要访问 Aptos 区块链数据但无需实时获取.
-我们提供了几种选项让您可以通过 SQL 或 UI 仪表盘访问这些数据.
-这类数据通常用于分析场景,因为它支持聚合操作.
+# 数据提供商
 
-## 数据端点概览
+除全节点提供的 API 之外，还可以通过以下方式获取 Aptos 区块链数据。
 
-直接访问全节点将获取最新数据(除非是归档全节点,否则不包含历史数据),使用 [REST API](/zh/build/apis#aptos-fullnode)
+## Aptos 数据端点概览
 
-在此之上的索引器层提供 [GRPC 交易流](/zh/build/indexer/txn-stream/aptos-hosted-txn-stream)
+[REST API](/zh/build/apis/fullnode-rest-api) 可直接查询全节点，数据最新（除非是归档全节点，否则不包含历史数据）。
 
-基于这个交易流,我们构建了一些可通过 [GraphQL](/zh/build/indexer) 查询的产品逻辑表
+[gRPC 交易流](/zh/build/indexer/txn-stream/aptos-hosted-txn-stream) 是我们构建的流式层，提供上述数据的类型化版本。
 
-由于交易解析逻辑是 [公开的](https://github.com/aptos-labs/aptos-indexer-processors-v2),部分供应商已实现类似的解析逻辑来创建数据表子集并开放查询.
+[GraphQL](/zh/build/indexer) 提供可查询的产品表（例如转账和余额）。
+
+产品表从交易中解析而来，逻辑是[公开的](https://github.com/aptos-labs/aptos-indexer-processors-v2)。部分供应商实现了类似的解析逻辑，创建了数据表子集并开放查询。
 
 ## SQL 数据表
 
-索引器定义了多个处理器来创建不同的数据库表.
+Indexer（为 GraphQL 端点提供支持的技术栈）定义了多个处理器，在 Postgres 中创建不同的产品表。
+
+这类数据常用于分析，因为它支持聚合操作。
 
 ### 核心表
 
-这些表直接解析自节点 API 响应,一种方案是将它们拆分为以下表:
+这些表包含与 REST API 非常相似的原始数据。注意：通常使用（交易）版本号而不是交易哈希。
 
-- 区块 - 版本号,区块高度,epoch,时间戳
-- 交易 - 版本号,发送方,入口函数,gas
-- 签名 - 签名类型,签名者,费用支付地址
+- 区块 - 版本号、区块高度、epoch、时间戳
+- 交易 - 版本号、类型、发送方、入口函数、gas
+- 签名 - 签名类型、签名者、费用支付地址
 - 事件 - 事件类型和数据
 
-我们将数据存储为表项(table items),资源(resources)或模块(modules):
+链上数据存储为：[表项](/zh/build/smart-contracts/table)、[资源](/zh/network/blockchain/resources) 或[模块](/zh/build/smart-contracts/modules-on-aptos)（可执行）
 
-- (写入集)变更 - 变更索引,变更类型,资源地址
-- 表项 - 表键,表句柄,键(内容与类型),值(内容与类型)
-- (Move)资源 - 资源地址,资源类型,数据
-- (Move)模块 - 已部署模块的字节码
+- （写入集）变更 - 变更索引、变更类型（对何种数据执行写入或删除）、资源地址
+- 表项 - 表键、表句柄、解码后的键（内容与类型）、值（内容与类型）
+- （Move）资源 - 资源地址、资源类型、数据
+- （Move）模块 - 已部署模块的字节码、friends 和对外函数
 
-## 链下数据供应商
+## 核心表与指标供应商：
 
-我们大多数数据供应商仅提供核心数据集.
-以下是 [部分供应商列表](https://aptosnetwork.com/currents/aptos-on-chain-data-capabilities-with-dune-nansen-and-other-providers)
+我们提供了若干可通过 SQL 或仪表板 UI 访问这些数据的选项。
 
 ### Google BigQuery 公共数据集
 
@@ -50,37 +51,66 @@ sidebar:
 
 ![bq\_sql](~/images/screenshots/bq_sql.png)
 
-我们还提供了 [使用上述资源](https://github.com/aptos-labs/explorer/tree/main/analytics) 的分析查询示例
+我们还提供了[使用上述资源](https://github.com/aptos-labs/explorer/tree/main/analytics) 的分析查询示例
 
 ### Dune
 
-我们的仪表盘地址:[https://dune.com/aptos/aptos-chain-metrics-overview](https://dune.com/aptos/aptos-chain-metrics-overview)
-
-### Flipside
-
-另一个仪表盘供应商,核心表中的签名已合并至 `fact_transactions`
-他们还提供了一些便利表(DeFi,NFT,价格),[表清单](https://flipsidecrypto.github.io/aptos-models/#!/overview)
-
-### Artemis
-
-提供 [关键指标](https://app.artemis.xyz/asset/aptos) 和图表构建工具
-
-### Nansen
-
-提供 [关键指标](https://app.nansen.ai/macro/blockchains?chain=aptos) 及账户附加功能
+仪表板地址：[https://dune.com/aptos/aptos-chain-metrics-overview](https://dune.com/aptos/aptos-chain-metrics-overview)
 
 ### Allium
 
-原始数据地址:[https://docs.allium.so/historical-data/supported-blockchains/move-ecosystem/aptos](https://docs.allium.so/historical-data/supported-blockchains/move-ecosystem/aptos)
+为 DefiLlama、rwa.xyz 等下游供应商提供数据。原始数据见：[https://docs.allium.so/historical-data/supported-blockchains/move-ecosystem/aptos](https://docs.allium.so/historical-data/supported-blockchains/move-ecosystem/aptos)
+他们还提供稳定币转账数据：[https://docs.allium.so/historical-data/stablecoins#stablecoin-metrics](https://docs.allium.so/historical-data/stablecoins#stablecoin-metrics)
+
+### Artemis
+
+提供[关键指标](https://app.artemis.xyz/asset/aptos) 以及图表构建工具
+
+### Nansen
+
+提供[关键指标](https://app.nansen.ai/macro/blockchains?chain=aptos)，账户可使用附加功能
 
 ### Sentio
 
-他们在这里提供了指南:[https://docs.sentio.xyz/docs/aptos](https://docs.sentio.xyz/docs/aptos)  数据可以在 data source -> external project -> sentio/aptos-overview 路径下找到\
-他们还提供交易的堆栈追踪功能
+他们有一份[指南](https://docs.sentio.xyz/docs/aptos)，
+数据位于 data source -> external project -> sentio/aptos-overview
+他们还提供交易的[堆栈追踪](https://app.sentio.xyz/explorer)
 
-## 其他供应商
+### RWA.xyz
 
-我们还有一些面向更企业级使用场景的合作伙伴- [Token Terminal](https://tokenterminal.com/resources/articles/aptos-data-partnership)
+[仪表板](https://app.rwa.xyz/networks/aptos) 提供 RWA 的高层指标。
+查看稳定币详情需要创建账户。
 
+### Pangea
+
+提供[原始数据](https://docs.pangea.foundation/overview/)、
+Coin/FA 转账以及部分 DEX 解析。
+
+### 其他供应商
+
+我们还有一些面向更企业级使用场景的合作伙伴
+
+- [Token Terminal](https://tokenterminal.com/resources/articles/aptos-data-partnership)
 - [The Tie](https://www.thetie.io/insights/news/introducing-aptos-ecosystem-dashboard-and-on-chain-data/)
 - [Elliptic](https://www.elliptic.co/media-center/elliptic-partners-with-aptos-foundation-as-a-data-integration-provider-to-offer-compliance-screening-and-risk-services-for-aptos-network)
+
+## 实时数据供应商
+
+- [Geomi](https://geomi.dev/)（原 Aptos Build）
+  - 提供 [API 密钥](https://geomi.dev/docs/start)，以提高 REST API 和 gRPC 交易流的速率限制。
+  - 提供[无代码索引](https://geomi.dev/docs/no-code-indexing)，将事件解析为可查询的表。
+- [NODEREAL](https://nodereal.io/aptos) 提供 REST API 端点
+- [Shinami](https://docs.shinami.com/developer-guides/aptos) 提供 Aptos 节点访问、gas 代付和钱包服务
+- [QuickNode](https://www.quicknode.com/chains/apt) 提供 REST API 端点
+- [Codex](https://docs.codex.io/networks/aptos) 提供 GraphQL API 和 WebSocket 订阅，覆盖 Aptos 代币价格、交易对、持有人和钱包余额（网络 ID `49705`）
+
+更多 RPC 供应商见 [此处](https://aptosnetwork.com/ecosystem/directory/category/rpc)
+
+## 数据分析提示
+
+- Aptos [数据概览](https://medium.com/aptoslabs/data-analyst-guide-to-aptos-pt-1-816367edc1c5)（第 1 部分）
+- 解析 [DeFi Swaps](https://medium.com/aptoslabs/data-analyst-guide-to-aptos-defi-swaps-pt2-e343ac6be84e)（第 2 部分）
+- 计算[供应与成交量](https://medium.com/aptoslabs/data-analyst-guide-to-aptos-supply-and-volume-pt-3-535e312946ad)（第 3 部分）
+- [Aptos Explorer 分析查询](https://github.com/aptos-labs/explorer/tree/main/analytics)
+- [Dune 上的 Aptos Spellbook](https://github.com/duneanalytics/spellbook/tree/main/dbt_subprojects/daily_spellbook/models/aptos)
+- 可使用 [Revela](https://revela.verichains.io/) 或 Aptos CLI（`aptos move decompile --decompiler-version v2`）反编译模块字节码

--- a/src/content/docs/zh/build/apis/faucet-api.mdx
+++ b/src/content/docs/zh/build/apis/faucet-api.mdx
@@ -1,72 +1,122 @@
 ---
 title: "水龙头 API"
-description: "使用水龙头 API 在 Devnet 上获取免费的 APT 代币，用于开发和测试"
+description: "使用水龙头 API、SDK、CLI 或测试网铸币页面，在 Devnet 和 Testnet 上铸造测试 APT"
 sidebar:
   label: "水龙头 API"
 ---
 
-水龙头允许用户在 Devnet 上获取 `APT`。在 Testnet 上，您只能通过[铸币页面](/zh/network/faucet)铸造代币。Mainnet 不提供水龙头。
+import { Aside } from '@astrojs/starlight/components';
 
-水龙头端点如下：
+水龙头用于铸造测试 `APT`，便于在进入主网之前进行开发。**Devnet** 可直接以编程方式调用，无需 Google 登录。**Testnet** 需要 Google 登录（[铸币页面](/zh/network/faucet) 或带 Firebase ID token 的 `POST /fund`）。主网没有水龙头。
 
-- Devnet：[https://faucet.devnet.aptoslabs.com](https://faucet.devnet.aptoslabs.com)
+金额单位为 [Octa](/zh/network/glossary#octa)（`1 APT = 100,000,000` Octa）。
 
-## 使用水龙头
+| 网络  | 端点                                     | 如何铸造                                                           |
+| --- | -------------------------------------- | -------------------------------------------------------------- |
+| 开发网 | `https://faucet.devnet.aptoslabs.com`  | SDK、CLI 或无需鉴权的 `POST /fund`                                    |
+| 测试网 | `https://faucet.testnet.aptoslabs.com` | [铸币页面](/zh/network/faucet)，或使用 Google ID token 调用 `POST /fund` |
+| 主网  | —                                      | 不可用                                                            |
 
-每个 SDK 都集成了 Devnet 水龙头。以下提供几个示例；更多信息请参阅各个 [SDK 文档](/zh/build/sdks)。
+OpenAPI（实时）：[Devnet 规范](https://faucet.devnet.aptoslabs.com/spec.yaml) 和 [Testnet 规范](https://faucet.testnet.aptoslabs.com/spec.yaml)。浏览器：[Devnet `/spec`](https://faucet.devnet.aptoslabs.com/spec)。源码：[crates/aptos-faucet/doc/spec.yaml](https://github.com/aptos-labs/aptos-core/blob/main/crates/aptos-faucet/doc/spec.yaml)。
 
-### 在钱包中使用水龙头
+当前操作为带 JSON `FundRequest` 请求体的 **`POST /fund`**（提供 `address`、`auth_key` 或 `pub_key`，以及可选的 `amount`）。Devnet 仍接受旧版 **`POST /mint?amount=&address=`** 查询；新集成应使用 `/fund`。
 
-大多数钱包（例如 [Petra](https://aptosnetwork.com/ecosystem/directory/petra)）都提供 Devnet 水龙头按钮。完整列表请参阅 [Aptos 钱包](https://aptosnetwork.com/ecosystem/projects/wallets)。
+## 在钱包中使用水龙头
 
-### 在 Aptos CLI 中使用水龙头
+大多数钱包（例如 [Petra](https://aptosnetwork.com/ecosystem/directory/petra)）都提供 Devnet 水龙头按钮。完整列表见 [Aptos 钱包目录](https://aptosnetwork.com/ecosystem/projects/wallets)。
 
-完成 [CLI 设置](/zh/build/cli/setup-cli)后，您只需调用 `fund-with-faucet`。金额单位为 Octa（1 APT = 100,000,000 Octa）。
+## 在 Aptos CLI 中使用水龙头
+
+完成 [CLI 设置](/zh/build/cli/setup-cli) 后，可在 **Devnet** 上为账户充值：
 
 ```shellscript filename="Terminal"
 aptos account fund-with-faucet --account 0xd0f523c9e73e6f3d68c16ae883a9febc616e484c4998a72d8899a1009e5a89d6 --amount 100000000
 ```
 
-### 在 TypeScript SDK 中使用水龙头
+在 Testnet 上请使用[铸币页面](/zh/network/faucet)，而不是此命令。
 
-以下示例在 Devnet 中向账户 `0xd0f523c9e73e6f3d68c16ae883a9febc616e484c4998a72d8899a1009e5a89d6` 充值 1 APT。金额单位为 Octa（1 APT = 100,000,000 Octa）。
+## 在 TypeScript SDK 中使用水龙头
+
+以下示例在 Devnet 上向 `0xd0f523c9e73e6f3d68c16ae883a9febc616e484c4998a72d8899a1009e5a89d6` 充值 1 APT。
 
 ```typescript filename="index.ts"
 import { Aptos, AptosConfig, Network } from "@aptos-labs/ts-sdk";
 
-const aptos = new Aptos(new AptosConfig({network: Network.Devnet}));
-aptos.fundAccount({accountAddress: "0xd0f523c9e73e6f3d68c16ae883a9febc616e484c4998a72d8899a1009e5a89d6", amount: 100000000});
+const aptos = new Aptos(new AptosConfig({ network: Network.DEVNET }));
+await aptos.fundAccount({
+  accountAddress: "0xd0f523c9e73e6f3d68c16ae883a9febc616e484c4998a72d8899a1009e5a89d6",
+  amount: 100_000_000,
+});
 ```
 
-### 在 Go SDK 中使用水龙头
+更多客户端示例见各个 [SDK](/zh/build/sdks)。
 
-以下示例在 Devnet 中向账户 `0xd0f523c9e73e6f3d68c16ae883a9febc616e484c4998a72d8899a1009e5a89d6` 充值 1 APT。金额单位为 Octa（1 APT = 100,000,000 Octa）。
+## 在 Python SDK 中使用水龙头
 
-```go filename="index.go"
-import "github.com/aptos-labs/aptos-go-sdk"
+```python filename="fund.py"
+from aptos_sdk.v2 import Aptos, AptosConfig, Network
+
+async with Aptos(AptosConfig(network=Network.DEVNET)) as aptos:
+    await aptos.faucet.fund_account(
+        "0xd0f523c9e73e6f3d68c16ae883a9febc616e484c4998a72d8899a1009e5a89d6",
+        100_000_000,
+    )
+```
+
+## 在 Go SDK 中使用水龙头
+
+```go filename="fund.go"
+package main
+
+import (
+	"github.com/aptos-labs/aptos-go-sdk"
+)
 
 func main() {
-	client, err := aptos.NewClient(aptos.LocalnetConfig)
+	client, err := aptos.NewClient(aptos.DevnetConfig)
 	if err != nil {
-		panic(err)
+		panic("Failed to create client: " + err.Error())
 	}
 
-  client.Fund("0xd0f523c9e73e6f3d68c16ae883a9febc616e484c4998a72d8899a1009e5a89d6", 100000000)
+	address := aptos.AccountAddress{}
+	err = address.ParseStringRelaxed("0xd0f523c9e73e6f3d68c16ae883a9febc616e484c4998a72d8899a1009e5a89d6")
+	if err != nil {
+		panic("Failed to parse address: " + err.Error())
+	}
+
+	err = client.Fund(address, 100_000_000)
+	if err != nil {
+		panic("Failed to fund account: " + err.Error())
+	}
 }
 ```
 
-### 调用水龙头：SDK 不支持的其他语言
+## 不使用 SDK 调用水龙头
 
-如果您尝试在其他语言中调用水龙头，有两种选择：
-
-1. 根据 [OpenAPI 规范](https://github.com/aptos-labs/aptos-core/blob/main/crates/aptos-faucet/doc/spec.yaml)生成客户端。
-2. 自行调用水龙头。
-
-对于后一种方式，请构建类似以下的查询：
+在 Devnet 上调用 `POST /fund`：
 
 ```shellscript filename="Terminal"
-curl -X POST
-'https://faucet.devnet.aptoslabs.com/mint?amount=10000&address=0xd0f523c9e73e6f3d68c16ae883a9febc616e484c4998a72d8899a1009e5a89d6'
+curl -X POST "https://faucet.devnet.aptoslabs.com/fund" \
+  -H "Content-Type: application/json" \
+  -d '{"address":"0xd0f523c9e73e6f3d68c16ae883a9febc616e484c4998a72d8899a1009e5a89d6","amount":100000000}'
 ```
 
-这意味着向地址 `0xd0f523c9e73e6f3d68c16ae883a9febc616e484c4998a72d8899a1009e5a89d6` 铸造 10000 个 [Octa](/zh/network/glossary#Octa)。
+成功响应类似 `{"txn_hashes":["..."]}`。如果省略 `amount`，水龙头会使用配置的默认值（不超过最大铸造额度）。
+
+<Aside type="note">
+  如果未使用官方 SDK，可以根据 [OpenAPI 规范](https://faucet.devnet.aptoslabs.com/spec.yaml) 生成类型化客户端。
+</Aside>
+
+### Testnet：Google 登录
+
+Testnet 的 `POST /fund` 需要人工完成 Google 登录。[铸币页面](/zh/network/faucet) 会代你完成该流程。若要直接调用 API，请发送 Firebase 项目 `aptos-api-gateway-prod` 的 ID token（scopes 为 `openid`、`email`、`profile`）：
+
+```shellscript filename="Terminal"
+curl -X POST "https://faucet.testnet.aptoslabs.com/fund" \
+  -H "Authorization: Bearer FIREBASE_ID_TOKEN" \
+  -H "x-is-jwt: true" \
+  -H "Content-Type: application/json" \
+  -d '{"address":"0xd0f523c9e73e6f3d68c16ae883a9febc616e484c4998a72d8899a1009e5a89d6"}'
+```
+
+没有智能体注册捷径。OAuth 发现文档见 [`/auth.md`](/auth.md)。

--- a/src/content/docs/zh/build/apis/fullnode-rest-api.mdx
+++ b/src/content/docs/zh/build/apis/fullnode-rest-api.mdx
@@ -7,86 +7,104 @@ sidebar:
 
 import { Aside, CardGrid, LinkCard } from '@astrojs/starlight/components';
 
-该 API 内置于全节点中,提供了一种简单,低延迟但底层的方式来读取状态和向 Aptos 区块链提交交易.它还支持交易模拟功能.
-如需进行更高级的查询,我们推荐使用 [索引器 GraphQL API](/zh/build/indexer).
+该 API 随每个全节点一起提供，是读取状态、提交交易和模拟交易的简单、低延迟、底层方式。如需查询 NFT、对象、历史活动或聚合表，请改用 [Indexer GraphQL API](/zh/build/indexer)。
 
-## 全节点 REST API 浏览器
+Aptos Labs 基址：`https://api.{network}.aptoslabs.com/v1`，例如 `https://api.mainnet.aptoslabs.com/v1`。`fullnode.{network}.aptoslabs.com` 是同一服务的别名。
+
+## 规范与浏览器
+
+节点 API 使用 OpenAPI 3.0（`Aptos Node API` 1.2.0）。本站发布规范及生成的参考文档；每个网络还托管实时 Swagger UI。
 
 <CardGrid>
-  <LinkCard href="https://api.mainnet.aptoslabs.com/v1/spec#/" title="主网全节点 REST API" description="主网 REST API 浏览器" target="_blank" />
+  <LinkCard href="/rest-api" title="REST API 参考" description="由 aptos-spec.json 生成的可浏览文档" />
 
-  <LinkCard href="https://api.testnet.aptoslabs.com/v1/spec#/" title="测试网全节点 REST API" description="测试网 REST API 浏览器" target="_blank" />
+  <LinkCard href="/aptos-spec.json" title="OpenAPI 规范（JSON）" description="机器可读的 Aptos 节点 API 规范" />
 
-  <LinkCard href="https://api.devnet.aptoslabs.com/v1/spec#/" title="开发网全节点 REST API" description="开发网 REST API 浏览器" target="_blank" />
+  <LinkCard href="https://api.mainnet.aptoslabs.com/v1/spec#/" title="主网浏览器" description="主网实时 Swagger UI" target="_blank" />
+
+  <LinkCard href="https://api.testnet.aptoslabs.com/v1/spec#/" title="测试网浏览器" description="测试网实时 Swagger UI" target="_blank" />
+
+  <LinkCard href="https://api.devnet.aptoslabs.com/v1/spec#/" title="开发网浏览器" description="开发网实时 Swagger UI" target="_blank" />
 </CardGrid>
 
-## 理解速率限制
+节点上的规范 YAML 为 `GET /v1/spec.yaml`。健康检查为 `GET /v1/-/healthy`。账本信息（chain ID、版本、epoch、角色）为 `GET /v1`。节点身份为 `GET /v1/info`。
 
-与 [Aptos 索引器](/zh/build/indexer/indexer-api) 类似,Aptos REST API 也基于计算单元设有速率限制.您可以通过阅读 [Geomi 文档](https://geomi.dev/docs/admin/billing) 了解更多关于速率限制的工作原理.
+```shellscript filename="Terminal"
+curl "https://api.mainnet.aptoslabs.com/v1"
+```
+
+## 身份验证与速率限制
+
+匿名访问按 IP 限额。附加 [Geomi](https://geomi.dev/) API 密钥可获得更高限额：
+
+```shellscript filename="Terminal"
+curl "https://api.mainnet.aptoslabs.com/v1/accounts/0x1" \
+  -H "Authorization: Bearer YOUR_API_KEY"
+```
+
+Labs 托管的节点和 Indexer API 以计算单元计费，并同时执行 HTTP 速率限制。详见 [Geomi 计费文档](https://geomi.dev/docs/admin/billing)。
+
+## 常用操作
+
+| 操作           | 方法与路径                                                           | 参考                                                                                |
+| ------------ | --------------------------------------------------------------- | --------------------------------------------------------------------------------- |
+| 账本信息         | `GET /v1`                                                       | [get\_ledger\_info](/rest-api/operations/get_ledger_info)                         |
+| 健康检查         | `GET /v1/-/healthy`                                             | [healthy](/rest-api/operations/healthy)                                           |
+| 账户           | `GET /v1/accounts/{address}`                                    | [get\_account](/rest-api/operations/get_account)                                  |
+| Coin 或 FA 余额 | `GET /v1/accounts/{address}/balance/{asset_type}`               | [get\_account\_balance](/rest-api/operations/get_account_balance)                 |
+| View 函数      | `POST /v1/view`                                                 | [view](/rest-api/operations/view)                                                 |
+| 提交交易         | `POST /v1/transactions`                                         | [submit\_transaction](/rest-api/operations/submit_transaction)                    |
+| 模拟交易         | `POST /v1/transactions/simulate`                                | [simulate\_transaction](/rest-api/operations/simulate_transaction)                |
+| 按版本查询交易      | `GET /v1/transactions/by_version/{txn_version}`                 | [get\_transaction\_by\_version](/rest-api/operations/get_transaction_by_version)  |
+| 账户交易         | `GET /v1/accounts/{address}/transactions`                       | [get\_account\_transactions](/rest-api/operations/get_account_transactions)       |
+| 按事件句柄查询事件    | `GET /v1/accounts/{address}/events/{event_handle}/{field_name}` | [get\_events\_by\_event\_handle](/rest-api/operations/get_events_by_event_handle) |
+
+[get\_account\_balance](/rest-api/operations/get_account_balance) 的 `asset_type` 可以是 Coin 类型（例如 `0x1::aptos_coin::AptosCoin`），也可以是同质化资产元数据地址（例如 APT 的 `0xa`）。在 [同质化资产迁移](/zh/build/smart-contracts/fungible-asset) 之后，请优先使用该端点（或 SDK 辅助方法如 `getAccountAPTAmount`），而不是读取 `CoinStore` 资源。
 
 ## 查看当前和历史状态
 
-大多数与 Aptos 区块链的集成都需要全面了解区块链当前和历史状态.Aptos 提供了历史交易,状态和事件,这些都是交易执行的结果.
+大多数集成需要同时了解当前和历史状态。Aptos 提供历史交易、状态和事件，这些都是交易执行的结果。
 
-- 历史交易包含执行状态,输出以及与相关事件的关联.每笔交易都有一个唯一的版本号,用于确定其在区块链账本历史中的全局顺序.
-- 状态表示截至特定版本的所有交易输出.换句话说,状态版本是包含该交易版本之前所有交易的累积结果.
-- 交易执行时可能会触发事件.[事件](/zh/network/blockchain/events) 是关于链上数据变更的提示信息.
+- 历史交易包含执行状态、输出以及相关事件。每笔交易都有唯一的**版本号**，表示它在账本中的全局顺序。
+- 某一版本的状态是截至并包含该版本的所有交易输出的累积。
+- 执行交易时可能会发出[事件](/zh/network/blockchain/events)，提示链上数据发生了变化。
 
 <Aside type="note">
-  请确保您通信的 [全节点](/zh/network/nodes/networks) 是最新版本。全节点必须达到包含您交易的版本才能从中检索相关数据。全节点从 [验证器全节点](/zh/network/blockchain/fullnodes) 获取状态可能存在延迟，而验证器全节点又依赖于 [验证器节点](/zh/network/blockchain/validator-nodes) 作为真实数据源。
+  你查询的[全节点](/zh/network/nodes/networks)必须已经达到包含目标数据的版本。公共全节点会滞后于[验证者全节点](/zh/network/blockchain/fullnodes)，而验证者全节点跟随[验证者节点](/zh/network/blockchain/validator-nodes)。
 </Aside>
 
-节点上的存储服务采用两种数据修剪机制来清除数据:
+节点会裁剪旧的账本历史（也可以裁剪状态）以限制磁盘占用。默认窗口保留最近 1.5 亿笔交易；几乎所有主网和测试网节点都使用该默认值。只有在运行自己的节点时才应禁用或调整裁剪——见[数据裁剪](/zh/network/nodes/configure/data-pruning)。超出裁剪窗口的历史数据请使用 [Indexer](/zh/build/indexer)。
 
-- 状态数据
-- 事件,交易等其他所有数据虽然可以禁用其中任一功能,但存储状态版本并不是特别可持续的做法.
-
-可以通过在 `storage_config.rs` 中将 [`enable_ledger_pruner`](https://github.com/aptos-labs/aptos-core/blob/cf0bc2e4031a843cdc0c04e70b3f7cd92666afcf/config/src/config/storage_config.rs#L141) 设置为 `false` 来禁用事件和交易剪枝功能.这在 Mainnet 中是默认行为.在不久的将来,Aptos 将提供索引器来减少直接从节点查询的需求.
-
-REST API 提供以下方式查询交易和事件:
-
-- [按账户查询交易](https://api.devnet.aptoslabs.com/v1/spec#/operations/get_account_transactions)
-- [按版本查询交易](https://api.devnet.aptoslabs.com/v1/spec#/operations/get_transaction_by_version)
-- [按事件句柄查询事件](https://api.devnet.aptoslabs.com/v1/spec#/operations/get_events_by_event_handle)
+按账户查询交易只返回该账户的序列号交易，不会返回该账户发送的[无序交易](/zh/build/guides/orderless-transactions)。
 
 ## 使用 View 函数读取状态
 
-通过 API 调用时,View 函数不会修改区块链状态.[View 函数](https://github.com/aptos-labs/aptos-core/blob/main/api/src/view_function.rs) 及其 [输入参数](https://github.com/aptos-labs/aptos-core/blob/main/api/types/src/view.rs) 可用于通过 Move 读取潜在的复杂链上状态.例如,您可以评估拍卖合约中的最高出价者.以下是相关文件:
+通过 API 调用时，View 函数不会修改区块链状态。View 函数及其参数可以用 Move 计算复杂的链上状态，例如拍卖中的最高出价。REST 操作为 [POST /view](/rest-api/operations/view)。
 
-- [`view_function.rs`](https://github.com/aptos-labs/aptos-core/blob/main/api/src/tests/view_function.rs) 示例
-- 相关 [Move](https://github.com/aptos-labs/aptos-core/blob/90c33dc7a18662839cd50f3b70baece0e2dbfc71/aptos-move/framework/aptos-framework/sources/coin.move#L226) 代码
-- [规范说明](https://github.com/aptos-labs/aptos-core/blob/90c33dc7a18662839cd50f3b70baece0e2dbfc71/api/doc/spec.yaml#L8513)
+该调用类似模拟，但没有副作用，并返回函数输出。你需要提供模块、函数名、类型参数和值。函数不必是不可变的才能使用 `#[view]`；即使函数可变，API 也不会提交状态。建议将此类函数设为私有，以免在运行时被当作入口函数调用。
 
-View 函数的运行方式类似于 Aptos 模拟 API,但没有副作用且具有可访问的输出路径.可以通过 `/view` 端点调用 View 函数.调用 View 函数需要提供模块名,函数名以及输入类型参数和值.
+框架模块已经暴露 View 函数，因此无需发布模块即可试用该端点：
 
-函数不必是不可变的才能标记为 `#[view]`,但如果函数是可变的,通过 API 调用时不会导致状态变更.如果要标记可变函数为 `#[view]`,建议将其设为私有,以防止在运行时被恶意调用.
-
-要使用 View 函数,需要通过 [Aptos CLI](/zh/build/cli) [发布模块](/zh/build/cli/working-with-move-contracts).
-
-在 Aptos CLI 中,View 函数请求示例如下:
-
-```shellscript filename="终端"
-aptos move view --function-id devnet::message::get_message --profile devnet --args address:devnet
-{
-  "Result": [
-    "View functions rock!"
-  ]
-}
+```shellscript filename="Terminal"
+curl -X POST "https://api.mainnet.aptoslabs.com/v1/view" \
+  -H "Content-Type: application/json" \
+  -d '{"function":"0x1::chain_id::get","type_arguments":[],"arguments":[]}'
 ```
 
-在 TypeScript SDK 中,View 函数请求示例如下:
+```shellscript filename="Terminal"
+aptos move view --function-id 0x1::chain_id::get
+```
 
 ```typescript filename="index.ts"
-import { Aptos } from "@aptos-labs/ts-sdk";
+import { Aptos, AptosConfig, Network, type InputViewFunctionData } from "@aptos-labs/ts-sdk";
 
-const aptos = new Aptos();
-const [balance] = aptos.view<[string]>({
-  function: "0x1::coin::balance",
-  typeArguments: ["0x1::aptos_coin::AptosCoin"],
-  functionArguments: [alice.accountAddress]
-});
-
-expect(balance).toBe("100000000");
+const aptos = new Aptos(new AptosConfig({ network: Network.MAINNET }));
+const payload: InputViewFunctionData = {
+  function: "0x1::chain_id::get",
+};
+const [chainId] = await aptos.view<[number]>({ payload });
 ```
 
-视图函数返回一个值列表作为向量.默认情况下,结果以 JSON 格式返回;不过,也可以选择以 Binary Canonical Serialization (BCS) 编码格式返回.
+对于你自己的模块，请使用 [Aptos CLI](/zh/build/cli) [发布模块](/zh/build/cli/working-with-move-contracts)，然后调用 `aptos move view --function-id <address>::<module>::<function>`。
+
+响应是返回值的 JSON 数组。也可以通过设置相应的 `Accept` / Content-Type 请求 Binary Canonical Serialization（BCS）编码结果。

--- a/src/content/docs/zh/network/glossary.mdx
+++ b/src/content/docs/zh/network/glossary.mdx
@@ -29,8 +29,8 @@ sidebar:
 
 ### API
 
-- **应用程序编程接口（API）** 是一组协议和工具，允许用户通过外部应用程序与 Aptos 区块链节点和客户端网络进行交互。Aptos 提供 REST API 来与我们的节点进行通信。
-- 详情请参阅 [API 文档](/zh/build/apis)。
+- **应用程序编程接口（API）** 是一组协议和工具，允许用户通过外部应用程序与 Aptos 区块链节点和客户端网络进行交互。Aptos 节点提供 REST API；Aptos Labs 还托管 Indexer GraphQL API 和 Transaction Stream gRPC API。
+- 详情请参阅 [Aptos APIs](/zh/build/apis)。
 
 ### APT
 
@@ -212,7 +212,7 @@ sidebar:
 
 ### 水龙头
 
-- **水龙头** 是在开发网上铸造 APT 的服务。对于测试网，请参阅 [铸造页面](/zh/network/faucet)。
+- **水龙头** 是在 Devnet（可编程）和 Testnet（Google 登录 / [铸币页面](/zh/network/faucet)）上铸造 APT 的服务。
 - 开发网和测试网上的 APT 没有现实价值，仅用于开发目的。
 - 要使用水龙头，请参阅 [水龙头 API](/zh/build/apis/faucet-api)。
 

--- a/src/lib/llms-curated-ids.ts
+++ b/src/lib/llms-curated-ids.ts
@@ -40,6 +40,7 @@ export const LLMS_INDEX_SECTIONS: LlmsSection[] = [
     ids: [
       "build/apis",
       "build/apis/fullnode-rest-api",
+      "build/apis/faucet-api",
       "build/guides/exchanges",
       "build/indexer/indexer-api",
       "build/indexer/indexer-api/indexer-reference",

--- a/tests/aptos-spec.test.ts
+++ b/tests/aptos-spec.test.ts
@@ -1,0 +1,67 @@
+/**
+ * Guards the committed Aptos Node API OpenAPI document against silent drift.
+ *
+ * public/aptos-spec.json powers /rest-api and is advertised as service-desc
+ * (see tests/agent-discovery.test.ts). Keep the live Node API paths listed here
+ * when you refresh the spec from https://api.mainnet.aptoslabs.com/v1/spec.yaml.
+ */
+
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const __dirname = fileURLToPath(new URL(".", import.meta.url));
+const ROOT = resolve(__dirname, "..");
+
+interface OpenApiSpec {
+  openapi?: string;
+  info?: { title?: string; version?: string };
+  servers?: { url?: string }[];
+  paths?: Record<string, unknown>;
+  components?: { schemas?: Record<string, unknown> };
+}
+
+function readSpec(): OpenApiSpec {
+  return JSON.parse(readFileSync(resolve(ROOT, "public/aptos-spec.json"), "utf8")) as OpenApiSpec;
+}
+
+const REQUIRED_PATHS = [
+  "/",
+  "/-/healthy",
+  "/info",
+  "/spec",
+  "/view",
+  "/accounts/{address}",
+  "/accounts/{address}/balance/{asset_type}",
+  "/accounts/{address}/transactions",
+  "/accounts/{address}/events/{event_handle}/{field_name}",
+  "/transactions",
+  "/transactions/auxiliary_info",
+  "/transactions/by_hash/{txn_hash}",
+  "/transactions/by_version/{txn_version}",
+  "/transactions/simulate",
+  "/estimate_gas_price",
+];
+
+describe("public/aptos-spec.json (Aptos Node API)", () => {
+  const spec = readSpec();
+
+  it("declares OpenAPI 3 and Aptos Node API 1.2.x", () => {
+    expect(spec.openapi).toMatch(/^3\./);
+    expect(spec.info?.title).toBe("Aptos Node API");
+    expect(spec.info?.version).toMatch(/^1\.2\./);
+    expect(spec.servers?.[0]?.url).toBe("/v1");
+  });
+
+  it("includes the live Node API paths used by the REST docs", () => {
+    const paths = spec.paths ?? {};
+    for (const path of REQUIRED_PATHS) {
+      expect(paths[path], `missing path ${path}`).toBeTruthy();
+    }
+  });
+
+  it("defines PersistedAuxiliaryInfo for GET /transactions/auxiliary_info", () => {
+    expect(spec.components?.schemas?.PersistedAuxiliaryInfo).toBeTruthy();
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Validated the Aptos APIs docs against live Node API, faucet, Indexer GraphQL, and Geomi surfaces, then updated the English pages and Chinese translations.

### What was wrong

- APIs overview linked to `/build/apis/fullnode-rest-api?network=…` as a “playground,” but that query param does nothing. The on-site playground is `/rest-api`.
- REST explorers used `fullnode.{network}.aptoslabs.com` instead of the canonical Geomi host `api.{network}.aptoslabs.com`.
- REST guide still said indexers were coming “in the near future,” pointed at a pinned 2022 `enable_ledger_pruner` blob, and used a non-`await` `coin::balance` view example.
- Faucet docs documented legacy `POST /mint` only, used `LocalnetConfig` in a Devnet Go example, and omitted Testnet `POST /fund` + Google OIDC.
- Chinese APIs/Geomi/data-provider pages were far behind English (leftover `todo translate`, Aptos Labs Developer Portal / API Gateway).
- `public/aptos-spec.json` was missing live `GET /transactions/auxiliary_info`.
- Data-provider links for Pangea and Shinami 404’d; Codex was missing.

### What changed

- APIs overview: choose-an-API table, official Labs endpoint table, `/rest-api` + live Swagger cards, Geomi bearer-token examples.
- Fullnode REST guide: canonical hosts, common operations table (including the FA/coin balance endpoint), pruning pointer to Data Pruning, working `chain_id::get` view examples.
- Faucet: `POST /fund` as current API, Devnet vs Testnet auth, TypeScript/Python/Go/CLI/curl examples.
- Geomi page: API keys, server vs client key prefixes, service links. Chinese page rewritten off API Gateway.
- Data providers: working Pangea/Shinami URLs, Codex, Chinese page synced to English.
- `aptos-spec.json` + `tests/aptos-spec.test.ts` so the committed OpenAPI document cannot drop live paths silently.

### Verification

Checked live: Node API 1.2.0 on mainnet/testnet/devnet, `POST /fund` on Devnet, Indexer GraphQL `ledger_infos`, Geomi docs, and vendor URLs.

Local:

- `pnpm test` — 103 passed, 9 skipped
- `pnpm lint` — Biome + Prettier clean
- `pnpm check` — 0 errors
- `pnpm check:links` — “All internal links are valid.”

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-60904c0b-c51a-4a4b-a2e4-e322d188150d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-60904c0b-c51a-4a4b-a2e4-e322d188150d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

