### PR TITLE
docs: validate and update the AI / LLMs section

### DIFF
--- a/astro.sidebar.ts
+++ b/astro.sidebar.ts
@@ -904,17 +904,20 @@ export const sidebar = [
       "build/ai",
       group("ai.group.aptos-mcp", {
         collapsed: true,
-        items: ["build/ai/aptos-mcp", "build/ai/aptos-mcp/claude", "build/ai/aptos-mcp/cursor"],
+        items: [
+          "build/ai/aptos-mcp",
+          "build/ai/aptos-mcp/claude",
+          "build/ai/aptos-mcp/cursor",
+          "build/ai/aptos-mcp/codex",
+        ],
       }),
       {
         label: "Agent Skills",
         link: "build/ai/aptos-agent-skills",
-        badge: { text: "NEW", variant: "tip" },
       },
       {
         label: "LLMs.txt",
         link: "llms-txt",
-        badge: { text: "NEW", variant: "tip" },
       },
     ],
   }),

--- a/public/.well-known/mcp/server-card.json
+++ b/public/.well-known/mcp/server-card.json
@@ -26,7 +26,8 @@
       "overview": "https://aptos.dev/build/ai/aptos-mcp",
       "claude": "https://aptos.dev/build/ai/aptos-mcp/claude",
       "cursor": "https://aptos.dev/build/ai/aptos-mcp/cursor",
-      "lastUpdated": "2026-04-21"
+      "codex": "https://aptos.dev/build/ai/aptos-mcp/codex",
+      "lastUpdated": "2026-08-27"
     }
   }
 }

--- a/src/content/docs/build/ai.mdx
+++ b/src/content/docs/build/ai.mdx
@@ -1,6 +1,6 @@
 ---
 title: "AI Tools for Aptos Development"
-description: "Use AI tools like Claude, Cursor, and GitHub Copilot to build on Aptos faster. Access the Aptos MCP server and LLMs.txt documentation feeds."
+description: "Use AI tools like Claude, Cursor, Codex, and GitHub Copilot to build on Aptos faster. Access the Aptos MCP server and LLMs.txt documentation feeds."
 sidebar:
   label: "AI Tools Overview"
 ---
@@ -20,7 +20,13 @@ Aptos APIs, query on-chain data, and generate correct Aptos code — without nee
   <LinkCard href="/build/ai/aptos-mcp/claude" title="Claude Code" description="Set up the Aptos MCP server for Claude Code" />
 
   <LinkCard href="/build/ai/aptos-mcp/cursor" title="Cursor" description="Set up the Aptos MCP server for Cursor" />
+
+  <LinkCard href="/build/ai/aptos-mcp/codex" title="OpenAI Codex" description="Set up the Aptos MCP server for Codex" />
 </CardGrid>
+
+Any MCP client that can launch a local stdio server — including GitHub Copilot — can use the same
+`npx -y @aptos-labs/aptos-mcp` command. See the [Aptos MCP overview](/build/ai/aptos-mcp) for prerequisites
+and the Geomi Bot Key.
 
 ## Aptos Agent Skills
 
@@ -51,7 +57,7 @@ Some clients resolve `/.well-known/llms.txt`; production serves the same index v
 
 The [`llms.txt`](/llms.txt) router also surfaces machine-readable **API** links—[`/aptos-spec.json`](/aptos-spec.json) (OpenAPI 3 JSON for the node REST API) and [`/rest-api`](/rest-api) (HTML reference)—plus **MCP**, Agent Skills, Explorer, GitHub, standards, and Indexer GraphQL `.md` links in one place.
 
-<LinkCard href="/llms-txt" title="How to use LLMs.txt with AI tools" description="Instructions for Cursor, GitHub Copilot, Claude.ai, ChatGPT, Windsurf, and more" />
+<LinkCard href="/llms-txt" title="How to use LLMs.txt with AI tools" description="Instructions for Cursor, Claude Code, GitHub Copilot, ChatGPT, Codex, Devin Desktop, and more" />
 
 ## Agent discovery endpoints
 

--- a/src/content/docs/build/ai/aptos-agent-skills.mdx
+++ b/src/content/docs/build/ai/aptos-agent-skills.mdx
@@ -19,22 +19,35 @@ import { LinkCard } from '@astrojs/starlight/components';
 npx skills add aptos-labs/aptos-agent-skills
 ```
 
-This installs the skills into your project so your AI coding assistant can use them automatically.
-
-### Claude Code Plugin
+This installs the skills so your AI coding assistant can use them automatically. Target a specific agent with `-a`:
 
 ```bash
-claude plugin add aptos-labs/aptos-agent-skills
+npx skills add aptos-labs/aptos-agent-skills -a claude-code
+npx skills add aptos-labs/aptos-agent-skills -a cursor
+npx skills add aptos-labs/aptos-agent-skills -a copilot
 ```
 
-### Manual Installation
+See the upstream [INSTALL.md](https://github.com/aptos-labs/aptos-agent-skills/blob/main/INSTALL.md) for selective skill installs.
 
-Clone the repository and copy the skills into your project's `.claude/skills/aptos/` directory:
+### Claude Code plugin
+
+Inside a Claude Code session, add the repository as a plugin marketplace:
+
+```text
+/plugin marketplace add aptos-labs/aptos-agent-skills
+```
+
+### Manual installation
+
+Clone the repository and copy the skills into your agent's skills directory:
 
 ```bash
 git clone https://github.com/aptos-labs/aptos-agent-skills.git
