### PR TITLE
docs: add BoltRPC to data providers

### DIFF
--- a/src/content/docs/build/apis/data-providers.mdx
+++ b/src/content/docs/build/apis/data-providers.mdx
@@ -103,6 +103,7 @@ We also have some partners who target more enterprise use cases
 - [NODEREAL](https://nodereal.io/aptos) for REST API endpoint
 - [Shinami](https://docs.shinami.com/developer-guides/aptos) for Aptos node access, gas station, and wallet services
 - [QuickNode](https://www.quicknode.com/chains/apt) for REST API endpoint
+- [BoltRPC](https://boltrpc.io/networks/aptos) for REST API endpoint and synthetic WebSocket `newHeads` subscriptions
 - [Codex](https://docs.codex.io/networks/aptos) GraphQL API and WebSocket subscriptions for Aptos token prices, trading pairs, holders, and wallet balances (network ID `49705`)
 
 Additional RPC vendors can be found [here](https://aptosnetwork.com/ecosystem/directory/category/rpc)

--- a/src/content/docs/zh/build/apis/data-providers.mdx
+++ b/src/content/docs/zh/build/apis/data-providers.mdx
@@ -102,6 +102,7 @@ Coin/FA 转账以及部分 DEX 解析。
 - [NODEREAL](https://nodereal.io/aptos) 提供 REST API 端点
 - [Shinami](https://docs.shinami.com/developer-guides/aptos) 提供 Aptos 节点访问、gas 代付和钱包服务
 - [QuickNode](https://www.quicknode.com/chains/apt) 提供 REST API 端点
+- [BoltRPC](https://boltrpc.io/networks/aptos) 提供 REST API 端点以及合成 WebSocket `newHeads` 订阅
 - [Codex](https://docs.codex.io/networks/aptos) 提供 GraphQL API 和 WebSocket 订阅，覆盖 Aptos 代币价格、交易对、持有人和钱包余额（网络 ID `49705`）
 
 更多 RPC 供应商见 [此处](https://aptosnetwork.com/ecosystem/directory/category/rpc)


### PR DESCRIPTION
## Description

Adds [BoltRPC](https://boltrpc.io/networks/aptos) to the "Vendors for real-time data" list on the Data Providers page.

BoltRPC provides a dedicated Aptos Mainnet fullnode REST API endpoint (HTTPS), plus **synthetic WebSocket `newHeads`** — a gap-aware block-header stream synthesized from their Aptos node fleet, since Aptos full nodes do not expose native WebSocket subscriptions. Compatible with the official Aptos SDKs via a configurable `fullnode` URL. See their [Aptos network page](https://boltrpc.io/networks/aptos) for endpoint details.

## Changes

- `src/content/docs/build/apis/data-providers.mdx`: add BoltRPC to the real-time data vendors list
- `src/content/docs/zh/build/apis/data-providers.mdx`: add the corresponding Chinese entry

## Checks

- [x] Link resolves (`https://boltrpc.io/networks/aptos`)
- [x] EN and ZH entries stay in sync
- [x] Wording covers REST + synthetic WebSocket `newHeads` without overclaiming native Aptos WS