-cp -r aptos-agent-skills/skills/* .claude/skills/aptos/
+cp -r aptos-agent-skills/skills/* ~/.claude/skills/
+cp -r aptos-agent-skills/patterns/* ~/.claude/patterns/
 ```
+
+Include `CLAUDE.md` from the cloned repository in your workspace context so the assistant can route to the right skill.
 
 ## Available Skills
 
@@ -42,36 +55,36 @@ cp -r aptos-agent-skills/skills/* .claude/skills/aptos/
 
 These skills help AI assistants write, test, audit, and deploy Move smart contracts:
 
-| Skill                        | Description                                                           |
-| ---------------------------- | --------------------------------------------------------------------- |
-| **write-contracts**          | Write Move smart contracts following Aptos best practices             |
-| **generate-tests**           | Generate comprehensive unit and integration tests for Move modules    |
-| **security-audit**           | Audit Move contracts for common vulnerabilities and security issues   |
-| **deploy-contracts**         | Deploy Move modules to Aptos devnet, testnet, or mainnet              |
-| **search-aptos-examples**    | Search official Aptos example contracts for reference implementations |
-| **analyze-gas-optimization** | Analyze and optimize Move code for gas efficiency                     |
-| **modernize-move**           | Upgrade Move code to use the latest Aptos Move features               |
+| Skill                        | Description                                                  |
+| ---------------------------- | ------------------------------------------------------------ |
+| **write-contracts**          | Generate secure Aptos Move V2 smart contracts                |
+| **generate-tests**           | Generate Move unit tests targeting 100% code coverage        |
+| **security-audit**           | Security audit for Move smart contracts before deployment    |
+| **deploy-contracts**         | Deploy Move modules to Aptos devnet, testnet, or mainnet     |
+| **search-aptos-examples**    | Search aptos-core for reference implementations and patterns |
+| **analyze-gas-optimization** | Analyze and reduce gas costs in Move smart contracts         |
+| **modernize-move**           | Migrate Move V1 resource accounts to the V2 object model     |
 
 ### TypeScript SDK Skills
 
 These skills help AI assistants use the Aptos TypeScript SDK correctly:
 
-| Skill                     | Description                                                 |
-| ------------------------- | ----------------------------------------------------------- |
-| **use-ts-sdk**            | General guidance for using the Aptos TypeScript SDK         |
-| **ts-sdk-client**         | Configure and use the Aptos client for network interactions |
-| **ts-sdk-account**        | Create and manage Aptos accounts and key pairs              |
-| **ts-sdk-address**        | Work with Aptos addresses and address formats               |
-| **ts-sdk-transactions**   | Build, simulate, sign, and submit transactions              |
-| **ts-sdk-view-and-query** | Query on-chain data and call view functions                 |
-| **ts-sdk-types**          | Use TypeScript types from the SDK correctly                 |
-| **ts-sdk-wallet-adapter** | Integrate wallet connections in frontend applications       |
+| Skill                     | Description                                                               |
+| ------------------------- | ------------------------------------------------------------------------- |
+| **use-ts-sdk**            | Aptos TypeScript SDK orchestrator for frontend integration                |
+| **ts-sdk-client**         | Set up the Aptos client with AptosConfig and network selection            |
+| **ts-sdk-account**        | Create Aptos accounts and signers from private keys or derivation paths   |
+| **ts-sdk-address**        | Parse and derive Aptos account addresses (AIP-40)                         |
+| **ts-sdk-transactions**   | Build, sign, and submit transactions, including sponsored and multi-agent |
+| **ts-sdk-view-and-query** | Call Move view functions and query on-chain Aptos data                    |
+| **ts-sdk-types**          | Map Move types to TypeScript (`u64`, `u128`, `address`, `vector`)         |
+| **ts-sdk-wallet-adapter** | Integrate Aptos wallets into React apps with `useWallet`                  |
 
 ### Project Skills
 
-| Skill                    | Description                                                                    |
-| ------------------------ | ------------------------------------------------------------------------------ |
-| **create-aptos-project** | Scaffold a new Aptos project with Move contracts, TypeScript SDK, and frontend |
+| Skill                    | Description                                        |
+| ------------------------ | -------------------------------------------------- |
+| **create-aptos-project** | Scaffold a new Aptos dApp with `create-aptos-dapp` |
 
 ## Recommended Workflow
 
@@ -82,13 +95,19 @@ For a typical Aptos dApp, use the skills in this order:
 3. **Test** — Use `generate-tests` to create comprehensive test coverage
 4. **Audit** — Use `security-audit` to check for vulnerabilities
 5. **Deploy** — Use `deploy-contracts` to publish to devnet or testnet
-6. **Frontend** — Use `ts-sdk-wallet-adapter` and other SDK skills to build the UI
+6. **Frontend** — Use `use-ts-sdk` and the other TypeScript SDK skills to build the UI
 
 ## Community Skills
 
-The repository includes a `community-skills/` directory where anyone can contribute additional skills. To add your own:
+The repository includes a `community-skills/` directory. Community skills are independently maintained and have not been reviewed by Aptos Labs.
 
-1. Create a new skill file following the existing format
+| Skill                  | Author    | Description                                             |
+| ---------------------- | --------- | ------------------------------------------------------- |
+| **smoothsend-gasless** | ivedmohan | Sponsor gas fees for Aptos transactions with SmoothSend |
+
+To add your own:
+
+1. Create a new skill following the existing format under `community-skills/`
 2. Submit a pull request to the [aptos-agent-skills repository](https://github.com/aptos-labs/aptos-agent-skills)
 
-See the [CONTRIBUTING.md](https://github.com/aptos-labs/aptos-agent-skills/blob/main/CONTRIBUTING.md) for details on the contribution process.
+See [CONTRIBUTING.md](https://github.com/aptos-labs/aptos-agent-skills/blob/main/CONTRIBUTING.md) for details.

--- a/src/content/docs/build/ai/aptos-mcp.mdx
+++ b/src/content/docs/build/ai/aptos-mcp.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Aptos Model Context Protocol (MCP)"
-description: "Learn how to use the Aptos MCP server to build applications with AI tools like Cursor and Claude Code"
+description: "Learn how to use the Aptos MCP server to build applications with AI tools like Cursor, Claude Code, and Codex"
 sidebar:
   label: "Aptos MCP"
 ---
@@ -9,33 +9,37 @@ import { CardGrid, LinkCard } from '@astrojs/starlight/components';
 
 The [Aptos MCP server](https://github.com/aptos-labs/aptos-npm-mcp) (`npx @aptos-labs/aptos-mcp`) provides tools, prompts, and resources to help
 developers build applications on the Aptos blockchain through [Geomi](https://geomi.dev). It is designed to be used with AI tools like Cursor, Claude Code,
-and others that support the [Model Context Protocol](https://modelcontextprotocol.io/).
+Codex, and others that support the [Model Context Protocol](https://modelcontextprotocol.io/).
+
+The published npm package is pinned on the [MCP Server Card](/.well-known/mcp/server-card.json). Do not use the `latest` tag in production configs; run `npx -y @aptos-labs/aptos-mcp` so npm resolves the current release, or pin the version from that card.
 
 ## Getting Started
 
 ### Prerequisites
 
-- [node and npm](https://nodejs.org/en)
-- Build Bot Api Key
+- [Node.js and npm](https://nodejs.org/en) (Node.js 22.12 or later; npm 10 ships with Node.js 22)
+- A Geomi Bot Key
 
-### Generate a Build Bot Api Key
+### Generate a Geomi Bot Key
 
-To be able to make Geomi actions like managing API keys, etc., follow these instructions to generate a new Bot API Key to use with the MCP.
+To make Geomi actions such as managing API keys, follow these steps to create a Bot Key for the MCP server.
 
 - Go to [https://geomi.dev/](https://geomi.dev/)
 - Click on your name in the bottom left corner
-- Click on "Bot Keys"
-- Click on the "Create Bot Key" button
-- Copy the Bot Key and paste it into the MCP configuration file as an env arg: `APTOS_BOT_KEY=<your-bot-key>`
+- Click on **Bot Keys**
+- Click on the **Create Bot Key** button
+- Copy the Bot Key and paste it into the MCP configuration as `APTOS_BOT_KEY=<your-bot-key>`
+
+Never commit the Bot Key to git. Prefer interpolating an environment variable (for example Cursor's `${env:APTOS_BOT_KEY}`) over hard-coding the secret in a shared config file.
 
 ### Supported Interfaces
 
-We've provided guides for Cursor and Claude Code to help you integrate the Aptos MCP into your development environment.
-If you're using a different AI tool, follow the steps for your favorite AI tool, and refer to the documentation for
-Cursor or Claude Code for examples.
+We've provided guides for Claude Code, Cursor, and OpenAI Codex. Other MCP clients — including GitHub Copilot — can reuse the same stdio command and `APTOS_BOT_KEY` environment variable.
 
 <CardGrid>
   <LinkCard href="/build/ai/aptos-mcp/claude" title="Claude Code" description="Set up for Claude Code" />
 
   <LinkCard href="/build/ai/aptos-mcp/cursor" title="Cursor" description="Set up for Cursor" />
+
+  <LinkCard href="/build/ai/aptos-mcp/codex" title="OpenAI Codex" description="Set up for Codex" />
 </CardGrid>

--- a/src/content/docs/build/ai/aptos-mcp/claude.mdx
+++ b/src/content/docs/build/ai/aptos-mcp/claude.mdx
@@ -5,52 +5,58 @@ sidebar:
   label: "Claude Code"
 ---
 
-1. Install the `claude-code` package
+1. Install [Claude Code](https://code.claude.com/docs/en/quickstart). The npm package still works:
 
 ```bash
 npm install -g @anthropic-ai/claude-code
 ```
 
-2. Locate where Claude Code stores its configuration, usually on Mac it is at `~/.claude.json`
-3. Edit the `mcpServers` object in the `json` file with
+2. Obtain your `APTOS_BOT_KEY` from [Geomi](https://geomi.dev/) (**Bot Keys** in the account menu). See [Aptos MCP](/build/ai/aptos-mcp) for the full steps.
 
-```json
-{
-  "mcpServers": {
-    "aptos-mcp": {
-      "command": "npx",
-      "args": ["-y", "@aptos-labs/aptos-mcp"],
-      "type": "stdio",
-      "env": {
-        "APTOS_BOT_KEY": "<bot_api_key>"
-      }
-    }
-  }
-}
-```
-
-4. Obtain your `APTOS_BOT_KEY`:
-
-- Visit [Geomi](https://geomi.dev/) and log in with your account.
-- Navigate to the API Keys section and create a new key.
-- Copy the generated key for use in the next step.
-
-5. Make sure to update the `APTOS_BOT_KEY` with the key you generated in the previous step.
-
-6. Navigate to your project
+3. Navigate to your project:
 
 ```bash
 cd your-awesome-project
 ```
 
-7. In a new terminal window type:
+4. Add the Aptos MCP server with the Claude CLI. Put Claude's own flags before the server name, and put the launch command after `--`:
+
+```bash
+claude mcp add --scope local --env APTOS_BOT_KEY=<your_bot_key> --transport stdio aptos-mcp -- npx -y @aptos-labs/aptos-mcp
+```
+
+Replace `<your_bot_key>` with the key from step 2.
+
+`--scope local` stores the server for this project only. Use `--scope user` for every project on this machine, or `--scope project` to write a shareable `.mcp.json` (do not commit the Bot Key).
+
+See the [Claude Code MCP documentation](https://code.claude.com/docs/en/mcp) for transport, scope, and `--env` syntax.
+
+5. Confirm the server is registered:
+
+```bash
+claude mcp list
+```
+
+You should see `aptos-mcp` in the list.
+
+6. Start Claude Code:
 
 ```bash
 claude
 ```
 
-8. You can now use Claude Code to interact with the Aptos MCP. Prompt the agent with `what aptos mcp version are you using?` to verify the connection. The agent should reply with something like:
+7. Prompt the agent with `what aptos mcp version are you using?` to verify the connection. It should report the currently published `@aptos-labs/aptos-mcp` version from the [MCP Server Card](/.well-known/mcp/server-card.json).
 
-```text
-I'm using Aptos MCP version 0.0.2.
+## Alternative: JSON configuration
+
+If the CLI command fails, add the same stdio server as JSON:
+
+```bash
+claude mcp add-json aptos-mcp '{"command": "npx", "args": ["-y", "@aptos-labs/aptos-mcp"], "type": "stdio", "env": {"APTOS_BOT_KEY": "<your_bot_key>"}}'
 ```
+
+## Troubleshooting
+
+- Quit and restart Claude Code after changing MCP config so it reloads the server list.
+- Run `claude mcp list` if the Aptos tools do not appear.
+- Confirm `APTOS_BOT_KEY` is a valid Geomi Bot Key.

--- a/src/content/docs/build/ai/aptos-mcp/codex.mdx
+++ b/src/content/docs/build/ai/aptos-mcp/codex.mdx
@@ -1,0 +1,65 @@
+---
+title: "Setting up Aptos MCP with Codex"
+description: "Step-by-step guide to configure and use Aptos MCP with OpenAI Codex"
+sidebar:
+  label: "Codex"
+---
+
+1. Install [OpenAI Codex](https://github.com/openai/codex).
+
+```bash
+npm install -g @openai/codex
+```
+
+On macOS you can also run `brew install codex`.
+
+2. Obtain your `APTOS_BOT_KEY` from [Geomi](https://geomi.dev/) (**Bot Keys** in the account menu). See [Aptos MCP](/build/ai/aptos-mcp) for the full steps.
+
+3. Navigate to your project:
+
+```bash
+cd your-awesome-project
+```
+
+4. Add the Aptos MCP server:
+
+```bash
+codex mcp add aptos-mcp --env APTOS_BOT_KEY=<your_bot_key> -- npx -y @aptos-labs/aptos-mcp
+```
+
+Replace `<your_bot_key>` with the key from step 2. You can pass additional `--env NAME=VALUE` pairs if needed.
+
+5. Confirm the server is registered:
+
+```bash
+codex mcp list
+```
+
+You should see `aptos-mcp` in the list.
+
+6. Start Codex:
+
+```bash
+codex
+```
+
+7. Run `/mcp` inside Codex and confirm `aptos-mcp` is listed.
+
+8. Prompt the agent with `what aptos mcp version are you using?` to verify the connection. It should report the currently published `@aptos-labs/aptos-mcp` version from the [MCP Server Card](/.well-known/mcp/server-card.json).
+
+## Alternative: TOML configuration
+
+If the CLI command fails, edit `~/.codex/config.toml` (in the IDE: gear icon → **MCP settings** → **Open config.toml**) and add:
+
+```toml
+# ~/.codex/config.toml
+
+[mcp_servers.aptos-mcp]
+command = "npx"
+args = ["-y", "@aptos-labs/aptos-mcp"]
+
+[mcp_servers.aptos-mcp.env]
+APTOS_BOT_KEY = "<your_bot_key>"
+```
+
+Save the file and restart Codex. Do not commit the Bot Key.

--- a/src/content/docs/build/ai/aptos-mcp/cursor.mdx
+++ b/src/content/docs/build/ai/aptos-mcp/cursor.mdx
@@ -5,6 +5,8 @@ sidebar:
   label: "Cursor"
 ---
 
+Cursor reads MCP servers from [`mcp.json`](https://cursor.com/docs/mcp). Use a project file at `.cursor/mcp.json` or a user-wide file at `~/.cursor/mcp.json`.
+
 1. Open the Cursor IDE
 2. On the project root folder, create a `.cursor` folder
 3. In the `.cursor` folder, create a `mcp.json` file
@@ -17,7 +19,7 @@ sidebar:
       "command": "npx",
       "args": ["-y", "@aptos-labs/aptos-mcp"],
       "env": {
-        "APTOS_BOT_KEY": "<bot_api_key>"
+        "APTOS_BOT_KEY": "${env:APTOS_BOT_KEY}"
       }
     }
   }
@@ -26,25 +28,24 @@ sidebar:
 
 5. Obtain your `APTOS_BOT_KEY`:
    - Visit [Geomi](https://geomi.dev/) and log in with your account.
-   - Navigate to the API Keys section and generate a new key.
-   - Copy the generated key for use in the next step.
+   - Open the account menu in the bottom left, then **Bot Keys**, and create a new key.
+   - Export the key in your shell (`export APTOS_BOT_KEY=...`) or replace `${env:APTOS_BOT_KEY}` with the value locally. Do not commit the secret.
 
-6. Make sure to update the `APTOS_BOT_KEY` in the `mcp.json` file with the key you just generated.
+6. Save the file. Cursor merges project and user `mcp.json` files; a project entry with the same name wins.
 
 ### Verify Cursor runs your MCP
 
-1. Open Cursor Settings: `cursor -> settings -> cursor settings`
-2. Head to the `MCP` or `Tools & Integrations` section
-3. Make sure it is enabled and showing a green color indicator
+1. Open Cursor Settings: **Cursor Settings** → **Tools & MCP** (the panel is also under **Customize** → **MCP**).
+2. Confirm `aptos-mcp` is enabled and showing a green indicator.
 
 ![Make sure it is enabled and showing a green color indicator](~/images/cursor/verify-cursor_step-3.png)
 
-4. Click the “refresh” icon to update the MCP.
+3. Click the “refresh” icon if the server does not connect on the first try.
 
-5. Make sure the Cursor AI window dropdown is set to `Agent`
+4. Make sure the Cursor chat is in **Agent** mode.
 
 ![Make sure the Cursor AI window dropdown is set to Agent](~/images/cursor/verify-cursor_step-5.png)
 
-6. Prompt the agent with `what aptos mcp version are you using?` to verify the connection. The agent should reply with something like:
+5. Prompt the agent with `what aptos mcp version are you using?` to verify the connection. It should report the currently published `@aptos-labs/aptos-mcp` version from the [MCP Server Card](/.well-known/mcp/server-card.json).
 
 ![Prompt the agent with what aptos mcp version are you using? to verify the connection.](~/images/cursor/verify-cursor_step-6.png)

--- a/src/content/docs/index.mdx
+++ b/src/content/docs/index.mdx
@@ -30,8 +30,8 @@ import ListCard from '~/components/ListCard.astro';
   <ListCard title="Getting Started" iconName="star" id="getting-started">
     - [Deploy Your First Move Smart Contract](/build/guides/first-move-module) Compile & publish Move modules to devnet in minutes.
     - [Your First Transaction](/build/guides/first-transaction) Write and read on-chain data using the TypeScript SDK.
-    - [Code with AI (MCP)](/build/ai/aptos-mcp) Give Cursor and Claude Code direct access to Aptos APIs.
-    - [NEW! Agent Skills](/build/ai/aptos-agent-skills) Move and TS SDK skills for Claude Code, Cursor, Copilot.
+    - [Code with AI (MCP)](/build/ai/aptos-mcp) Give Cursor, Claude Code, and Codex direct access to Aptos APIs.
+    - [Agent Skills](/build/ai/aptos-agent-skills) Move and TS SDK skills for Claude Code, Cursor, Copilot.
   </ListCard>
 
   <ListCard title="Tools" iconName="terminal">
@@ -55,7 +55,7 @@ import ListCard from '~/components/ListCard.astro';
   </ListCard>
 
   <ListCard title="Resources" iconName="file-text">
-    - [NEW! LLMs.txt Integration](/llms-txt) AI-optimized documentation format, paste it in your favorite large context AI and get moving!
+    - [LLMs.txt Integration](/llms-txt) AI-optimized documentation feeds for coding assistants and chat tools.
     - [Query, Index, or Stream On-Chain Data](/build/indexer) Query Indexer API, index contracts, stream raw transactions.
     - [Apply for a Grant](https://aptosnetwork.com/grants)
   </ListCard>

--- a/src/content/docs/llms-txt.mdx
+++ b/src/content/docs/llms-txt.mdx
@@ -1,6 +1,6 @@
 ---
 title: LLMs.txt
-description: How to get tools like Cursor, GitHub Copilot, ChatGPT, and Claude to understand Aptos documentation.
+description: How to get tools like Cursor, GitHub Copilot, ChatGPT, Claude, Codex, and Devin to understand Aptos documentation.
 ---
 
 ## What is LLMs.txt?
@@ -22,6 +22,8 @@ The [`llms.txt`](/llms.txt) index also lists **structured API assets** that are 
 
 It also surfaces **agent tooling** (Aptos MCP, Agent Skills, Explorer, GitHub org) and key **Markdown** deep links (AI hub, standards, Indexer GraphQL reference) so models can fetch the right surface without guessing URLs.
 
+Discovery endpoints, the MCP Server Card, and WebMCP tools are documented on the [AI tools overview](/build/ai).
+
 ## Per-Page Markdown Access
 
 Every documentation page is also available as rendered Markdown by appending `.md` to the URL:
@@ -32,28 +34,35 @@ Every documentation page is also available as rendered Markdown by appending `.m
 | `https://aptos.dev/build/sdks/ts-sdk`                 | `https://aptos.dev/build/sdks/ts-sdk.md`                 |
 | `https://aptos.dev/zh/build/guides/first-transaction` | `https://aptos.dev/zh/build/guides/first-transaction.md` |
 
-This is useful for AI tools that need to fetch individual pages with minimal tokens, rather than ingesting the full documentation. The [llms.txt](/llms.txt) file acts as a compact router, while [llms-small.txt](/llms-small.txt) and [llms-full.txt](/llms-full.txt) provide curated and comprehensive corpus exports.
+You can also send `Accept: text/markdown` to the HTML URL. This is useful for AI tools that need to fetch individual pages with minimal tokens, rather than ingesting the full documentation. The [llms.txt](/llms.txt) file acts as a compact router, while [llms-small.txt](/llms-small.txt) and [llms-full.txt](/llms-full.txt) provide curated and comprehensive corpus exports.
 
 ## Usage with AI Tools
 
 ### Claude Code
 
-Add Aptos documentation context to [Claude Code](https://docs.anthropic.com/en/docs/agents-and-tools/claude-code/overview) projects:
+Add Aptos documentation context to [Claude Code](https://code.claude.com/docs/en/overview) projects:
 
-1. Add `https://aptos.dev/llms.txt` to your project's `CLAUDE.md` file as a reference
+1. Add `https://aptos.dev/llms.txt` to your project's `CLAUDE.md` or `AGENTS.md` file as a reference
 2. Claude Code will read the index and fetch relevant pages via `.md` URLs as needed
-3. For deeper integration with on-chain tools, see [Aptos MCP for Claude Code](/build/ai/aptos-mcp/claude)
+3. For on-chain tools, see [Aptos MCP for Claude Code](/build/ai/aptos-mcp/claude)
 
 ### Cursor
 
-Use the `@Docs` feature in Cursor to include the LLMs.txt files in your project. This helps Cursor provide more accurate
-code suggestions and documentation for Aptos development.
+Cursor's `@Docs` index was removed. Point Agent at the feeds instead:
 
-[Read more about @Docs in Cursor](https://docs.cursor.com/context/@-symbols/@-docs)
+1. Add `https://aptos.dev/llms.txt` to the project `AGENTS.md` (or a [project rule](https://cursor.com/docs/rules))
+2. Paste a feed URL in chat when you need a one-off fetch — Agent can retrieve it directly
+3. For on-chain tools, see [Aptos MCP for Cursor](/build/ai/aptos-mcp/cursor)
 
 ### GitHub Copilot
 
-GitHub Copilot can leverage the information in these LLMs.txt files to provide better assistance when developing Aptos applications. You can reference these files in your GitHub Copilot Chat by using the following URLs:
+In [Copilot Chat](https://code.visualstudio.com/docs/chat/copilot-chat-context), fetch a feed for the current session:
+
+```
+#fetch https://aptos.dev/llms.txt
+```
+
+For standing project context, add the URLs to [`.github/copilot-instructions.md`](https://docs.github.com/en/copilot/how-tos/copilot-on-github/customize-copilot/add-custom-instructions/add-repository-instructions):
 
 ```
 https://aptos.dev/llms.txt
@@ -61,27 +70,31 @@ https://aptos.dev/llms-small.txt
 https://aptos.dev/llms-full.txt
 ```
 
-### Windsurf
+### OpenAI Codex
 
-Reference the LLMs.txt files using `@` or in your `.windsurfrules` files to enhance Windsurf's understanding of Aptos development.
+Add `https://aptos.dev/llms.txt` to `AGENTS.md`, then start Codex. For on-chain tools, see [Aptos MCP for Codex](/build/ai/aptos-mcp/codex).
 
-[Read more about Windsurf Memories](https://docs.codeium.com/windsurf/memories#memories-and-rules)
+### Devin Desktop (formerly Windsurf)
+
+Devin Desktop reads `AGENTS.md` and `.devin/rules/` (legacy `.windsurfrules` still works). Put `https://aptos.dev/llms.txt` in the project `AGENTS.md`.
+
+[Read more about AGENTS.md in Devin Desktop](https://docs.devin.ai/desktop/cascade/agents-md)
 
 ### Claude.ai
 
-Add Aptos documentation as a knowledge source in [Claude Projects](https://claude.ai):
+Add Aptos documentation as project knowledge in [Claude Projects](https://claude.ai):
 
 1. Open [Claude.ai](https://claude.ai) and create or open a Project
-2. Click **Add content**
+2. Add project knowledge / content
 3. Paste `https://aptos.dev/llms-full.txt` as a URL source
-4. Claude will now have Aptos documentation context in all conversations within that Project
+4. Claude will now have Aptos documentation context in conversations within that Project
 
 ### ChatGPT
 
 Reference the Aptos docs directly in ChatGPT conversations:
 
 - Paste `https://aptos.dev/llms-full.txt` into your message and ask ChatGPT to read it before answering Aptos questions
-- For [custom GPTs](https://openai.com/index/introducing-gpts/): add `https://aptos.dev/llms.txt` as a knowledge source in the GPT Builder
+- For custom GPTs: add `https://aptos.dev/llms.txt` as a knowledge source
 
 ### Other AI Tools
 

--- a/src/content/docs/network/glossary.mdx
+++ b/src/content/docs/network/glossary.mdx
@@ -33,6 +33,13 @@ See [Accounts](/network/blockchain/accounts) for more information.
 
 See [Accounts](/network/blockchain/accounts) for more information.
 
+### Agent Skills
+
+- **Agent Skills** are installable instruction packs that give coding assistants Aptos-specific knowledge for Move contracts, the TypeScript SDK, and dApp scaffolding.
+- Install them with `npx skills add aptos-labs/aptos-agent-skills`.
+
+See [Aptos Agent Skills](/build/ai/aptos-agent-skills) for more information.
+
 ### API
 
 - An **Application Programming Interface (API)** is a set of protocols and tools
@@ -409,6 +416,13 @@ See [Gas and Storage Fees](/network/blockchain/gas-txn-fee) for more information
 - Leaders are selected by a function that takes the
   current [round number](#round-number) as input.
 
+### LLMs.txt
+
+- **LLMs.txt** is a machine-readable documentation index that points AI tools at Aptos docs, per-page Markdown exports, and related API assets.
+- Aptos publishes `/llms.txt` (index), `/llms-small.txt` (condensed corpus), and `/llms-full.txt` (full corpus).
+
+See [LLMs.txt](/llms-txt) for more information.
+
 ## M
 
 ### Mainnet
@@ -462,6 +476,13 @@ more information.
 - A Merkle accumulator can provide proofs that a transaction was included in the
   chain ("proof of inclusion").
 - They are also called "history trees" in literature.
+
+### Model Context Protocol (MCP)
+
+- The **Model Context Protocol (MCP)** is an open protocol that lets AI coding tools call external tools and data sources.
+- Aptos publishes an MCP server (`@aptos-labs/aptos-mcp`) so assistants can query on-chain data, call Aptos APIs, and follow current Move workflows.
+
+See [Aptos MCP](/build/ai/aptos-mcp) for more information.
 
 ### Module
 
@@ -758,6 +779,13 @@ runbook covering download, CLI verification, and rotation.
   transaction version 100 is the 101st transaction in the blockchain.
 
 ## W
+
+### WebMCP
+
+- **WebMCP** is a browser proposal that lets pages register tools on `navigator.modelContext`.
+- Every Aptos docs page registers search, navigation, Markdown fetch, and LLMs.txt discovery tools for browsers that implement the proposal.
+
+See [AI Tools Overview](/build/ai) for more information.
 
 ### Well-Formed Transaction
 

--- a/src/content/docs/zh/build/ai.mdx
+++ b/src/content/docs/zh/build/ai.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Aptos 开发的 AI 工具"
-description: "使用 Claude、Cursor 和 GitHub Copilot 等 AI 工具更快地在 Aptos 上构建。访问 Aptos MCP 服务器和 LLMs.txt 文档源。"
+description: "使用 Claude、Cursor、Codex 和 GitHub Copilot 等 AI 工具更快地在 Aptos 上构建。访问 Aptos MCP 服务器和 LLMs.txt 文档源。"
 sidebar:
   label: "AI 工具概览"
 ---
@@ -19,7 +19,13 @@ Aptos 为 AI 驱动的开发工作流提供一流支持。无论您使用的是 
   <LinkCard href="/zh/build/ai/aptos-mcp/claude" title="Claude Code" description="为 Claude Code 配置 Aptos MCP 服务器" />
 
   <LinkCard href="/zh/build/ai/aptos-mcp/cursor" title="Cursor" description="为 Cursor 配置 Aptos MCP 服务器" />
+
+  <LinkCard href="/zh/build/ai/aptos-mcp/codex" title="OpenAI Codex" description="为 Codex 配置 Aptos MCP 服务器" />
 </CardGrid>
+
+任何能够启动本地 stdio 服务器的 MCP 客户端（包括 GitHub Copilot）都可以使用相同的
+`npx -y @aptos-labs/aptos-mcp` 命令。前置要求和 Geomi Bot Key 请参阅
+[Aptos MCP 概览](/zh/build/ai/aptos-mcp)。
 
 ## Aptos Agent Skills
 
@@ -49,7 +55,7 @@ npx skills add aptos-labs/aptos-agent-skills
 
 [`llms.txt`](/llms.txt) 路由还会列出机器可读的 **API** 链接——[`/aptos-spec.json`](/aptos-spec.json)（全节点 REST API 的 OpenAPI 3 JSON）以及 [`/zh/rest-api`](/zh/rest-api)（HTML 参考文档）——并在同一处汇总 **MCP**、Agent Skills、浏览器、GitHub、标准与 Indexer GraphQL 等 `.md` 链接。
 
-<LinkCard href="/zh/llms-txt" title="如何在 AI 工具中使用 LLMs.txt" description="Cursor、GitHub Copilot、Claude.ai、ChatGPT、Windsurf 等工具的使用说明" />
+<LinkCard href="/zh/llms-txt" title="如何在 AI 工具中使用 LLMs.txt" description="Cursor、Claude Code、GitHub Copilot、ChatGPT、Codex、Devin Desktop 等工具的使用说明" />
 
 ## 面向智能体的发现端点
 

--- a/src/content/docs/zh/build/ai/aptos-agent-skills.mdx
+++ b/src/content/docs/zh/build/ai/aptos-agent-skills.mdx
@@ -19,23 +19,35 @@ import { LinkCard } from '@astrojs/starlight/components';
 npx skills add aptos-labs/aptos-agent-skills
 ```
 
-这会将技能安装到您的项目中，以便 AI 编程助手自动使用它们。
+这会安装技能，以便 AI 编程助手自动使用它们。可以用 `-a` 指定目标代理：
+
+```bash
+npx skills add aptos-labs/aptos-agent-skills -a claude-code
+npx skills add aptos-labs/aptos-agent-skills -a cursor
+npx skills add aptos-labs/aptos-agent-skills -a copilot
+```
+
+按技能选择性安装见上游 [INSTALL.md](https://github.com/aptos-labs/aptos-agent-skills/blob/main/INSTALL.md)。
 
 ### Claude Code 插件
 
-```bash
-claude plugin add aptos-labs/aptos-agent-skills
+在 Claude Code 会话中，将该仓库添加为插件市场：
+
+```text
+/plugin marketplace add aptos-labs/aptos-agent-skills
 ```
 
 ### 手动安装
 
-克隆仓库并将技能复制到项目的 `.claude/skills/` 目录中：
+克隆仓库，并将技能复制到代理的 skills 目录：
 
 ```bash
 git clone https://github.com/aptos-labs/aptos-agent-skills.git
-mkdir -p .claude/skills
-cp -r aptos-agent-skills/skills/* .claude/skills/
+cp -r aptos-agent-skills/skills/* ~/.claude/skills/
+cp -r aptos-agent-skills/patterns/* ~/.claude/patterns/
 ```
+
+把克隆仓库中的 `CLAUDE.md` 加入工作区上下文，以便助手路由到正确的技能。
 
 ## 可用技能
 
@@ -45,34 +57,34 @@ cp -r aptos-agent-skills/skills/* .claude/skills/
 
 | 技能                           | 描述                                          |
 | ---------------------------- | ------------------------------------------- |
-| **write-contracts**          | 按照 Aptos 最佳实践编写 Move 智能合约                   |
-| **generate-tests**           | 为 Move 模块生成全面的单元测试和集成测试                     |
-| **security-audit**           | 审计 Move 合约中的常见漏洞和安全问题                       |
+| **write-contracts**          | 生成安全的 Aptos Move V2 智能合约                    |
+| **generate-tests**           | 生成面向 100% 代码覆盖率的 Move 单元测试                  |
+| **security-audit**           | 在部署前对 Move 智能合约进行安全审计                       |
 | **deploy-contracts**         | 将 Move 模块部署到 Aptos devnet、testnet 或 mainnet |
-| **search-aptos-examples**    | 搜索官方 Aptos 示例合约以获取参考实现                      |
-| **analyze-gas-optimization** | 分析和优化 Move 代码的 gas 效率                       |
-| **modernize-move**           | 将 Move 代码升级为使用最新的 Aptos Move 功能             |
+| **search-aptos-examples**    | 在 aptos-core 中搜索参考实现与模式                     |
+| **analyze-gas-optimization** | 分析并降低 Move 智能合约的 gas 成本                     |
+| **modernize-move**           | 将 Move V1 资源账户迁移到 V2 object 模型              |
 
 ### TypeScript SDK 技能
 
 这些技能帮助 AI 助手正确使用 Aptos TypeScript SDK：
 
-| 技能                        | 描述                            |
-| ------------------------- | ----------------------------- |
-| **use-ts-sdk**            | 使用 Aptos TypeScript SDK 的通用指导 |
-| **ts-sdk-client**         | 配置和使用 Aptos 客户端进行网络交互         |
-| **ts-sdk-account**        | 创建和管理 Aptos 账户和密钥对            |
-| **ts-sdk-address**        | 处理 Aptos 地址和地址格式              |
-| **ts-sdk-transactions**   | 构建、模拟、签名和提交交易                 |
-| **ts-sdk-view-and-query** | 查询链上数据和调用 view 函数             |
-| **ts-sdk-types**          | 正确使用 SDK 中的 TypeScript 类型     |
-| **ts-sdk-wallet-adapter** | 在前端应用中集成钱包连接                  |
+| 技能                        | 描述                                                       |
+| ------------------------- | -------------------------------------------------------- |
+| **use-ts-sdk**            | Aptos TypeScript SDK 前端集成编排器                             |
+| **ts-sdk-client**         | 使用 AptosConfig 配置 Aptos 客户端并选择网络                         |
+| **ts-sdk-account**        | 从私钥或派生路径创建 Aptos 账户和签名器                                  |
+| **ts-sdk-address**        | 解析和派生 Aptos 账户地址（AIP-40）                                 |
+| **ts-sdk-transactions**   | 构建、签名并提交交易，包括赞助交易和多代理交易                                  |
+| **ts-sdk-view-and-query** | 调用 Move view 函数并查询链上 Aptos 数据                            |
+| **ts-sdk-types**          | 将 Move 类型映射到 TypeScript（`u64`、`u128`、`address`、`vector`） |
+| **ts-sdk-wallet-adapter** | 使用 `useWallet` 在 React 应用中集成 Aptos 钱包                    |
 
 ### 项目技能
 
-| 技能                       | 描述                                         |
-| ------------------------ | ------------------------------------------ |
-| **create-aptos-project** | 搭建包含 Move 合约、TypeScript SDK 和前端的新 Aptos 项目 |
+| 技能                       | 描述                                     |
+| ------------------------ | -------------------------------------- |
+| **create-aptos-project** | 使用 `create-aptos-dapp` 搭建新的 Aptos dApp |
 
 ## 推荐工作流
 
@@ -83,13 +95,19 @@ cp -r aptos-agent-skills/skills/* .claude/skills/
 3. **测试** — 使用 `generate-tests` 创建全面的测试覆盖
 4. **审计** — 使用 `security-audit` 检查漏洞
 5. **部署** — 使用 `deploy-contracts` 发布到 devnet 或 testnet
-6. **前端** — 使用 `ts-sdk-wallet-adapter` 和其他 SDK 技能构建 UI
+6. **前端** — 使用 `use-ts-sdk` 和其他 TypeScript SDK 技能构建 UI
 
 ## 社区技能
 
-仓库包含一个 `community-skills/` 目录，任何人都可以贡献额外的技能。要添加您自己的技能：
+仓库包含一个 `community-skills/` 目录。社区技能由贡献者独立维护，未经 Aptos Labs 审核。
 
-1. 按照现有格式创建新的技能文件
-2. 向 [aptos-agent-skills 仓库](https://github.com/aptos-labs/aptos-agent-skills)提交 pull request
+| 技能                     | 作者        | 描述                               |
+| ---------------------- | --------- | -------------------------------- |
+| **smoothsend-gasless** | ivedmohan | 使用 SmoothSend 为 Aptos 交易赞助 gas 费 |
 
-详细的贡献流程请参阅 [CONTRIBUTING.md](https://github.com/aptos-labs/aptos-agent-skills/blob/main/CONTRIBUTING.md)。
+要添加你自己的技能：
+
+1. 按现有格式在 `community-skills/` 下创建新技能
+2. 向 [aptos-agent-skills 仓库](https://github.com/aptos-labs/aptos-agent-skills) 提交 pull request
+
+详细贡献流程见 [CONTRIBUTING.md](https://github.com/aptos-labs/aptos-agent-skills/blob/main/CONTRIBUTING.md)。

--- a/src/content/docs/zh/build/ai/aptos-mcp.mdx
+++ b/src/content/docs/zh/build/ai/aptos-mcp.mdx
@@ -1,40 +1,43 @@
 ---
 title: "Aptos 模型上下文协议"
-description: "学习如何使用 Aptos MCP 服务器与 Cursor、Claude Code 等 AI 工具构建应用程序"
+description: "学习如何使用 Aptos MCP 服务器与 Cursor、Claude Code、Codex 等 AI 工具构建应用程序"
 sidebar:
   label: "Aptos MCP"
 ---
 
 import { CardGrid, LinkCard } from '@astrojs/starlight/components';
 
-# Aptos Model Context Protocol (MCP)
+[Aptos MCP 服务器](https://github.com/aptos-labs/aptos-npm-mcp)（`npx @aptos-labs/aptos-mcp`）提供工具、提示和资源，帮助开发者通过 [Geomi](https://geomi.dev) 在 Aptos 区块链上构建应用。它适用于 Cursor、Claude Code、Codex 以及其他支持 [模型上下文协议](https://modelcontextprotocol.io/) 的 AI 工具。
 
-Aptos Model Context Protocol (MCP) 是一个服务器，提供了一套工具、提示和资源，帮助开发者在 Aptos 区块链上构建应用程序。它设计用于与支持 Model Context Protocol 的 AI 工具（如 Cursor、Claude Code 等）一起使用。
+已发布的 npm 包版本记录在 [MCP Server Card](/.well-known/mcp/server-card.json) 中。生产配置不要使用 `latest` 标签；运行 `npx -y @aptos-labs/aptos-mcp` 让 npm 解析当前版本，或按该卡片中的版本号进行固定。
 
 ## 开始使用
 
 ### 前置要求
 
-- [node 和 npm](https://nodejs.org/en)
-- Build Bot Api Key
+- [Node.js 和 npm](https://nodejs.org/en)（Node.js 22.12 或更高版本；npm 10 随 Node.js 22 一起提供）
+- Geomi Bot Key
 
-### 生成 Build Bot Api Key
+### 生成 Geomi Bot Key
 
-为了能够执行 Geomi 操作（如管理 API 密钥等），请按照以下说明生成一个新的 Bot API Key 以与 MCP 一起使用。
+要执行管理 API 密钥等 Geomi 操作，请按以下步骤为 MCP 服务器创建 Bot Key。
 
 - 访问 [https://geomi.dev/](https://geomi.dev/)
-- 点击左下角的您的姓名
-- 点击 "Bot Keys"
-- 点击 "Create Bot Key" 按钮
-- 复制 Bot Key 并将其粘贴到 MCP 配置文件中作为环境变量：`APTOS_BOT_KEY=<your-bot-key>`
+- 点击左下角的姓名
+- 点击 **Bot Keys**
+- 点击 **Create Bot Key** 按钮
+- 复制 Bot Key，并在 MCP 配置中设置为 `APTOS_BOT_KEY=<your-bot-key>`
+
+不要把 Bot Key 提交到 git。优先通过环境变量插值（例如 Cursor 的 `${env:APTOS_BOT_KEY}`），而不是把密钥写进共享配置文件。
 
 ### 支持的接口
 
-我们为 Cursor 和 Claude Code 提供了指南，帮助您将 Aptos MCP 集成到您的开发环境中。
-如果您使用的是其他 AI 工具，请按照您喜欢的 AI 工具的步骤操作，并参考 Cursor 或 Claude Code 的文档作为示例。
+我们为 Claude Code、Cursor 和 OpenAI Codex 提供了指南。其他 MCP 客户端（包括 GitHub Copilot）可以复用相同的 stdio 命令和 `APTOS_BOT_KEY` 环境变量。
 
 <CardGrid>
   <LinkCard href="/zh/build/ai/aptos-mcp/claude" title="Claude Code" description="为 Claude Code 设置" />
 
   <LinkCard href="/zh/build/ai/aptos-mcp/cursor" title="Cursor" description="为 Cursor 设置" />
+
+  <LinkCard href="/zh/build/ai/aptos-mcp/codex" title="OpenAI Codex" description="为 Codex 设置" />
 </CardGrid>

--- a/src/content/docs/zh/build/ai/aptos-mcp/claude.mdx
+++ b/src/content/docs/zh/build/ai/aptos-mcp/claude.mdx
@@ -5,54 +5,58 @@ sidebar:
   label: "Claude Code"
 ---
 
-## 使用 Aptos MCP 设置 Claude Code
-
-1. 安装 `claude-code` 包
+1. 安装 [Claude Code](https://code.claude.com/docs/en/quickstart)。npm 包仍然可用：
 
 ```bash
 npm install -g @anthropic-ai/claude-code
 ```
 
-2. 找到 Claude Code 存储配置的位置，通常在 Mac 上位于 `~/.claude.json`
-3. 编辑 `json` 文件中的 `mcpServers` 对象：
+2. 从 [Geomi](https://geomi.dev/) 获取 `APTOS_BOT_KEY`（账户菜单中的 **Bot Keys**）。完整步骤见 [Aptos MCP](/zh/build/ai/aptos-mcp)。
 
-```json
-{
-  "mcpServers": {
-    "aptos-mcp": {
-      "command": "npx",
-      "args": ["-y", "@aptos-labs/aptos-mcp"],
-      "type": "stdio",
-      "env": {
-        "APTOS_BOT_KEY": "<bot_api_key>"
-      }
-    }
-  }
-}
-```
-
-4. 获取您的 `APTOS_BOT_KEY`：
-
-- 访问 [Geomi](https://geomi.dev/) 并使用您的账户登录。
-- 导航到 API Keys 部分并创建一个新密钥。
-- 复制生成的密钥以供下一步使用。
-
-5. 确保使用您在上一步中生成的密钥更新 `APTOS_BOT_KEY`。
-
-6. 导航到您的项目
+3. 进入你的项目目录：
 
 ```bash
 cd your-awesome-project
 ```
 
-7. 在新的终端窗口中输入：
+4. 使用 Claude CLI 添加 Aptos MCP 服务器。把 Claude 自己的参数放在服务器名称之前，把启动命令放在 `--` 之后：
+
+```bash
+claude mcp add --scope local --env APTOS_BOT_KEY=<your_bot_key> --transport stdio aptos-mcp -- npx -y @aptos-labs/aptos-mcp
+```
+
+将 `<your_bot_key>` 替换为第 2 步生成的密钥。
+
+`--scope local` 只对当前项目生效。使用 `--scope user` 可在本机所有项目中启用，或使用 `--scope project` 写入可共享的 `.mcp.json`（不要提交 Bot Key）。
+
+传输方式、作用域和 `--env` 语法见 [Claude Code MCP 文档](https://code.claude.com/docs/en/mcp)。
+
+5. 确认服务器已注册：
+
+```bash
+claude mcp list
+```
+
+列表中应出现 `aptos-mcp`。
+
+6. 启动 Claude Code：
 
 ```bash
 claude
 ```
 
-8. 您现在可以使用 Claude Code 与 Aptos MCP 进行交互。向代理询问 `what aptos mcp version are you using?` 来验证连接。代理应该回复类似的内容：
+7. 向代理询问 `what aptos mcp version are you using?` 以验证连接。它应返回 [MCP Server Card](/.well-known/mcp/server-card.json) 中当前发布的 `@aptos-labs/aptos-mcp` 版本。
 
-```text
-I'm using Aptos MCP version 0.0.2.
+## 备选：JSON 配置
+
+如果 CLI 命令失败，可以用 JSON 添加同一个 stdio 服务器：
+
+```bash
+claude mcp add-json aptos-mcp '{"command": "npx", "args": ["-y", "@aptos-labs/aptos-mcp"], "type": "stdio", "env": {"APTOS_BOT_KEY": "<your_bot_key>"}}'
 ```
+
+## 故障排查
+
+- 修改 MCP 配置后请完全退出并重新启动 Claude Code，以便重新加载服务器列表。
+- 如果 Aptos 工具没有出现，运行 `claude mcp list`。
+- 确认 `APTOS_BOT_KEY` 是有效的 Geomi Bot Key。

--- a/src/content/docs/zh/build/ai/aptos-mcp/codex.mdx
+++ b/src/content/docs/zh/build/ai/aptos-mcp/codex.mdx
@@ -1,0 +1,65 @@
+---
+title: "使用 Codex 配置 Aptos MCP"
+description: "配置和使用 Aptos MCP 与 OpenAI Codex 的分步指南"
+sidebar:
+  label: "Codex"
+---
+
+1. 安装 [OpenAI Codex](https://github.com/openai/codex)。
+
+```bash
+npm install -g @openai/codex
+```
+
+在 macOS 上也可以运行 `brew install codex`。
+
+2. 从 [Geomi](https://geomi.dev/) 获取 `APTOS_BOT_KEY`（账户菜单中的 **Bot Keys**）。完整步骤见 [Aptos MCP](/zh/build/ai/aptos-mcp)。
+
+3. 进入你的项目目录：
+
+```bash
+cd your-awesome-project
+```
+
+4. 添加 Aptos MCP 服务器：
+
+```bash
+codex mcp add aptos-mcp --env APTOS_BOT_KEY=<your_bot_key> -- npx -y @aptos-labs/aptos-mcp
+```
+
+将 `<your_bot_key>` 替换为第 2 步生成的密钥。如有需要，可以继续传递更多 `--env NAME=VALUE` 参数。
+
+5. 确认服务器已注册：
+
+```bash
+codex mcp list
+```
+
+列表中应出现 `aptos-mcp`。
+
+6. 启动 Codex：
+
+```bash
+codex
+```
+
+7. 在 Codex 中运行 `/mcp`，确认列表中包含 `aptos-mcp`。
+
+8. 向代理询问 `what aptos mcp version are you using?` 以验证连接。它应返回 [MCP Server Card](/.well-known/mcp/server-card.json) 中当前发布的 `@aptos-labs/aptos-mcp` 版本。
+
+## 备选：TOML 配置
+
+如果 CLI 命令失败，编辑 `~/.codex/config.toml`（在 IDE 中：齿轮图标 → **MCP settings** → **Open config.toml**）并添加：
+
+```toml
+# ~/.codex/config.toml
+
+[mcp_servers.aptos-mcp]
+command = "npx"
+args = ["-y", "@aptos-labs/aptos-mcp"]
+
+[mcp_servers.aptos-mcp.env]
+APTOS_BOT_KEY = "<your_bot_key>"
+```
+
+保存文件并重启 Codex。不要把 Bot Key 提交到 git。

--- a/src/content/docs/zh/build/ai/aptos-mcp/cursor.mdx
+++ b/src/content/docs/zh/build/ai/aptos-mcp/cursor.mdx
@@ -5,6 +5,8 @@ sidebar:
   label: "Cursor"
 ---
 
+Cursor 从 [`mcp.json`](https://cursor.com/docs/mcp) 读取 MCP 服务器。可以使用项目级文件 `.cursor/mcp.json`，或用户级文件 `~/.cursor/mcp.json`。
+
 1. 打开 Cursor IDE
 2. 在项目根文件夹中，创建一个 `.cursor` 文件夹
 3. 在 `.cursor` 文件夹中，创建一个 `mcp.json` 文件
@@ -17,34 +19,33 @@ sidebar:
       "command": "npx",
       "args": ["-y", "@aptos-labs/aptos-mcp"],
       "env": {
-        "APTOS_BOT_KEY": "<bot_api_key>"
+        "APTOS_BOT_KEY": "${env:APTOS_BOT_KEY}"
       }
     }
   }
 }
 ```
 
-5. 获取您的 `APTOS_BOT_KEY`：
-   - 访问 [Geomi](https://geomi.dev/) 并使用您的账户登录。
-   - 导航到 API Keys 部分并生成一个新密钥。
-   - 复制生成的密钥以供下一步使用。
+5. 获取你的 `APTOS_BOT_KEY`：
+   - 访问 [Geomi](https://geomi.dev/) 并登录账户。
+   - 打开左下角账户菜单，进入 **Bot Keys**，然后创建新密钥。
+   - 在 shell 中导出该密钥（`export APTOS_BOT_KEY=...`），或在本地把 `${env:APTOS_BOT_KEY}` 替换为实际值。不要把密钥提交到 git。
 
-6. 确保使用您刚刚生成的密钥更新 `mcp.json` 文件中的 `APTOS_BOT_KEY`。
+6. 保存文件。Cursor 会合并项目级和用户级 `mcp.json`；同名条目以项目配置为准。
 
-### 验证 Cursor 运行您的 MCP
+### 验证 Cursor 运行你的 MCP
 
-1. 打开 Cursor 设置：`cursor -> settings -> cursor settings`
-2. 前往 `MCP` 或 `Tools & Integrations` 部分
-3. 确保它已启用并显示绿色指示器
+1. 打开 Cursor 设置：**Cursor Settings** → **Tools & MCP**（也可以在 **Customize** → **MCP** 中找到）。
+2. 确认 `aptos-mcp` 已启用并显示绿色指示器。
 
 ![确保它已启用并显示绿色指示器](~/images/cursor/verify-cursor_step-3.png)
 
-4. 点击 "refresh" 图标以更新 MCP。
+3. 如果首次未能连接，点击 “refresh” 图标。
 
-5. 确保 Cursor AI 窗口下拉菜单设置为 `Agent`
+4. 确保 Cursor 聊天处于 **Agent** 模式。
 
 ![确保 Cursor AI 窗口下拉菜单设置为 Agent](~/images/cursor/verify-cursor_step-5.png)
 
-6. 向代理询问 `what aptos mcp version are you using?` 来验证连接。代理应该回复类似的内容：
+5. 向代理询问 `what aptos mcp version are you using?` 以验证连接。它应返回 [MCP Server Card](/.well-known/mcp/server-card.json) 中当前发布的 `@aptos-labs/aptos-mcp` 版本。
 
 ![向代理询问 what aptos mcp version are you using? 来验证连接。](~/images/cursor/verify-cursor_step-6.png)

--- a/src/content/docs/zh/index.mdx
+++ b/src/content/docs/zh/index.mdx
@@ -30,8 +30,8 @@ import ListCard from '~/components/ListCard.astro';
   <ListCard title="入门指南" iconName="star" id="getting-started">
     - [部署你的第一个 Move 智能合约](/zh/build/guides/first-move-module) 几分钟内编译并发布 Move 模块到 devnet。
     - [你的第一笔交易](/zh/build/guides/first-transaction) 使用 TypeScript SDK 写入和读取链上数据。
-    - [使用 AI 编程 (MCP)](/zh/build/ai/aptos-mcp) 让 Cursor 和 Claude Code 直接访问 Aptos API。
-    - [新！Agent Skills](/zh/build/ai/aptos-agent-skills) 适用于 Claude Code、Cursor、Copilot 的 Move 和 TS SDK 技能。
+    - [使用 AI 编程 (MCP)](/zh/build/ai/aptos-mcp) 让 Cursor、Claude Code 和 Codex 直接访问 Aptos API。
+    - [Agent Skills](/zh/build/ai/aptos-agent-skills) 适用于 Claude Code、Cursor、Copilot 的 Move 和 TS SDK 技能。
   </ListCard>
 
   <ListCard title="工具" iconName="terminal">
@@ -55,7 +55,7 @@ import ListCard from '~/components/ListCard.astro';
   </ListCard>
 
   <ListCard title="资源" iconName="file-text">
-    - [新！LLMs.txt 集成](/zh/llms-txt) AI 优化的文档格式，粘贴到你喜欢的大上下文 AI 中即可开始！
+    - [LLMs.txt 集成](/zh/llms-txt) 面向编程助手和聊天工具的 AI 优化文档源。
     - [查询、索引或流式传输链上数据](/zh/build/indexer) 查询 Indexer API、索引合约、流式传输原始交易。
     - [申请资助](https://aptosnetwork.com/grants)
   </ListCard>

--- a/src/content/docs/zh/llms-txt.mdx
+++ b/src/content/docs/zh/llms-txt.mdx
@@ -1,6 +1,6 @@
 ---
 title: LLMs.txt
-description: 如何让 Cursor、GitHub Copilot、ChatGPT 和 Claude 等工具理解 Aptos 文档。
+description: 如何让 Cursor、GitHub Copilot、ChatGPT、Claude、Codex 和 Devin 等工具理解 Aptos 文档。
 ---
 
 ## 什么是 LLMs.txt？
@@ -22,6 +22,8 @@ description: 如何让 Cursor、GitHub Copilot、ChatGPT 和 Claude 等工具理
 
 此外还会列出 **Agent 工具链**（Aptos MCP、Agent Skills、浏览器、GitHub 组织）以及重要 **Markdown** 深链（AI 总览、标准、Indexer GraphQL 参考），便于模型直接拉取正确资源。
 
+发现端点、MCP Server Card 和 WebMCP 工具见 [AI 工具概览](/zh/build/ai)。
+
 ## 逐页 Markdown 访问
 
 每个文档页面也可以通过在 URL 后添加 `.md` 获取渲染后的 Markdown 格式：
@@ -32,27 +34,35 @@ description: 如何让 Cursor、GitHub Copilot、ChatGPT 和 Claude 等工具理
 | `https://aptos.dev/build/sdks/ts-sdk`                 | `https://aptos.dev/build/sdks/ts-sdk.md`                 |
 | `https://aptos.dev/zh/build/guides/first-transaction` | `https://aptos.dev/zh/build/guides/first-transaction.md` |
 
-这对于需要用最少 token 获取单个页面的 AI 工具非常有用，而不必摄取完整文档。[llms.txt](/llms.txt) 作为紧凑路由文件使用，而 [llms-small.txt](/llms-small.txt) 和 [llms-full.txt](/llms-full.txt) 分别提供精选版和完整版语料导出。
+也可以向 HTML URL 发送 `Accept: text/markdown`。这对于需要用最少 token 获取单个页面的 AI 工具非常有用，而不必摄取完整文档。[llms.txt](/llms.txt) 作为紧凑路由文件使用，而 [llms-small.txt](/llms-small.txt) 和 [llms-full.txt](/llms-full.txt) 分别提供精选版和完整版语料导出。
 
 ## 与 AI 工具的使用
 
 ### Claude Code
 
-将 Aptos 文档上下文添加到 [Claude Code](https://docs.anthropic.com/en/docs/agents-and-tools/claude-code/overview) 项目：
+将 Aptos 文档上下文添加到 [Claude Code](https://code.claude.com/docs/en/overview) 项目：
 
-1. 将 `https://aptos.dev/llms.txt` 添加到项目的 `CLAUDE.md` 文件中作为参考
+1. 将 `https://aptos.dev/llms.txt` 添加到项目的 `CLAUDE.md` 或 `AGENTS.md` 文件中作为参考
 2. Claude Code 会读取索引并根据需要通过 `.md` URL 获取相关页面
-3. 如需更深层次的链上工具集成，请参阅 [Aptos MCP for Claude Code](/zh/build/ai/aptos-mcp/claude)
+3. 如需链上工具集成，请参阅 [Aptos MCP for Claude Code](/zh/build/ai/aptos-mcp/claude)
 
 ### Cursor
 
-在 Cursor 中使用 `@Docs` 功能将 LLMs.txt 文件包含在您的项目中。这有助于 Cursor 为 Aptos 开发提供更准确的代码建议和文档。
+Cursor 已移除 `@Docs` 索引。请改为让 Agent 直接使用这些文档源：
 
-[了解更多关于 Cursor 中的 @Docs](https://docs.cursor.com/context/@-symbols/@-docs)
+1. 将 `https://aptos.dev/llms.txt` 写入项目的 `AGENTS.md`（或 [项目规则](https://cursor.com/docs/rules)）
+2. 需要一次性拉取时，把文档源 URL 粘贴到聊天中——Agent 可以直接获取
+3. 如需链上工具，请参阅 [Aptos MCP for Cursor](/zh/build/ai/aptos-mcp/cursor)
 
 ### GitHub Copilot
 
-GitHub Copilot 可以利用这些 LLMs.txt 文件中的信息，在开发 Aptos 应用程序时提供更好的帮助。您可以在 GitHub Copilot Chat 中使用以下 URL 引用这些文件：
+在 [Copilot Chat](https://code.visualstudio.com/docs/chat/copilot-chat-context) 中，为当前会话拉取文档源：
+
+```
+#fetch https://aptos.dev/llms.txt
+```
+
+若要作为项目长期上下文，把这些 URL 写入 [`.github/copilot-instructions.md`](https://docs.github.com/en/copilot/how-tos/copilot-on-github/customize-copilot/add-custom-instructions/add-repository-instructions)：
 
 ```
 https://aptos.dev/llms.txt
@@ -60,27 +70,31 @@ https://aptos.dev/llms-small.txt
 https://aptos.dev/llms-full.txt
 ```
 
-### Windsurf
+### OpenAI Codex
 
-使用 `@` 或在您的 `.windsurfrules` 文件中引用 LLMs.txt 文件，以增强 Windsurf 对 Aptos 开发的理解。
+将 `https://aptos.dev/llms.txt` 添加到 `AGENTS.md`，然后启动 Codex。链上工具见 [Aptos MCP for Codex](/zh/build/ai/aptos-mcp/codex)。
 
-[了解更多关于 Windsurf Memories](https://docs.codeium.com/windsurf/memories#memories-and-rules)
+### Devin Desktop（原 Windsurf）
+
+Devin Desktop 会读取 `AGENTS.md` 和 `.devin/rules/`（旧的 `.windsurfrules` 仍然有效）。把 `https://aptos.dev/llms.txt` 放进项目的 `AGENTS.md`。
+
+[了解 Devin Desktop 中的 AGENTS.md](https://docs.devin.ai/desktop/cascade/agents-md)
 
 ### Claude.ai
 
-将 Aptos 文档添加为 [Claude Projects](https://claude.ai) 的知识来源：
+将 Aptos 文档添加为 [Claude Projects](https://claude.ai) 的项目知识：
 
 1. 打开 [Claude.ai](https://claude.ai) 并创建或打开一个项目
-2. 点击**添加内容**
+2. 添加项目知识 / 内容
 3. 将 `https://aptos.dev/llms-full.txt` 粘贴为 URL 来源
-4. Claude 将在该项目的所有对话中具备 Aptos 文档的上下文
+4. Claude 将在该项目的对话中具备 Aptos 文档上下文
 
 ### ChatGPT
 
 在 ChatGPT 对话中直接引用 Aptos 文档：
 
-- 将 `https://aptos.dev/llms-full.txt` 粘贴到您的消息中，要求 ChatGPT 在回答 Aptos 问题之前先阅读它
-- 对于[自定义 GPT](https://openai.com/index/introducing-gpts/)：在 GPT Builder 中添加 `https://aptos.dev/llms.txt` 作为知识来源
+- 将 `https://aptos.dev/llms-full.txt` 粘贴到消息中，要求 ChatGPT 在回答 Aptos 问题之前先阅读它
+- 对于自定义 GPT：在 GPT Builder 中添加 `https://aptos.dev/llms.txt` 作为知识来源
 
 ### 其他 AI 工具
 

--- a/src/content/docs/zh/network/glossary.mdx
+++ b/src/content/docs/zh/network/glossary.mdx
@@ -27,6 +27,13 @@ sidebar:
 
 详情请参阅 [账户](/zh/network/blockchain/accounts)。
 
+### Agent Skills
+
+- **Agent Skills** 是可安装的指令包，为编程助手提供 Aptos 相关知识，覆盖 Move 合约、TypeScript SDK 和 dApp 脚手架。
+- 使用 `npx skills add aptos-labs/aptos-agent-skills` 安装。
+
+详情请参阅 [Aptos Agent Skills](/zh/build/ai/aptos-agent-skills)。
+
 ### API
 
 - **应用程序编程接口（API）** 是一组协议和工具，允许用户通过外部应用程序与 Aptos 区块链节点和客户端网络进行交互。Aptos 提供 REST API 来与我们的节点进行通信。
@@ -282,6 +289,13 @@ sidebar:
 - 在基于领导者的协议中，节点必须就领导者达成一致才能取得进展。
 - 领导者由一个以当前 [轮次号](#轮次号) 为输入的函数选择。
 
+### LLMs.txt
+
+- **LLMs.txt** 是面向 AI 工具的机器可读文档索引，指向 Aptos 文档、逐页 Markdown 导出以及相关 API 资源。
+- Aptos 发布 `/llms.txt`（索引）、`/llms-small.txt`（精简语料）和 `/llms-full.txt`（完整语料）。
+
+详情请参阅 [LLMs.txt](/zh/llms-txt)。
+
 ## M
 
 ### 主网
@@ -316,6 +330,13 @@ sidebar:
 - **[Merkle 累加器](https://www.usenix.org/legacy/event/sec09/tech/full_papers/crosby.pdf)** 是 Aptos 区块链用于存储账本的 _只追加_ Merkle 树。
 - Merkle 累加器可以提供交易包含在链中的证明（"包含证明"）。
 - 它们在文献中也被称为"历史树"。
+
+### 模型上下文协议（MCP）
+
+- **模型上下文协议（MCP）** 是一种开放协议，让 AI 编程工具能够调用外部工具和数据源。
+- Aptos 发布 MCP 服务器（`@aptos-labs/aptos-mcp`），以便助手查询链上数据、调用 Aptos API，并遵循当前的 Move 工作流。
+
+详情请参阅 [Aptos MCP](/zh/build/ai/aptos-mcp)。
 
 ### 模块
 
@@ -529,6 +550,13 @@ sidebar:
 - 交易版本 0 是第一笔交易（创世交易），交易版本 100 是区块链中的第 101 笔交易。
 
 ## W
+
+### WebMCP
+
+- **WebMCP** 是一项浏览器提案，允许页面在 `navigator.modelContext` 上注册工具。
+- 每个 Aptos 文档页面都会为支持该提案的浏览器注册搜索、导航、Markdown 获取和 LLMs.txt 发现工具。
+
+详情请参阅 [AI 工具概览](/zh/build/ai)。
 
 ### 格式良好的交易
 

--- a/src/lib/llms-curated-ids.ts
+++ b/src/lib/llms-curated-ids.ts
@@ -62,7 +62,7 @@ export const LLMS_INDEX_SECTIONS: LlmsSection[] = [
   },
   {
     title: "AI Tooling",
-    ids: ["build/ai", "build/ai/aptos-mcp", "llms-txt"],
+    ids: ["build/ai", "build/ai/aptos-mcp", "build/ai/aptos-agent-skills", "llms-txt"],
   },
   {
     title: "Nodes And Operations",
@@ -97,6 +97,7 @@ export const FULL_PRIORITY_DOC_IDS = [
   "build/cli",
   "build/smart-contracts",
   "build/ai",
+  "build/ai/aptos-agent-skills",
   "network/nodes",
   "network/glossary",
   "llms-txt",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Validates the AI / LLMs documentation against the live agent-discovery surface, upstream Aptos MCP and Agent Skills repos, and current client docs.

## What changed

- **MCP:** Claude Code setup now uses `claude mcp add` (with a JSON fallback). Cursor docs use Geomi **Bot Keys**, `${env:APTOS_BOT_KEY}`, and Cursor Settings → Tools & MCP. Added an OpenAI Codex guide matching the upstream MCP repo.
- **Agent Skills:** Install commands, plugin marketplace slash command, skill descriptions, workflow, and the `smoothsend-gasless` community skill now match [aptos-agent-skills](https://github.com/aptos-labs/aptos-agent-skills).
- **LLMs.txt usage:** Cursor `@Docs` is gone; Windsurf is Devin Desktop. Copilot uses `#fetch` / `copilot-instructions.md`. Added Codex. Cross-link to the AI hub for discovery endpoints.
- **Hub / homepage / sidebar:** Codex cards, Copilot stdio note, dropped stale NEW badges.
- **Glossary:** Agent Skills, LLMs.txt, MCP, and WebMCP (English + Chinese).
- **Curation:** `build/ai/aptos-agent-skills` is in the llms.txt AI Tooling section.
- **MCP Server Card:** `_meta.codex` URL and `lastUpdated`. npm package is still `0.0.22` (current on npm). Agent Skills digests were regenerated and are unchanged.

Chinese (`zh`) pages are updated in parallel. Spanish is out of scope.

## Validation notes

- Production `Link` header, well-known documents, markdown negotiation, and `_index._agents.aptos.dev` HTTPS still match this repo.
- `_catalog._agents.aptos.dev` is still unpublished (docs already tell operators to add it).
- DNSSEC `DS` at `.dev` is still missing (`AD=0`); that cannot be fixed from this repo.

## Test plan

- [x] Guardrail tests: `tests/agent-discovery.test.ts`, `tests/llms-curated-ids.test.ts`, `tests/llms-html-sanitize.test.ts` (50 passed)
- [x] `tests/markdown-negotiation.test.ts` and `tests/sitemap-xml-alias.test.ts` (19 passed)
- [x] `pnpm lint` and `pnpm check` (after `astro sync`)
- [x] Dev-server HTTP 200 + Markdown export probes for the AI hub, MCP (Claude/Cursor/Codex), Agent Skills, LLMs.txt, glossary, and Chinese counterparts

No browser automation was available in this environment; pages were verified with curl against `http://localhost:4321`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5febf598-31c8-4e25-9314-074b576f228c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5febf598-31c8-4e25-9314-074b576f228c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

